### PR TITLE
Test on a big-endian platform; use stdlib funxions for BE conversions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
   include:
     - rust: stable
       env: FLAGS="--no-default-features"
+    - rust: stable
+      env: CROSS_TARGET=mips64-unknown-linux-gnuabi64 FLAGS="--all-features --target $CROSS_TARGET"
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
     - rust: stable
@@ -32,6 +34,12 @@ matrix:
   allow_failures:
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
+
+before_script:
+  - if [ ! -z "$CROSS_TARGET" ]; then
+      rustup target add $CROSS_TARGET;
+      cargo install cross --force;
+    fi
 
 script:
   - cargo build -v $FLAGS

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,22 +1,27 @@
 use std::io;
 
-// Will be replaced by stdlib solution
-fn read_all<R: io::Read + ?Sized>(this: &mut R, buf: &mut [u8]) -> io::Result<()> {
-    let mut total = 0;
-    while total < buf.len() {
-        match this.read(&mut buf[total..]) {
-            Ok(0) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "failed to read the whole buffer",
-                ))
+macro_rules! read_bytes_ext {
+    ($output_type:ty) => {
+        impl<W: io::Read + ?Sized> ReadBytesExt<$output_type> for W {
+            #[inline]
+            fn read_be(&mut self) -> io::Result<$output_type> {
+                let mut bytes = [0u8; std::mem::size_of::<$output_type>()];
+                self.read_exact(&mut bytes)?;
+                Ok(<$output_type>::from_be_bytes(bytes))
             }
-            Ok(n) => total += n,
-            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
-            Err(e) => return Err(e),
         }
-    }
-    Ok(())
+    };
+}
+
+macro_rules! write_bytes_ext {
+    ($input_type:ty) => {
+        impl<W: io::Write + ?Sized> WriteBytesExt<$input_type> for W {
+            #[inline]
+            fn write_be(&mut self, n: $input_type) -> io::Result<()> {
+                self.write_all(&n.to_be_bytes())
+            }
+        }
+    };
 }
 
 /// Read extension to read big endian data
@@ -31,38 +36,8 @@ pub trait WriteBytesExt<T>: io::Write {
     fn write_be(&mut self, _: T) -> io::Result<()>;
 }
 
-impl<W: io::Read + ?Sized> ReadBytesExt<u8> for W {
-    #[inline]
-    fn read_be(&mut self) -> io::Result<u8> {
-        let mut byte = [0];
-        read_all(self, &mut byte)?;
-        Ok(byte[0])
-    }
-}
-impl<W: io::Read + ?Sized> ReadBytesExt<u16> for W {
-    #[inline]
-    fn read_be(&mut self) -> io::Result<u16> {
-        let mut bytes = [0, 0];
-        read_all(self, &mut bytes)?;
-        Ok((u16::from(bytes[0])) << 8 | u16::from(bytes[1]))
-    }
-}
+read_bytes_ext!(u8);
+read_bytes_ext!(u16);
+read_bytes_ext!(u32);
 
-impl<W: io::Read + ?Sized> ReadBytesExt<u32> for W {
-    #[inline]
-    fn read_be(&mut self) -> io::Result<u32> {
-        let mut bytes = [0, 0, 0, 0];
-        read_all(self, &mut bytes)?;
-        Ok((u32::from(bytes[0])) << 24
-            | (u32::from(bytes[1])) << 16
-            | (u32::from(bytes[2])) << 8
-            | u32::from(bytes[3]))
-    }
-}
-
-impl<W: io::Write + ?Sized> WriteBytesExt<u32> for W {
-    #[inline]
-    fn write_be(&mut self, n: u32) -> io::Result<()> {
-        self.write_all(&[(n >> 24) as u8, (n >> 16) as u8, (n >> 8) as u8, n as u8])
-    }
-}
+write_bytes_ext!(u32);


### PR DESCRIPTION
The bespoke `read_be()` functions could probably be replaced with `byteorder`.

Opened this to get Travis to run for a BE platform, WIP.