### PR TITLE
LibFuzzer, cargo-fuzz and Fuzzit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ matrix:
       env: FLAGS="--no-default-features"
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
+    - rust: nightly
+      env:
+        - FUZZIT_TARGET="png-decoder"
+        - FUZZIT_BINARY="decode"
+      services:
+        - docker
   allow_failures:
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
@@ -20,3 +26,4 @@ script:
   - cargo build -v $FLAGS
   - cargo doc -v $FLAGS
   - cargo test -v $FLAGS
+  - if [ -n "$FUZZIT_TARGET" ]; then ./fuzzit.sh "$FUZZIT_TARGET" "$FUZZIT_BINARY"; fi

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+
+[package]
+name = "png-fuzz"
+version = "0.0.1"
+authors = ["Automatically generated"]
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies.png]
+path = ".."
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "decode"
+path = "fuzz_targets/decode.rs"

--- a/fuzz/fuzz_targets/decode.rs
+++ b/fuzz/fuzz_targets/decode.rs
@@ -1,0 +1,22 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate png;
+
+#[inline(always)]
+fn png_decode(data: &[u8]) -> Result<(png::OutputInfo, Vec<u8>), ()> {
+    let decoder = png::Decoder::new(data);
+    let (info, mut reader) = decoder.read_info().map_err(|_| ())?;
+
+    if info.buffer_size() > 5_000_000 {
+        return Err(());
+    }
+
+    let mut img_data = Vec::with_capacity(info.buffer_size());
+    reader.next_frame(&mut img_data).map_err(|_| ())?;
+
+    Ok((info, img_data))
+}
+
+fuzz_target!(|data: &[u8]| {
+    let _ = png_decode(&data);
+});

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,12 @@
+# Arguments: fuzz target-id, fuzzer name
+fuzzer_target="$1"
+fuzzer_binary="$2"
+
+# Get cargo-fuzz
+cargo install cargo-fuzz
+# Build the fuzzer binary
+cargo fuzz run "$fuzzer_binary" -- -runs=0
+
+wget -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.55/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+./fuzzit create job --type local-regression "$fuzzer_target" "./fuzz/target/x86_64-unknown-linux-gnu/debug/$fuzzer_binary"

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -2,11 +2,15 @@
 fuzzer_target="$1"
 fuzzer_binary="$2"
 
+ORG_NAME="image-rs"
+FUZZIT_VERSION=2.4.46
+
 # Get cargo-fuzz
 cargo install cargo-fuzz
 # Build the fuzzer binary
 cargo fuzz run "$fuzzer_binary" -- -runs=0
 
-wget -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.55/fuzzit_Linux_x86_64
+wget -O fuzzit "https://github.com/fuzzitdev/fuzzit/releases/download/v$FUZZIT_VERSION/fuzzit_Linux_x86_64"
 chmod a+x fuzzit
-./fuzzit create job --type local-regression "$fuzzer_target" "./fuzz/target/x86_64-unknown-linux-gnu/debug/$fuzzer_binary"
+./fuzzit --version
+./fuzzit create job --type local-regression "$ORG_NAME/$fuzzer_target" "./fuzz/target/x86_64-unknown-linux-gnu/debug/$fuzzer_binary"


### PR DESCRIPTION
Integrates CI checks on the dynamically updated corpus of decoder test cases from [fuzzit.dev](fuzzit.dev)¹. The end goal is to have fuzzing running with continually updated builds of the master branch but this will give us a large coverage in any case and to expand this to other repositories as well.

The seed of the current corpus was generated with a ~1 hour manual run of `cargo-fuzz`, with the `decoder` fuzzing harness included here as well.

-----

¹ More on that soon. @fintelia, can I add you as an additional admin on fuzzit simply to increase bus factor?