### PR TITLE
Only expand bit depths less than 8 to 8

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -351,7 +351,7 @@ impl<R: Read> Reader<R> {
                 16 if t.intersects(
                     crate::Transformations::SCALE_16 | crate::Transformations::STRIP_16
                 ) => 8,
-                _ if t.contains(crate::Transformations::EXPAND) => 8,
+                n if n < 8 && t.contains(crate::Transformations::EXPAND) => 8,
                 n => n
             };
             let color_type = if t.contains(crate::Transformations::EXPAND) {


### PR DESCRIPTION
When using the `EXPAND` transform, match the libpng behavior by only
changing the bit depth to 8 if it is less than 8. This also fixes
broken/wrong buffer size decodings when the bit depth is greater than 8
but the `EXPAND` transform is set.

This is also necessary for supporting 16 bit per channel `ImageBuffer`s and `DynamicImage` in a PR I'm nearly done with for `image`, without breaking the current behavior for 1/2/4 bit images.

Unfortunately tests are currently broken on OSX, so I'll see if this passes CI.