### PR TITLE
Update metadata for 0.15 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "png"
-version = "0.14.1"
-license = "MIT/Apache-2.0"
+version = "0.15.0"
+license = "MIT OR Apache-2.0"
+
 description = "PNG decoding and encoding library in pure Rust"
+categories = ["multimedia::images"]
 authors = ["nwin <nwin@users.noreply.github.com>"]
 repository = "https://github.com/image-rs/image-png.git"
+
 edition = "2018"
 exclude = [
     "tests/*",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,22 @@
 ![Lines of Code](https://tokei.rs/b1/github/image-rs/image-png)
 [![License](https://img.shields.io/crates/l/png.svg)](https://github.com/image-rs/image-png)
 
-PNG decoder/encoder in pure Rust. Currently `pngcheck` is the most usable part. Build with `cargo build --release --example pngcheck`.
+PNG decoder/encoder in pure Rust.
+
+It contains all features required to handle the entirety of [the PngSuite by
+Willem van Schack][PngSuite].
+
+[PngSuite]: http://www.schaik.com/pngsuite2011/pngsuite.html
+
+## pngcheck
+
+The `pngcheck` utility is a small demonstration binary that checks and prints
+metadata on every `.png` image provided via parameter. You can run it (for
+example on the test directories) with
+
+```bash
+cargo run --release --example pngcheck ./tests/pngsuite/*
+```
 
 ## License
 


### PR DESCRIPTION
The previous license description was allowed but deprecated. An explicit
OR makes the selection clear.