### PR TITLE
Fix decoding invalid color combinations

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -49,6 +49,16 @@ impl ColorType {
             }
             + 1 // filter method
     }
+
+    pub(crate) fn is_combination_invalid(self, bit_depth: BitDepth) -> bool {
+        // Section 11.2.2 of the PNG standard disallows several combinations
+        // of bit depth and color type
+        ((bit_depth == BitDepth::One || bit_depth == BitDepth::Two || bit_depth == BitDepth::Four)
+            && (self == ColorType::RGB
+                || self == ColorType::GrayscaleAlpha
+                || self == ColorType::RGBA))
+            || (bit_depth == BitDepth::Sixteen && self == ColorType::Indexed)
+    }
 }
 
 /// Bit depth of the png file

--- a/src/common.rs
+++ b/src/common.rs
@@ -37,6 +37,18 @@ impl ColorType {
             _ => None,
         }
     }
+
+    pub(crate) fn raw_row_length_from_width(&self, depth: BitDepth, width: u32) -> usize {
+        let bits = width as usize * self.samples() * depth as usize;
+
+        let extra = bits % 8;
+        bits / 8
+            + match extra {
+                0 => 0,
+                _ => 1,
+            }
+            + 1 // filter method
+    }
 }
 
 /// Bit depth of the png file
@@ -316,20 +328,8 @@ impl Info {
 
     /// Returns the number of bytes needed for one deinterlaced row of width `width`
     pub fn raw_row_length_from_width(&self, width: u32) -> usize {
-        let bits = width as usize
-            * match self.color_type {
-                ColorType::Indexed => 1,
-                c @ _ => c.samples(),
-            }
-            * self.bit_depth as usize;
-
-        let extra = bits % 8;
-        bits / 8
-            + match extra {
-                0 => 0,
-                _ => 1,
-            }
-            + 1 // filter method
+        self.color_type
+            .raw_row_length_from_width(self.bit_depth, width)
     }
 }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -116,6 +116,19 @@ impl<R: Read> Decoder<R> {
     pub fn read_info(self) -> Result<(OutputInfo, Reader<R>), DecodingError> {
         let mut r = Reader::new(self.r, StreamingDecoder::new(), self.transform, self.limits);
         r.init()?;
+
+        let color_type = r.info().color_type;
+        let bit_depth = r.info().bit_depth;
+        if color_type.is_combination_invalid(bit_depth) {
+            return Err(DecodingError::Format(
+                format!(
+                    "Invalid color/depth combination in header: {:?}/{:?}",
+                    color_type, bit_depth
+                )
+                .into(),
+            ));
+        }
+
         let (ct, bits) = r.output_color_type();
         let info = {
             let info = r.info();

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -517,6 +517,10 @@ impl<R: Read> Reader<R> {
     /// Returns the color type and the number of bits per sample
     /// of the data returned by `Reader::next_row` and Reader::frames`.
     pub fn output_color_type(&mut self) -> (ColorType, BitDepth) {
+        self.imm_output_color_type()
+    }
+
+    pub(crate) fn imm_output_color_type(&self) -> (ColorType, BitDepth) {
         use crate::common::ColorType::*;
         let t = self.transform;
         let info = get_info!(self);
@@ -559,16 +563,8 @@ impl<R: Read> Reader<R> {
 
     /// Returns the number of bytes required to hold a deinterlaced row.
     pub fn output_line_size(&self, width: u32) -> usize {
-        let size = self.line_size(width);
-        if get_info!(self).bit_depth as u8 == 16
-            && self
-                .transform
-                .intersects(crate::Transformations::SCALE_16 | crate::Transformations::STRIP_16)
-        {
-            size / 2
-        } else {
-            size
-        }
+        let (color, depth) = self.imm_output_color_type();
+        color.raw_row_length_from_width(depth, width) - 1
     }
 
     /// Returns the number of bytes required to decode a deinterlaced row.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -143,7 +143,11 @@ impl<W: Write> Writer<W> {
             return Err(EncodingError::Format("Zero height not allowed".into()));
         }
 
-        if self.is_bit_depth_color_type_combination_invalid() {
+        if self
+            .info
+            .color_type
+            .is_combination_invalid(self.info.bit_depth)
+        {
             return Err(EncodingError::Format(
                 format!(
                     "Invalid combination of bit-depth '{:?}' and color-type '{:?}'",
@@ -167,19 +171,6 @@ impl<W: Write> Writer<W> {
         };
 
         Ok(self)
-    }
-
-    fn is_bit_depth_color_type_combination_invalid(&self) -> bool {
-        let bit_depth = self.info.bit_depth;
-        let color_type = self.info.color_type;
-
-        // Section 11.2.2 of the PNG standard disallows several combinations
-        // of bit depth and color type
-        ((bit_depth == BitDepth::One || bit_depth == BitDepth::Two || bit_depth == BitDepth::Four)
-            && (color_type == ColorType::RGB
-                || color_type == ColorType::GrayscaleAlpha
-                || color_type == ColorType::RGBA))
-            || (bit_depth == BitDepth::Sixteen && color_type == ColorType::Indexed)
     }
 
     pub fn write_chunk(&mut self, name: [u8; 4], data: &[u8]) -> Result<()> {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -523,6 +523,10 @@ mod tests {
 
             let palette: Vec<u8> = reader.info().palette.clone().unwrap();
             let mut decoded_pixels = vec![0; info.buffer_size()];
+            assert_eq!(
+                info.width as usize * info.height as usize * samples,
+                decoded_pixels.len()
+            );
             reader.next_frame(&mut decoded_pixels).unwrap();
 
             let pixels_per_byte = 8 / usize::from(bit_depth);


### PR DESCRIPTION
The calculation for buffer size used a different path than the color
used during actual decoding, especially when the flags would expand
colors. This would only panic during the decoding of interlaced images.
For standard images the remaining data would simply get dropped.

Closes: #222 