### PR TITLE
Remove the num-iter dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ exclude = [
 [dependencies]
 inflate = "0.4.2"
 deflate = { version = "0.7.12", optional = true }
-num-iter = "0.1.32"
 bitflags = "1.0"
 crc32fast = "1.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,6 @@
 
 #[macro_use] extern crate bitflags;
 
-extern crate num_iter;
-
 pub mod chunk;
 mod decoder;
 #[cfg(feature = "png-encoding")]


### PR DESCRIPTION
`num-iter` is used just for `range_step` iterator. By using `std::iter::step_by` we can remove a lot of bloat:

```
`-- num-iter v0.1.39
    |-- num-integer v0.1.41
    |   `-- num-traits v0.2.8
    |       [build-dependencies]
    |       `-- autocfg v0.1.4
    |   [build-dependencies]
    |   `-- autocfg v0.1.4 (*)
    `-- num-traits v0.2.8 (*)
    [build-dependencies]
    `-- autocfg v0.1.4 (*)
```

This also decreases the build time: 4.9s vs 6.7s