### PR TITLE
Prevent encoding images with invalid bit depth/color type combination

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -128,6 +128,24 @@ impl<W: Write> Writer<W> {
             return Err(EncodingError::Format("Zero height not allowed".into()));
         }
 
+        let bit_depth = self.info.bit_depth;
+        let color_type = self.info.color_type;
+
+        if (bit_depth == BitDepth::One || bit_depth == BitDepth::Two || bit_depth == BitDepth::Four)
+            && (color_type == ColorType::RGB
+                || color_type == ColorType::GrayscaleAlpha
+                || color_type == ColorType::RGBA)
+            || bit_depth == BitDepth::Sixteen && color_type == ColorType::Indexed
+        {
+            return Err(EncodingError::Format(
+                format!(
+                    "Invalid combination of bit-depth '{:?}' and color-type '{:?}'",
+                    bit_depth, color_type
+                )
+                .into(),
+            ));
+        }
+
         self.w.write_all(&[137, 80, 78, 71, 13, 10, 26, 10])?;
         let mut data = [0; 13];
         (&mut data[..]).write_be(self.info.width)?;
@@ -506,6 +524,151 @@ mod tests {
 
         let encoder = Encoder::new(&mut writer, 0, 100);
         assert!(encoder.write_header().is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn expect_error_on_invalid_bit_depth_color_type_combination() -> Result<()> {
+        use std::io::Cursor;
+
+        let output = vec![0u8; 1024];
+        let mut writer = Cursor::new(output);
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::One);
+        encoder.set_color(ColorType::RGB);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::One);
+        encoder.set_color(ColorType::GrayscaleAlpha);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::One);
+        encoder.set_color(ColorType::RGBA);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Two);
+        encoder.set_color(ColorType::RGB);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Two);
+        encoder.set_color(ColorType::GrayscaleAlpha);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Two);
+        encoder.set_color(ColorType::RGBA);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Four);
+        encoder.set_color(ColorType::RGB);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Four);
+        encoder.set_color(ColorType::GrayscaleAlpha);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Four);
+        encoder.set_color(ColorType::RGBA);
+        assert!(encoder.write_header().is_err());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Sixteen);
+        encoder.set_color(ColorType::Indexed);
+        assert!(encoder.write_header().is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_write_header_with_valid_bit_depth_color_type_combination() -> Result<()> {
+        use std::io::Cursor;
+
+        let output = vec![0u8; 1024];
+        let mut writer = Cursor::new(output);
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::One);
+        encoder.set_color(ColorType::Grayscale);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::One);
+        encoder.set_color(ColorType::Indexed);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Two);
+        encoder.set_color(ColorType::Grayscale);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Two);
+        encoder.set_color(ColorType::Indexed);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Four);
+        encoder.set_color(ColorType::Grayscale);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Four);
+        encoder.set_color(ColorType::Indexed);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Eight);
+        encoder.set_color(ColorType::Grayscale);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Eight);
+        encoder.set_color(ColorType::RGB);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Eight);
+        encoder.set_color(ColorType::Indexed);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Eight);
+        encoder.set_color(ColorType::GrayscaleAlpha);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Eight);
+        encoder.set_color(ColorType::RGBA);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Sixteen);
+        encoder.set_color(ColorType::Grayscale);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Sixteen);
+        encoder.set_color(ColorType::RGB);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Sixteen);
+        encoder.set_color(ColorType::GrayscaleAlpha);
+        assert!(encoder.write_header().is_ok());
+
+        let mut encoder = Encoder::new(&mut writer, 1, 1);
+        encoder.set_depth(BitDepth::Sixteen);
+        encoder.set_color(ColorType::RGBA);
+        assert!(encoder.write_header().is_ok());
 
         Ok(())
     }


### PR DESCRIPTION
The PNG standard specifies certain combinations of pixel depth and color type as invalid, [see here](https://www.w3.org/TR/PNG/#11IHDR). Previously the encoder would accept any combination of these two values and produce image files that cannot be read by other tools:
```rust
use std::path::Path;
use std::fs::File;
use std::io::BufWriter;

fn main() {
    let path = Path::new(r"test.png");
    let file = File::create(path).unwrap();
    let w = BufWriter::new(file);

    let mut encoder = png::Encoder::new(w, 6, 1);
    encoder.set_color(png::ColorType::RGBA);
    encoder.set_depth(png::BitDepth::Four);
    let mut writer = encoder.write_header().unwrap();

    // red, green, blue, black, white, transparent
    let data = [0xf0, 0x0f, 0x0f, 0x0f, 0x00, 0xff, 0x00, 0x0f, 0xff, 0xff, 0x00, 0x00];
    writer.write_image_data(&data).unwrap();
}
```

```
$ identify  test.png 
identify: Invalid color type/bit depth combination in IHDR `test.png' @ warning/png.c/MagickPNGWarningHandler/1748.
identify: Invalid IHDR data `test.png' @ error/png.c/MagickPNGErrorHandler/1715.
```

Instead it will now produce an error.