### PR TITLE
Test and build on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,14 @@ matrix:
     - rust: stable
       env: FLAGS="--no-default-features"
     - rust: stable
-      env: CROSS_TARGET=mips64-unknown-linux-gnuabi64 FLAGS="--all-features --target $CROSS_TARGET"
+      env: CROSS_TARGET=mips64-unknown-linux-gnuabi64
+      script:
+        - rustup target add $CROSS_TARGET
+        - cargo install cross --force
+        - cargo build -v --all-features --target $CROSS_TARGET
+    - rust: stable
+      arch: s390x
+      env: FLAGS="--all-features"
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
     - rust: stable
@@ -34,12 +41,6 @@ matrix:
   allow_failures:
     - rust: nightly
       env: FLAGS="-Z minimal-versions"
-
-before_script:
-  - if [ ! -z "$CROSS_TARGET" ]; then
-      rustup target add $CROSS_TARGET;
-      cargo install cross --force;
-    fi
 
 script:
   - cargo build -v $FLAGS


### PR DESCRIPTION
Supported by Travis Beta, this does no cross build but actually runs on
big endian hardware including executing our tests. The platform is
listed as Tier 2, same as the mips to which previously cross compiled.