### PR TITLE
Avoid compiling dev-dependencies with minimal versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ matrix:
 script:
   - cargo build -v $FLAGS
   - cargo doc -v $FLAGS
-  - cargo test -v $FLAGS
+  - if [ "$FLAGS" != "-Z minimal-versions" ]; then cargo test -v $FLAGS; fi


### PR DESCRIPTION
Works around an issue where no version of `glium` actually depends on
semantically valid crates with `minimal-versions` enabled. Tests and
examples are still compiled and/or ran on other configurations.

Closes: #113

See #119 for details on version resolution that fails. In the long term, it 
could be beneficial to replace `glium` with a dependency that is still 
actively developed.