### PR TITLE
Fix infinite loop in pngcheck

### DIFF
--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -165,9 +165,16 @@ fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {
     loop {
         if buf.len() == 0 {
             // circumvent borrow checker
+            assert!(!data.is_empty());
             let n = reader.read(unsafe {
                 ::std::slice::from_raw_parts_mut(data_p, data.len())
             })?;
+
+            // EOF
+            if n == 0 {
+                println!("ERROR: premature end of file {}", fname);
+                break;
+            }
             buf = &data[..n];
         }
         match decoder.update(buf, &mut Vec::new()) {


### PR DESCRIPTION
Manual usage of streaming decoder lead to ignored signal of EOF when the
read returns `Ok(0)`. An image crafted to terminate early within would
then lead to an infinite loop waiting on new data.

Closes: #143 