### PR TITLE
Allow -Z minimal-versions to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ matrix:
       env: FLAGS="--no-default-features"
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
+  allow_failures:
+    - rust: nightly
+      env: FLAGS="-Z minimal-versions"
+
 script:
   - cargo build -v $FLAGS
   - cargo doc -v $FLAGS
-  - if [ "$FLAGS" != "-Z minimal-versions" ]; then cargo test -v $FLAGS; fi
+  - cargo test -v $FLAGS


### PR DESCRIPTION
The actual build fails already (hence it was disabled by a scripted if).
With these changes, the build is ran but allowed it to fail. In its
current state, minimal versions can at most give an indication on the
health of our dependencies but is not required (as indicated by the
disabled build). Since this is also prone to the most failures from
nightly, it has only little bearing on the decision of merging a PR and
releases. The standard nightly target is still enabled regardless.