### PR TITLE
Update term to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crc32fast = "1.2.0"
 
 [dev-dependencies]
 getopts = "0.2.14"
-term = "0.4"
+term = "0.6.1"
 glob = "0.3"
 rand = "0.7.0"
 

--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -3,7 +3,6 @@
 extern crate getopts;
 extern crate glob;
 extern crate png;
-extern crate term;
 
 use std::io;
 use std::io::prelude::*;


### PR DESCRIPTION
From changelog:
- removes unnecessary dependency
- updates to 2018 edition