### PR TITLE
 Replaces the parameter trait with standard setters 

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -7,7 +7,6 @@ use std::mem;
 use std::borrow;
 use std::io::{Read, Write, BufReader, BufRead};
 
-use crate::traits::{HasParameters, Parameter};
 use crate::common::{ColorType, BitDepth, Info, Transformations};
 use crate::filter::{unfilter, FilterType};
 use crate::chunk::IDAT;
@@ -22,20 +21,7 @@ pub enum InterlaceHandling {
     /// Only fill the needed pixels
     Sparkle
 }
-
-impl Parameter<Reader> for InterlaceHandling {
-    fn set_param(self, this: &mut Reader) {
-        this.color_output = self
-    }
-}*/
-
-
-impl<R: Read> Parameter<Decoder<R>> for Transformations {
-    fn set_param(self, this: &mut Decoder<R>) {
-        this.transform = self
-    }
-}
-
+*/
 
 /// Output info
 pub struct OutputInfo {
@@ -128,9 +114,15 @@ impl<R: Read> Decoder<R> {
         };
         Ok((info, r))
     }
-}
 
-impl<R: Read> HasParameters for Decoder<R> {}
+    /// Set the allowed and performed transformations.
+    ///
+    /// A transformation is a pre-processing on the raw image data modifying content or encoding.
+    /// Many options have an impact on memory or CPU usage during decoding.
+    pub fn set_transformations(&mut self, transform: Transformations) {
+        self.transform = transform;
+    }
+}
 
 struct ReadDecoder<R: Read> {
     reader: BufReader<R>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,3 @@ pub use crate::decoder::{Decoder, Reader, OutputInfo, StreamingDecoder, Decoded,
 #[cfg(feature = "png-encoding")]
 pub use crate::encoder::{Encoder, Writer, StreamWriter, EncodingError};
 pub use crate::filter::FilterType;
-
-pub use crate::traits::{Parameter, HasParameters};

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,19 +1,5 @@
 use std::io;
 
-/// Configuration parameter trait
-pub trait Parameter<Object> {
-    fn set_param(self, _: &mut Object);
-}
-
-/// Object has parameters
-pub trait HasParameters: Sized {
-    fn set<T: Parameter<Self>>(&mut self, value: T) -> &mut Self {
-        value.set_param(self);
-        self
-    }
-}
-
-
 // Will be replaced by stdlib solution
 fn read_all<R: io::Read + ?Sized>(this: &mut R, buf: &mut [u8]) -> io::Result<()> {
     let mut total = 0;


### PR DESCRIPTION
The pattern complicates the documentation, hurts the discoverability and
establishes an interface that is less flexible due to being bound to the
trait coherence rules, which are stricter than necessary here. This
makes the setter much more natural and improves their documentation
items themselves.

Closes #139.