### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -16,9 +16,9 @@ pub enum ColorType {
 
 impl ColorType {
     /// Returns the number of samples used per pixel of `ColorType`
-    pub fn samples(&self) -> usize {
+    pub fn samples(self) -> usize {
         use self::ColorType::*;
-        match *self {
+        match self {
             Grayscale | Indexed => 1,
             RGB => 3,
             GrayscaleAlpha => 2,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -70,11 +70,11 @@ impl<R: Read> Decoder<R> {
         Decoder::new_with_limits(r, Limits::default())
     }
     
-    pub fn new_with_limits(r: R, l: Limits) -> Decoder<R> {
+    pub fn new_with_limits(r: R, limits: Limits) -> Decoder<R> {
         Decoder {
-            r: r,
+            r,
             transform: crate::Transformations::EXPAND | crate::Transformations::SCALE_16 | crate::Transformations::STRIP_16,
-            limits: l,
+            limits,
         }
     }
 
@@ -283,7 +283,7 @@ impl<R: Read> Reader<R> {
             // swap buffer to circumvent borrow issues
             let mut buffer = mem::replace(&mut self.processed, Vec::new());
             let (got_next, adam7) = if let Some((row, adam7)) = self.next_raw_interlaced_row()? {
-                (&mut buffer[..]).write(row)?;
+                (&mut buffer[..]).write_all(row)?;
                 (true, adam7)
             } else {
                 (false, None)
@@ -472,7 +472,7 @@ impl<R: Read> Reader<R> {
                 match val {
                     Some(Decoded::ImageData) => {}
                     None => {
-                        if self.current.len() > 0 {
+                        if !self.current.is_empty() {
                             return Err(DecodingError::Format(
                               "file truncated".into()
                             ))

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -61,7 +61,7 @@ impl<W: Write> Encoder<W> {
         let mut info = Info::default();
         info.width = width;
         info.height = height;
-        Encoder { w: w, info: info }
+        Encoder { w, info }
     }
 
     pub fn write_header(self) -> Result<Writer<W>> {
@@ -111,8 +111,7 @@ pub struct Writer<W: Write> {
 
 impl<W: Write> Writer<W> {
     fn new(w: W, info: Info) -> Writer<W> {
-        let w = Writer { w: w, info: info };
-        w
+        Writer { w, info }
     }
 
     fn init(mut self) -> Result<Self> {
@@ -216,7 +215,7 @@ impl<'a, W: Write> Write for ChunkWriter<'a, W> {
 
     fn flush(&mut self) -> io::Result<()> {
         if self.index > 0 {
-            self.writer.write_chunk(chunk::IDAT, &self.buffer[..self.index+1])?;
+            self.writer.write_chunk(chunk::IDAT, &self.buffer[..=self.index])?;
         }
         self.index = 0;
         Ok(())

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -30,9 +30,9 @@ pub enum FilterType {
 }
 
 fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
-    let ia = a as i16;
-    let ib = b as i16;
-    let ic = c as i16;
+    let ia = i16::from(a);
+    let ib = i16::from(b);
+    let ic = i16::from(c);
 
     let p = ia + ib - ic;
 
@@ -90,7 +90,7 @@ pub fn unfilter(filter: FilterType, bpp: usize, previous: &[u8], current: &mut [
 
                 for i in bpp..len {
                     current[i] = current[i].wrapping_add(
-                        ((current[i - bpp] as i16 + previous[i] as i16) / 2) as u8
+                        ((i16::from(current[i - bpp]) + i16::from(previous[i])) / 2) as u8
                     );
                 }
                 Ok(())

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -42,7 +42,7 @@ impl<W: io::Read + ?Sized> ReadBytesExt<u16> for W {
 	fn read_be(&mut self) -> io::Result<u16> {
         let mut bytes = [0, 0];
 		read_all(self, &mut bytes)?;
-        Ok((bytes[0] as u16) << 8 | bytes[1] as u16)
+        Ok((u16::from(bytes[0])) << 8 | u16::from(bytes[1]))
 	}
 }
 
@@ -51,10 +51,10 @@ impl<W: io::Read + ?Sized> ReadBytesExt<u32> for W {
 	fn read_be(&mut self) -> io::Result<u32> {
         let mut bytes = [0, 0, 0, 0];
 		read_all(self, &mut bytes)?;
-        Ok(  (bytes[0] as u32) << 24 
-           | (bytes[1] as u32) << 16
-           | (bytes[2] as u32) << 8
-           |  bytes[3] as u32
+        Ok(  (u32::from(bytes[0])) << 24 
+           | (u32::from(bytes[1])) << 16
+           | (u32::from(bytes[2])) << 8
+           |  u32::from(bytes[3])
         )
 	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -99,8 +99,8 @@ impl Adam7Iterator {
             lines: 0,
             line_width: 0,
             current_pass: 1,
-            width: width,
-            height: height
+            width,
+            height,
         };
         this.init_pass();
         this
@@ -108,8 +108,8 @@ impl Adam7Iterator {
 
     /// Calculates the bounds of the current pass
     fn init_pass(&mut self) {
-        let w = self.width as f64;
-        let h = self.height as f64;
+        let w = f64::from(self.width);
+        let h = f64::from(self.height);
         let (line_width, lines) = match self.current_pass {
             1 => (w/8.0, h/8.0),
             2 => ((w-4.0)/8.0, h/8.0),
@@ -183,7 +183,7 @@ fn expand_adam7_bits(pass: u8, width: usize, line_no: usize, bits_pp: usize) -> 
     // the equivalent line number in progressive scan
     let prog_line = line_mul * line_no + line_off;
     // line width is rounded up to the next byte
-    let line_width = width * bits_pp + 7 & !7;
+    let line_width = (width * bits_pp + 7) & !7;
     let line_start = prog_line * line_width;
     let start = line_start + (samp_off * bits_pp);
     let stop = line_start + (width * bits_pp);


### PR DESCRIPTION
- replace `as *` with `*::from()`
- use `write_all` instead of `write`

etc.