### PR TITLE
Update dev-dependency glium to 0.25

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
       env: FLAGS="--no-default-features"
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
+    - rust: stable
+      env:
+        - FLAGS="--all-features"
+        - IMAGE_PNG_TEST=yes
     - rust: nightly
       env:
         - FUZZIT_TARGET="png-decoder"
@@ -26,5 +30,5 @@ matrix:
 script:
   - cargo build -v $FLAGS
   - cargo doc -v $FLAGS
-  - cargo test -v $FLAGS
+  - if [ -n "$IMAGE_PNG_TEST" ]; then cargo test -v $FLAGS; fi
   - if [ -n "$FUZZIT_TARGET" ]; then ./fuzzit.sh "$FUZZIT_TARGET" "$FUZZIT_BINARY"; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ glob = "0.3"
 rand = "0.7.0"
 
 [dev-dependencies.glium]
-version = "0.22"
+version = "0.24"
 features = ["glutin"]
 default-features = false
 

--- a/examples/show.rs
+++ b/examples/show.rs
@@ -157,7 +157,7 @@ fn resize_window(display: &Display, image: &RawImage2d<'static, u8>) {
         width *= 10;
         height *= 10;
     }
-    display.gl_window().set_inner_size(dpi::LogicalSize::new(f64::from(width), f64::from(height)));
+    display.gl_window().window().set_inner_size(dpi::LogicalSize::new(f64::from(width), f64::from(height)));
 }
 
 fn main() {


### PR DESCRIPTION
The previous version could error in a very deep dependency `cocoa`,
only required on osx. This seems to have regressed silently.