### PR TITLE
Update limits to be byte based

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -69,7 +69,8 @@ pub enum DecodingError {
         chunk: ChunkType
     },
     Other(Cow<'static, str>),
-    CorruptFlateStream
+    CorruptFlateStream,
+    LimitsExceeded,
 }
 
 impl error::Error for DecodingError {
@@ -80,7 +81,8 @@ impl error::Error for DecodingError {
             Format(ref desc) | Other(ref desc) => &desc,
             InvalidSignature => "invalid signature",
             CrcMismatch { .. } => "CRC error",
-            CorruptFlateStream => "compressed data stream corrupted"
+            CorruptFlateStream => "compressed data stream corrupted",
+            LimitsExceeded => "limits are exceeded"
         }
     }
 }


### PR DESCRIPTION
Limiting allocated bytes is more effective and useful than image
size. Especially when incrementally decoding an image which may not
fit in memory, limiting pixels doesn't make much sense. Also see the discussion in https://github.com/image-rs/image-tiff/issues/29

This will change the public api in that the `Limits` struct now has a different field.

This fixes #105 

@HeroicKatora @fintelia @Shnatsel  what do you guys think?