### PR TITLE
[Don't merge yet] Update glob dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ bitflags = "1.0"
 
 [dev-dependencies]
 getopts = "0.2.14"
-term = "0.4"
-glob = "0.2.11"
+term = "0.5"
+glob = "0.3"
 rand = "0.5.5"
 
 [dev-dependencies.glium]
-version = "0.22"
+version = "0.24"
 features = ["glutin"]
 default-features = false
 


### PR DESCRIPTION
Tries to fix the tests under minimal-versions in the Travis matrix. Some dependency
resolves to `winapi=0.0.1` in that condition and this is a faulty version that was not
yanked. The guess here is that `getopts` is affected since it did depend on `tempdir`
but now that has been relegated to a `dev-dependency`. We'll see.