### PR TITLE
Follow up to Fuzzit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target
+fuzz/artifacts
+fuzz/target
+png-afl/target
+png-afl/out
+Cargo.lock
+/.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM rustlang/rust:nightly
+WORKDIR /image-png
+COPY . .
+RUN cargo install cargo-fuzz
+RUN cargo fuzz run decode -- -runs=0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/png.svg)](https://crates.io/crates/png)
 ![Lines of Code](https://tokei.rs/b1/github/image-rs/image-png)
 [![License](https://img.shields.io/crates/l/png.svg)](https://github.com/image-rs/image-png)
+[![fuzzit](https://app.fuzzit.dev/badge?org_id=image-rs)](https://app.fuzzit.dev/orgs/image-rs/dashboard)
 
 PNG decoder/encoder in pure Rust.
 


### PR DESCRIPTION
* Add a badge
* Add docker related files to locally reproduce building the fuzzer binary that can be submitted to fuzzit. Not sure if this is the most convenient setup but it worked.