### PR TITLE
Adds reading and writing of gAMA (gamma) and cHRM (primary chromaticities).

### DIFF
--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -218,7 +218,7 @@ fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {
                         "in {} ({} chunks, {:.1}% compression)",
                         fname,
                         n_chunks,
-                        100.0 * (1.0 - c_ratio!())
+                        100.0 * (1.0 - c_ratio!()),
                     )
                 }
                 break;

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -27,6 +27,8 @@ pub const tIME: ChunkType = [b't', b'I', b'M', b'E'];
 pub const pHYs: ChunkType = [b'p', b'H', b'Y', b's'];
 /// Color primary chromaticities
 pub const cHRM: ChunkType = [b'c', b'H', b'R', b'M'];
+/// Source system's gamma value (multiplied by 100000)
+pub const gAMA: ChunkType = [b'g', b'A', b'M', b'A'];
 
 // -- Extension chunks --
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -25,7 +25,7 @@ pub const bKGD: ChunkType = [b'b', b'K', b'G', b'D'];
 pub const tIME: ChunkType = [b't', b'I', b'M', b'E'];
 /// Physical pixel dimensions
 pub const pHYs: ChunkType = [b'p', b'H', b'Y', b's'];
-/// Color primary chromaticities
+/// Source system's pixel chromaticities
 pub const cHRM: ChunkType = [b'c', b'H', b'R', b'M'];
 /// Source system's gamma value
 pub const gAMA: ChunkType = [b'g', b'A', b'M', b'A'];

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -27,7 +27,7 @@ pub const tIME: ChunkType = [b't', b'I', b'M', b'E'];
 pub const pHYs: ChunkType = [b'p', b'H', b'Y', b's'];
 /// Color primary chromaticities
 pub const cHRM: ChunkType = [b'c', b'H', b'R', b'M'];
-/// Source system's gamma value (multiplied by 100000)
+/// Source system's gamma value
 pub const gAMA: ChunkType = [b'g', b'A', b'M', b'A'];
 
 // -- Extension chunks --

--- a/src/common.rs
+++ b/src/common.rs
@@ -295,7 +295,7 @@ pub struct ScaledFloat(u32);
 
 impl ScaledFloat {
     const SCALING: f32 = 100000.0;
-    
+
     /// Gets whether the value is within the clamped range of this type.
     pub fn in_range(value: f32) -> bool {
         value >= 0.0 && (value * Self::SCALING).floor() <= std::u32::MAX as f32
@@ -319,7 +319,9 @@ impl ScaledFloat {
     /// Slightly inaccurate scaling and quantization.
     /// Clamps the value into the representible range if it is negative of too large.
     pub fn new(value: f32) -> Self {
-        Self { 0: Self::forward(value) }
+        Self {
+            0: Self::forward(value),
+        }
     }
 
     /// Fully accurate construction from a value scaled as per specification.
@@ -340,16 +342,16 @@ impl ScaledFloat {
 
 /// Chromaticities of the color space primaries
 #[derive(Debug, Clone, Copy)]
-pub struct PrimaryChromaticities {
+pub struct SourceChromaticities {
     pub white: (ScaledFloat, ScaledFloat),
     pub red: (ScaledFloat, ScaledFloat),
     pub green: (ScaledFloat, ScaledFloat),
     pub blue: (ScaledFloat, ScaledFloat),
 }
 
-impl PrimaryChromaticities {
+impl SourceChromaticities {
     pub fn new(white: (f32, f32), red: (f32, f32), green: (f32, f32), blue: (f32, f32)) -> Self {
-        PrimaryChromaticities {
+        SourceChromaticities {
             white: (ScaledFloat::new(white.0), ScaledFloat::new(white.1)),
             red: (ScaledFloat::new(red.0), ScaledFloat::new(red.1)),
             green: (ScaledFloat::new(green.0), ScaledFloat::new(green.1)),
@@ -375,7 +377,7 @@ pub struct Info {
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
     pub filter: filter::FilterType,
-    pub primary_chromaticities: Option<PrimaryChromaticities>,
+    pub source_chromaticities: Option<SourceChromaticities>,
 }
 
 impl Default for Info {
@@ -396,7 +398,7 @@ impl Default for Info {
             // to maintain backward compatible output.
             compression: Compression::Fast,
             filter: filter::FilterType::Sub,
-            primary_chromaticities: None,
+            source_chromaticities: None,
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -289,7 +289,7 @@ pub enum Compression {
 }
 
 /// Chromaticities of the color space primaries
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct PrimaryChromaticities {
     pub white_point: (f32, f32),
     pub red: (f32, f32),
@@ -307,6 +307,8 @@ pub struct Info {
     pub interlaced: bool,
     pub trns: Option<Vec<u8>>,
     pub pixel_dims: Option<PixelDimensions>,
+    /// Source system's gamma
+    pub source_gamma: Option<f32>,
     pub palette: Option<Vec<u8>>,
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
@@ -326,6 +328,7 @@ impl Default for Info {
             palette: None,
             trns: None,
             pixel_dims: None,
+            source_gamma: None,
             frame_control: None,
             animation_control: None,
             // Default to `deflate::Compresion::Fast` and `filter::FilterType::Sub`

--- a/src/common.rs
+++ b/src/common.rs
@@ -290,7 +290,7 @@ pub enum Compression {
 
 /// An unsigned integer scaled version of a floating point value,
 /// equivalent to an integer quotient with fixed denominator (100000)).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ScaledFloat(u32);
 
 impl ScaledFloat {
@@ -341,7 +341,7 @@ impl ScaledFloat {
 }
 
 /// Chromaticities of the color space primaries
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SourceChromaticities {
     pub white: (ScaledFloat, ScaledFloat),
     pub red: (ScaledFloat, ScaledFloat),

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -827,8 +827,24 @@ mod tests {
             let actual: Option<SourceChromaticities> = reader.info().source_chromaticities;
             assert!(actual == expected);
         }
-        trial("tests/pngsuite/ccwn2c08.png", Some(SourceChromaticities::new((0.3127, 0.3290), (0.64, 0.33), (0.30, 0.60), (0.15, 0.06))));
-        trial("tests/pngsuite/ccwn3p08.png", Some(SourceChromaticities::new((0.3127, 0.3290), (0.64, 0.33), (0.30, 0.60), (0.15, 0.06))));
+        trial(
+            "tests/pngsuite/ccwn2c08.png",
+            Some(SourceChromaticities::new(
+                (0.3127, 0.3290),
+                (0.64, 0.33),
+                (0.30, 0.60),
+                (0.15, 0.06),
+            )),
+        );
+        trial(
+            "tests/pngsuite/ccwn3p08.png",
+            Some(SourceChromaticities::new(
+                (0.3127, 0.3290),
+                (0.64, 0.33),
+                (0.30, 0.60),
+                (0.15, 0.06),
+            )),
+        );
         trial("tests/pngsuite/basi0g01.png", None);
         trial("tests/pngsuite/basi0g02.png", None);
         trial("tests/pngsuite/basi0g04.png", None);

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -14,7 +14,7 @@ use super::zlib::ZlibStream;
 use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
 use crate::common::{
     AnimationControl, BitDepth, BlendOp, ColorType, DisposeOp, FrameControl, Info, PixelDimensions,
-    ScaledFloat, PrimaryChromaticities, Unit,
+    ScaledFloat, SourceChromaticities, Unit,
 };
 use crate::traits::ReadBytesExt;
 
@@ -626,11 +626,23 @@ impl StreamingDecoder {
         let blue_x: u32 = buf.read_be()?;
         let blue_y: u32 = buf.read_be()?;
 
-        let primary_chromaticities = PrimaryChromaticities {
-            white: (ScaledFloat::from_scaled(white_x), ScaledFloat::from_scaled(white_y)),
-            red: (ScaledFloat::from_scaled(red_x), ScaledFloat::from_scaled(red_y)),
-            green: (ScaledFloat::from_scaled(green_x), ScaledFloat::from_scaled(green_y)),
-            blue: (ScaledFloat::from_scaled(blue_x), ScaledFloat::from_scaled(blue_y)),
+        let source_chromaticities = SourceChromaticities {
+            white: (
+                ScaledFloat::from_scaled(white_x),
+                ScaledFloat::from_scaled(white_y),
+            ),
+            red: (
+                ScaledFloat::from_scaled(red_x),
+                ScaledFloat::from_scaled(red_y),
+            ),
+            green: (
+                ScaledFloat::from_scaled(green_x),
+                ScaledFloat::from_scaled(green_y),
+            ),
+            blue: (
+                ScaledFloat::from_scaled(blue_x),
+                ScaledFloat::from_scaled(blue_y),
+            ),
         };
 
         let info = match self.info {
@@ -642,7 +654,7 @@ impl StreamingDecoder {
             }
         };
 
-        info.primary_chromaticities = Some(primary_chromaticities);
+        info.source_chromaticities = Some(source_chromaticities);
         Ok(Decoded::Nothing)
     }
 
@@ -760,11 +772,10 @@ pub fn get_info(d: &StreamingDecoder) -> Option<&Info> {
     d.info.as_ref()
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
     use super::ScaledFloat;
+    use std::fs::File;
 
     #[test]
     fn image_gamma() -> Result<(), ()> {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -775,6 +775,7 @@ pub fn get_info(d: &StreamingDecoder) -> Option<&Info> {
 #[cfg(test)]
 mod tests {
     use super::ScaledFloat;
+    use super::SourceChromaticities;
     use std::fs::File;
 
     #[test]
@@ -782,8 +783,8 @@ mod tests {
         fn trial(path: &str, expected: Option<ScaledFloat>) {
             let decoder = crate::Decoder::new(File::open(path).unwrap());
             let (_, reader) = decoder.read_info().unwrap();
-            let source_gamma: Option<ScaledFloat> = reader.info().source_gamma;
-            assert!(source_gamma == expected);
+            let actual: Option<ScaledFloat> = reader.info().source_gamma;
+            assert!(actual == expected);
         }
         trial("tests/pngsuite/f00n0g08.png", None);
         trial("tests/pngsuite/f00n2c08.png", None);
@@ -815,6 +816,177 @@ mod tests {
         trial("tests/pngsuite/g25n0g16.png", Some(ScaledFloat::new(2.5)));
         trial("tests/pngsuite/g25n2c08.png", Some(ScaledFloat::new(2.5)));
         trial("tests/pngsuite/g25n3p04.png", Some(ScaledFloat::new(2.5)));
+        Ok(())
+    }
+
+    #[test]
+    fn image_source_chromaticities() -> Result<(), ()> {
+        fn trial(path: &str, expected: Option<SourceChromaticities>) {
+            let decoder = crate::Decoder::new(File::open(path).unwrap());
+            let (_, reader) = decoder.read_info().unwrap();
+            let actual: Option<SourceChromaticities> = reader.info().source_chromaticities;
+            assert!(actual == expected);
+        }
+        trial("tests/pngsuite/ccwn2c08.png", Some(SourceChromaticities::new((0.3127, 0.3290), (0.64, 0.33), (0.30, 0.60), (0.15, 0.06))));
+        trial("tests/pngsuite/ccwn3p08.png", Some(SourceChromaticities::new((0.3127, 0.3290), (0.64, 0.33), (0.30, 0.60), (0.15, 0.06))));
+        trial("tests/pngsuite/basi0g01.png", None);
+        trial("tests/pngsuite/basi0g02.png", None);
+        trial("tests/pngsuite/basi0g04.png", None);
+        trial("tests/pngsuite/basi0g08.png", None);
+        trial("tests/pngsuite/basi0g16.png", None);
+        trial("tests/pngsuite/basi2c08.png", None);
+        trial("tests/pngsuite/basi2c16.png", None);
+        trial("tests/pngsuite/basi3p01.png", None);
+        trial("tests/pngsuite/basi3p02.png", None);
+        trial("tests/pngsuite/basi3p04.png", None);
+        trial("tests/pngsuite/basi3p08.png", None);
+        trial("tests/pngsuite/basi4a08.png", None);
+        trial("tests/pngsuite/basi4a16.png", None);
+        trial("tests/pngsuite/basi6a08.png", None);
+        trial("tests/pngsuite/basi6a16.png", None);
+        trial("tests/pngsuite/basn0g01.png", None);
+        trial("tests/pngsuite/basn0g02.png", None);
+        trial("tests/pngsuite/basn0g04.png", None);
+        trial("tests/pngsuite/basn0g08.png", None);
+        trial("tests/pngsuite/basn0g16.png", None);
+        trial("tests/pngsuite/basn2c08.png", None);
+        trial("tests/pngsuite/basn2c16.png", None);
+        trial("tests/pngsuite/basn3p01.png", None);
+        trial("tests/pngsuite/basn3p02.png", None);
+        trial("tests/pngsuite/basn3p04.png", None);
+        trial("tests/pngsuite/basn3p08.png", None);
+        trial("tests/pngsuite/basn4a08.png", None);
+        trial("tests/pngsuite/basn4a16.png", None);
+        trial("tests/pngsuite/basn6a08.png", None);
+        trial("tests/pngsuite/basn6a16.png", None);
+        trial("tests/pngsuite/bgai4a08.png", None);
+        trial("tests/pngsuite/bgai4a16.png", None);
+        trial("tests/pngsuite/bgan6a08.png", None);
+        trial("tests/pngsuite/bgan6a16.png", None);
+        trial("tests/pngsuite/bgbn4a08.png", None);
+        trial("tests/pngsuite/bggn4a16.png", None);
+        trial("tests/pngsuite/bgwn6a08.png", None);
+        trial("tests/pngsuite/bgyn6a16.png", None);
+        trial("tests/pngsuite/cdfn2c08.png", None);
+        trial("tests/pngsuite/cdhn2c08.png", None);
+        trial("tests/pngsuite/cdsn2c08.png", None);
+        trial("tests/pngsuite/cdun2c08.png", None);
+        trial("tests/pngsuite/ch1n3p04.png", None);
+        trial("tests/pngsuite/ch2n3p08.png", None);
+        trial("tests/pngsuite/cm0n0g04.png", None);
+        trial("tests/pngsuite/cm7n0g04.png", None);
+        trial("tests/pngsuite/cm9n0g04.png", None);
+        trial("tests/pngsuite/cs3n2c16.png", None);
+        trial("tests/pngsuite/cs3n3p08.png", None);
+        trial("tests/pngsuite/cs5n2c08.png", None);
+        trial("tests/pngsuite/cs5n3p08.png", None);
+        trial("tests/pngsuite/cs8n2c08.png", None);
+        trial("tests/pngsuite/cs8n3p08.png", None);
+        trial("tests/pngsuite/ct0n0g04.png", None);
+        trial("tests/pngsuite/ct1n0g04.png", None);
+        trial("tests/pngsuite/cten0g04.png", None);
+        trial("tests/pngsuite/ctfn0g04.png", None);
+        trial("tests/pngsuite/ctgn0g04.png", None);
+        trial("tests/pngsuite/cthn0g04.png", None);
+        trial("tests/pngsuite/ctjn0g04.png", None);
+        trial("tests/pngsuite/ctzn0g04.png", None);
+        trial("tests/pngsuite/f00n0g08.png", None);
+        trial("tests/pngsuite/f00n2c08.png", None);
+        trial("tests/pngsuite/f01n0g08.png", None);
+        trial("tests/pngsuite/f01n2c08.png", None);
+        trial("tests/pngsuite/f02n0g08.png", None);
+        trial("tests/pngsuite/f02n2c08.png", None);
+        trial("tests/pngsuite/f03n0g08.png", None);
+        trial("tests/pngsuite/f03n2c08.png", None);
+        trial("tests/pngsuite/f04n0g08.png", None);
+        trial("tests/pngsuite/f04n2c08.png", None);
+        trial("tests/pngsuite/f99n0g04.png", None);
+        trial("tests/pngsuite/g03n0g16.png", None);
+        trial("tests/pngsuite/g03n2c08.png", None);
+        trial("tests/pngsuite/g03n3p04.png", None);
+        trial("tests/pngsuite/g04n0g16.png", None);
+        trial("tests/pngsuite/g04n2c08.png", None);
+        trial("tests/pngsuite/g04n3p04.png", None);
+        trial("tests/pngsuite/g05n0g16.png", None);
+        trial("tests/pngsuite/g05n2c08.png", None);
+        trial("tests/pngsuite/g05n3p04.png", None);
+        trial("tests/pngsuite/g07n0g16.png", None);
+        trial("tests/pngsuite/g07n2c08.png", None);
+        trial("tests/pngsuite/g07n3p04.png", None);
+        trial("tests/pngsuite/g10n0g16.png", None);
+        trial("tests/pngsuite/g10n2c08.png", None);
+        trial("tests/pngsuite/g10n3p04.png", None);
+        trial("tests/pngsuite/g25n0g16.png", None);
+        trial("tests/pngsuite/g25n2c08.png", None);
+        trial("tests/pngsuite/g25n3p04.png", None);
+        trial("tests/pngsuite/oi1n0g16.png", None);
+        trial("tests/pngsuite/oi1n2c16.png", None);
+        trial("tests/pngsuite/oi2n0g16.png", None);
+        trial("tests/pngsuite/oi2n2c16.png", None);
+        trial("tests/pngsuite/oi4n0g16.png", None);
+        trial("tests/pngsuite/oi4n2c16.png", None);
+        trial("tests/pngsuite/oi9n0g16.png", None);
+        trial("tests/pngsuite/oi9n2c16.png", None);
+        trial("tests/pngsuite/PngSuite.png", None);
+        trial("tests/pngsuite/pp0n2c16.png", None);
+        trial("tests/pngsuite/pp0n6a08.png", None);
+        trial("tests/pngsuite/ps1n0g08.png", None);
+        trial("tests/pngsuite/ps1n2c16.png", None);
+        trial("tests/pngsuite/ps2n0g08.png", None);
+        trial("tests/pngsuite/ps2n2c16.png", None);
+        trial("tests/pngsuite/s01i3p01.png", None);
+        trial("tests/pngsuite/s01n3p01.png", None);
+        trial("tests/pngsuite/s02i3p01.png", None);
+        trial("tests/pngsuite/s02n3p01.png", None);
+        trial("tests/pngsuite/s03i3p01.png", None);
+        trial("tests/pngsuite/s03n3p01.png", None);
+        trial("tests/pngsuite/s04i3p01.png", None);
+        trial("tests/pngsuite/s04n3p01.png", None);
+        trial("tests/pngsuite/s05i3p02.png", None);
+        trial("tests/pngsuite/s05n3p02.png", None);
+        trial("tests/pngsuite/s06i3p02.png", None);
+        trial("tests/pngsuite/s06n3p02.png", None);
+        trial("tests/pngsuite/s07i3p02.png", None);
+        trial("tests/pngsuite/s07n3p02.png", None);
+        trial("tests/pngsuite/s08i3p02.png", None);
+        trial("tests/pngsuite/s08n3p02.png", None);
+        trial("tests/pngsuite/s09i3p02.png", None);
+        trial("tests/pngsuite/s09n3p02.png", None);
+        trial("tests/pngsuite/s32i3p04.png", None);
+        trial("tests/pngsuite/s32n3p04.png", None);
+        trial("tests/pngsuite/s33i3p04.png", None);
+        trial("tests/pngsuite/s33n3p04.png", None);
+        trial("tests/pngsuite/s34i3p04.png", None);
+        trial("tests/pngsuite/s34n3p04.png", None);
+        trial("tests/pngsuite/s35i3p04.png", None);
+        trial("tests/pngsuite/s35n3p04.png", None);
+        trial("tests/pngsuite/s36i3p04.png", None);
+        trial("tests/pngsuite/s36n3p04.png", None);
+        trial("tests/pngsuite/s37i3p04.png", None);
+        trial("tests/pngsuite/s37n3p04.png", None);
+        trial("tests/pngsuite/s38i3p04.png", None);
+        trial("tests/pngsuite/s38n3p04.png", None);
+        trial("tests/pngsuite/s39i3p04.png", None);
+        trial("tests/pngsuite/s39n3p04.png", None);
+        trial("tests/pngsuite/s40i3p04.png", None);
+        trial("tests/pngsuite/s40n3p04.png", None);
+        trial("tests/pngsuite/tbbn0g04.png", None);
+        trial("tests/pngsuite/tbbn2c16.png", None);
+        trial("tests/pngsuite/tbbn3p08.png", None);
+        trial("tests/pngsuite/tbgn2c16.png", None);
+        trial("tests/pngsuite/tbgn3p08.png", None);
+        trial("tests/pngsuite/tbrn2c08.png", None);
+        trial("tests/pngsuite/tbwn0g16.png", None);
+        trial("tests/pngsuite/tbwn3p08.png", None);
+        trial("tests/pngsuite/tbyn3p08.png", None);
+        trial("tests/pngsuite/tm3n3p02.png", None);
+        trial("tests/pngsuite/tp0n0g08.png", None);
+        trial("tests/pngsuite/tp0n2c08.png", None);
+        trial("tests/pngsuite/tp0n3p08.png", None);
+        trial("tests/pngsuite/tp1n3p08.png", None);
+        trial("tests/pngsuite/z00n2c08.png", None);
+        trial("tests/pngsuite/z03n2c08.png", None);
+        trial("tests/pngsuite/z06n2c08.png", None);
         Ok(())
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -11,7 +11,7 @@ use std::result;
 use crc32fast::Hasher as Crc32;
 
 use crate::chunk;
-use crate::common::{BitDepth, BytesPerPixel, ColorType, Compression, Info};
+use crate::common::{BitDepth, BytesPerPixel, ColorType, Compression, Info, ScaledFloat};
 use crate::filter::{filter, FilterType};
 use crate::traits::WriteBytesExt;
 
@@ -75,20 +75,11 @@ impl<W: Write> Encoder<W> {
         self.info.trns = Some(trns);
     }
 
-    pub fn set_source_gamma(&mut self, source_gamma: f32) {
-        assert!(source_gamma > 0.);
+    pub fn set_source_gamma(&mut self, source_gamma: ScaledFloat) {
         self.info.source_gamma = Some(source_gamma);
     }
     
     pub fn set_primary_chromaticities(&mut self, primary_chromaticities: super::PrimaryChromaticities) {
-        assert!(primary_chromaticities.white_point.0 >= 0.);
-        assert!(primary_chromaticities.white_point.1 >= 0.);
-        assert!(primary_chromaticities.red.0 >= 0.);
-        assert!(primary_chromaticities.red.1 >= 0.);
-        assert!(primary_chromaticities.green.0 >= 0.);
-        assert!(primary_chromaticities.green.1 >= 0.);
-        assert!(primary_chromaticities.blue.0 >= 0.);
-        assert!(primary_chromaticities.blue.1 >= 0.);
         self.info.primary_chromaticities = Some(primary_chromaticities);
     }
 
@@ -197,35 +188,37 @@ impl<W: Write> Writer<W> {
         }
 
         if let Some(g) = &self.info.source_gamma {
-            let scale_factor = 100000.;
-            let g = (g * scale_factor).floor() as u32;
-            write_chunk(&mut self.w, chunk::gAMA, &g.to_be_bytes())?;
+            write_chunk(&mut self.w, chunk::gAMA, &g.into_scaled().to_be_bytes())?;
         }
 
         if let Some(c) = &self.info.primary_chromaticities {
-            let scale_factor = 100000.;
-            let white_x = ((c.white_point.0 * scale_factor).round() as u32).to_be_bytes();
-            let white_y = ((c.white_point.1 * scale_factor).round() as u32).to_be_bytes();
-            let red_x = ((c.red.0 * scale_factor).round() as u32).to_be_bytes();
-            let red_y = ((c.red.1 * scale_factor).round() as u32).to_be_bytes();
-            let green_x = ((c.green.0 * scale_factor).round() as u32).to_be_bytes();
-            let green_y = ((c.green.1 * scale_factor).round() as u32).to_be_bytes();
-            let blue_x = ((c.blue.0 * scale_factor).round() as u32).to_be_bytes();
-            let blue_y = ((c.blue.1 * scale_factor).round() as u32).to_be_bytes();
-            let enc = [
-                white_x[0], white_x[1], white_x[2], white_x[3],
-                white_y[0], white_y[1], white_y[2], white_y[3],
-                  red_x[0],   red_x[1],   red_x[2],   red_x[3],
-                  red_y[0],   red_y[1],   red_y[2],   red_y[3],
-                green_x[0], green_x[1], green_x[2], green_x[3],
-                green_y[0], green_y[1], green_y[2], green_y[3],
-                 blue_x[0],  blue_x[1],  blue_x[2],  blue_x[3],
-                 blue_y[0],  blue_y[1],  blue_y[2],  blue_y[3],
-            ];
+            let enc = Self::chromaticities_to_be_bytes(&c);
             write_chunk(&mut self.w, chunk::cHRM, &enc)?;
         }
 
         Ok(self)
+    }
+
+    #[rustfmt::skip]
+    fn chromaticities_to_be_bytes(c: &super::common::PrimaryChromaticities) -> [u8; 32] {
+        let white_x = c.white.0.into_scaled().to_be_bytes();
+        let white_y = c.white.1.into_scaled().to_be_bytes();
+        let red_x = c.red.0.into_scaled().to_be_bytes();
+        let red_y = c.red.1.into_scaled().to_be_bytes();
+        let green_x = c.green.0.into_scaled().to_be_bytes();
+        let green_y = c.green.1.into_scaled().to_be_bytes();
+        let blue_x = c.blue.0.into_scaled().to_be_bytes();
+        let blue_y = c.blue.1.into_scaled().to_be_bytes();
+        [
+            white_x[0], white_x[1], white_x[2], white_x[3],
+            white_y[0], white_y[1], white_y[2], white_y[3],
+            red_x[0],   red_x[1],   red_x[2],   red_x[3],
+            red_y[0],   red_y[1],   red_y[2],   red_y[3],
+            green_x[0], green_x[1], green_x[2], green_x[3],
+            green_y[0], green_y[1], green_y[2], green_y[3],
+            blue_x[0],  blue_x[1],  blue_x[2],  blue_x[3],
+            blue_y[0],  blue_y[1],  blue_y[2],  blue_y[3],
+        ]
     }
 
     pub fn write_chunk(&mut self, name: [u8; 4], data: &[u8]) -> Result<()> {
@@ -845,7 +838,7 @@ mod tests {
     fn some_gamma_roundtrip() -> io::Result<()> {
         let pixel: Vec<_> = (0..48).collect();
 
-        let roundtrip = |gamma: Option<f32>| -> io::Result<()> {
+        let roundtrip = |gamma: Option<ScaledFloat>| -> io::Result<()> {
             let mut buffer = vec![];
             let mut encoder = Encoder::new(&mut buffer, 4, 4);
             encoder.set_depth(BitDepth::Eight);
@@ -868,12 +861,12 @@ mod tests {
         };
 
         roundtrip(None)?;
-        roundtrip(Some(0.35))?;
-        roundtrip(Some(0.45))?;
-        roundtrip(Some(0.55))?;
-        roundtrip(Some(0.7))?;
-        roundtrip(Some(1.0))?;
-        roundtrip(Some(2.5))?;
+        roundtrip(Some(ScaledFloat::new(0.35)))?;
+        roundtrip(Some(ScaledFloat::new(0.45)))?;
+        roundtrip(Some(ScaledFloat::new(0.55)))?;
+        roundtrip(Some(ScaledFloat::new(0.7)))?;
+        roundtrip(Some(ScaledFloat::new(1.0)))?;
+        roundtrip(Some(ScaledFloat::new(2.5)))?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,14 @@
 //! encoder.set_color(png::ColorType::RGBA);
 //! encoder.set_depth(png::BitDepth::Eight);
 //! encoder.set_trns(vec!(0xFFu8, 0xFFu8, 0xFFu8, 0xFFu8));
-//! encoder.set_source_gamma(45455); // 100000 / 2.2 (default png scaling to u32)
+//! encoder.set_source_gamma(png::ScaledFloat::from_scaled(45455)); // 1.0 / 2.2, scaled by 100000
+//! let primary_chromaticities = png::PrimaryChromaticities::new(
+//!     (0.31270, 0.32900),
+//!     (0.64000, 0.33000),
+//!     (0.30000, 0.60000),
+//!     (0.15000, 0.06000)
+//! );
+//! encoder.set_primary_chromaticities(primary_chromaticities);
 //! let mut writer = encoder.write_header().unwrap();
 //!
 //! let data = [255, 0, 0, 255, 0, 0, 0, 255]; // An array containing a RGBA sequence. First pixel is red and second pixel is black.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@
 //! let mut encoder = png::Encoder::new(w, 2, 1); // Width is 2 pixels and height is 1.
 //! encoder.set_color(png::ColorType::RGBA);
 //! encoder.set_depth(png::BitDepth::Eight);
+//! encoder.set_trns(vec!(0xFFu8, 0xFFu8, 0xFFu8, 0xFFu8));
+//! encoder.set_source_gamma(45455); // 100000 / 2.2 (default png scaling to u32)
 //! let mut writer = encoder.write_header().unwrap();
 //!
 //! let data = [255, 0, 0, 255, 0, 0, 0, 255]; // An array containing a RGBA sequence. First pixel is red and second pixel is black.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,14 @@
 //! encoder.set_depth(png::BitDepth::Eight);
 //! encoder.set_trns(vec!(0xFFu8, 0xFFu8, 0xFFu8, 0xFFu8));
 //! encoder.set_source_gamma(png::ScaledFloat::from_scaled(45455)); // 1.0 / 2.2, scaled by 100000
-//! let primary_chromaticities = png::PrimaryChromaticities::new(
+//! encoder.set_source_gamma(png::ScaledFloat::new(1.0 / 2.2));     // 1.0 / 2.2, unscaled, but rounded
+//! let source_chromaticities = png::SourceChromaticities::new(     // Using unscaled instantiation here
 //!     (0.31270, 0.32900),
 //!     (0.64000, 0.33000),
 //!     (0.30000, 0.60000),
 //!     (0.15000, 0.06000)
 //! );
-//! encoder.set_primary_chromaticities(primary_chromaticities);
+//! encoder.set_source_chromaticities(source_chromaticities);
 //! let mut writer = encoder.write_header().unwrap();
 //!
 //! let data = [255, 0, 0, 255, 0, 0, 0, 255]; // An array containing a RGBA sequence. First pixel is red and second pixel is black.


### PR DESCRIPTION
I've included tests for gamma (passing) based on the PngSuite images.
I've used the modified library in my personal project and found it to work fine.

cHRM code is pulled from kettle11's fork which didn't include tests. I have also not tested it, but will do so in the future.