### PR TITLE
Forbid unsafe code

### DIFF
--- a/examples/show.rs
+++ b/examples/show.rs
@@ -4,7 +4,6 @@ extern crate png;
 
 use std::borrow::Cow;
 use std::env;
-use std::error::Error;
 use std::fs::File;
 use std::io;
 use std::path;

--- a/png-afl/src/main.rs
+++ b/png-afl/src/main.rs
@@ -1,3 +1,6 @@
+
+#![forbid(unsafe_code)]
+
 #[macro_use]
 extern crate afl;
 extern crate png;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@
 //!
 //#![cfg_attr(test, feature(test))]
 
+#![forbid(unsafe_code)]
+
 #[macro_use]
 extern crate bitflags;
 


### PR DESCRIPTION
Forbid unsafe code by adding `#![forbid(unsafe_code)]`