### PR TITLE
Adhere to maximum length of IDAT chunks

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -139,6 +139,7 @@ impl<W: Write> Writer<W> {
 
     /// Writes the image data.
     pub fn write_image_data(&mut self, data: &[u8]) -> Result<()> {
+        const MAX_CHUNK_LEN: u32 = (1u32 << 31) - 1;
         let bpp = self.info.bytes_per_pixel();
         let in_len = self.info.raw_row_length() - 1;
         let mut prev = vec![0; in_len];
@@ -157,7 +158,11 @@ impl<W: Write> Writer<W> {
             zlib.write_all(&current)?;
             mem::swap(&mut prev, &mut current);
         }
-        self.write_chunk(chunk::IDAT, &zlib.finish()?)
+        let zlib_encoded = zlib.finish()?;
+        for chunk in zlib_encoded.chunks(MAX_CHUNK_LEN as usize) {
+            self.write_chunk(chunk::IDAT, &chunk)?;
+        }
+        Ok(())
     }
 
     /// Create an stream writer.


### PR DESCRIPTION
All chunks must only have lengths smaller than 2 << 31. Hence, the final
IDAT stream must be split into several parts to conform to this
expectation instead of silently wrapping and loosing length information
which would corrupt the file.

Fixes: https://github.com/image-rs/image/issues/1074