### PR TITLE
Change Cargo.toml to an explicit include list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ authors = ["nwin <nwin@users.noreply.github.com>"]
 repository = "https://github.com/image-rs/image-png.git"
 
 edition = "2018"
-exclude = [
-    "tests/*",
+include = [
+    "/LICENSE-MIT",
+    "/LICENSE-APACHE",
+    "/README.md",
+    "/CHANGES.md",
+    "/src/",
 ]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ include = [
     "/README.md",
     "/CHANGES.md",
     "/src/",
+    "/examples/",
+    "/benches/",
 ]
 
 [dependencies]


### PR DESCRIPTION
The published `png 0.16.0` package contains a rather large `seed/`
directory which is presumably only needed for fuzzing.

    $ dutree -s
    [ png-0.16.0 2.93 MiB ]
    ├─ seed                   │ ██████████████│  95%      2.81 MiB
    └─ <aggregated>           │               │   4%    126.78 KiB

To prevent this from happening accidentally, I've changed the `exclude`
list in `Cargo.toml` to an explicit `include` list, containing only the
licenses, documentation, and `/src/` files.