### PR TITLE
Check buffer sizes for overflow

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -419,6 +419,7 @@ mod tests {
                     // x* files are expected to fail to decode
                     continue;
                 }
+                eprintln!("{}", path.display());
                 // Decode image
                 let decoder = crate::Decoder::new(File::open(path).unwrap());
                 let (info, mut reader) = decoder.read_info().unwrap();
@@ -427,6 +428,7 @@ mod tests {
                     continue;
                 }
                 let mut buf = vec![0; info.buffer_size()];
+                eprintln!("{:?}", info);
                 reader.next_frame(&mut buf).unwrap();
                 // Encode decoded image
                 let mut out = Vec::new();


### PR DESCRIPTION
Fixes an issue affecting mainly platforms with 32-bit (or smaller)
pointer size where the calculation of required buffer sizes would
use unchecked math ops that could silently overflow.

We now try to calculate the maximum of the necessary lengths up-front,
as part of converting to a Reader, which ensures that all other
computations have no overflow.

Closes: #225 