### PR TITLE
Encapsulated error

### DIFF
--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -179,7 +179,11 @@ fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {
         match decoder.update(buf, &mut Vec::new()) {
             Ok((_, ImageEnd)) => {
                 if !have_idat {
-                    display_error(png::DecodingError::Format("IDAT chunk missing".into()))?;
+                    // This isn't beautiful. But it works.
+                    display_error(png::DecodingError::IoError(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "IDAT chunk missing",
+                    )))?;
                     break;
                 }
                 if !c.verbose && !c.quiet {

--- a/src/common.rs
+++ b/src/common.rs
@@ -531,12 +531,12 @@ pub struct ParameterError {
 
 #[derive(Debug)]
 pub(crate) enum ParameterErrorKind {
-    /// A provided buffer must be large enough to hold the image data. Where the buffer can be
-    /// allocated by the caller, it must ensure that it has a minimum size as hinted previously.
+    /// A provided buffer must be have the exact size to hold the image data. Where the buffer can
+    /// be allocated by the caller, they must ensure that it has a minimum size as hinted previously.
     /// Even though the size is calculated from image data, this does counts as a parameter error
     /// because they must react to a value produced by this library, which can have been subjected
     /// to limits.
-    ImageBufferSize(usize, usize),
+    ImageBufferSize { expected: usize, actual: usize },
     /// A bit like return `None` from an iterator.
     /// We use it to differentiate between failing to seek to the next image in a sequence and the
     /// absence of a next image. This is an error of the caller because they should have checked
@@ -556,8 +556,8 @@ impl fmt::Display for ParameterError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use ParameterErrorKind::*;
         match self.inner {
-            ImageBufferSize(expected, got) => {
-                write!(fmt, "wrong data size, expected {} got {}", expected, got)
+            ImageBufferSize { expected, actual } => {
+                write!(fmt, "wrong data size, expected {} got {}", expected, actual)
             }
             PolledAfterEndOfImage => write!(fmt, "End of image has been reached"),
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -524,6 +524,35 @@ bitflags! {
     }
 }
 
+#[derive(Debug)]
+pub struct ParameterError {
+    inner: ParameterErrorKind,
+}
+
+#[derive(Debug)]
+pub(crate) enum ParameterErrorKind {
+    WrongDataSize(usize, usize),
+    EndOfImageReached,
+}
+
+impl From<ParameterErrorKind> for ParameterError {
+    fn from(inner: ParameterErrorKind) -> Self {
+        ParameterError { inner }
+    }
+}
+
+impl fmt::Display for ParameterError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use ParameterErrorKind::*;
+        match self.inner {
+            WrongDataSize(expected, got) => {
+                write!(fmt, "wrong data size, expected {} got {}", expected, got)
+            }
+            EndOfImageReached => write!(fmt, "End of image has been reached"),
+        }
+    }
+}
+
 /// Mod to encapsulate the converters depending on the `deflate` crate.
 ///
 /// Since this only contains trait impls, there is no need to make this public, they are simply

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -9,7 +9,9 @@ use std::mem;
 use std::ops::Range;
 
 use crate::chunk;
-use crate::common::{BitDepth, BytesPerPixel, ColorType, Info, Transformations};
+use crate::common::{
+    BitDepth, BytesPerPixel, ColorType, Info, ParameterErrorKind, Transformations,
+};
 use crate::filter::{unfilter, FilterType};
 use crate::utils;
 
@@ -317,7 +319,7 @@ impl<R: Read> Reader<R> {
             return Ok(());
         } else if self.next_frame == SubframeIdx::End {
             return Err(DecodingError::Parameter(
-                "End of image has been reached".into(),
+                ParameterErrorKind::EndOfImageReached.into(),
             ));
         }
 
@@ -434,7 +436,7 @@ impl<R: Read> Reader<R> {
         let (color_type, bit_depth) = self.output_color_type();
         if buf.len() < self.output_buffer_size() {
             return Err(DecodingError::Parameter(
-                "supplied buffer is too small to hold the image".into(),
+                ParameterErrorKind::WrongDataSize(buf.len(), self.output_buffer_size()).into(),
             ));
         }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -319,7 +319,7 @@ impl<R: Read> Reader<R> {
             return Ok(());
         } else if self.next_frame == SubframeIdx::End {
             return Err(DecodingError::Parameter(
-                ParameterErrorKind::EndOfImageReached.into(),
+                ParameterErrorKind::PolledAfterEndOfImage.into(),
             ));
         }
 
@@ -436,7 +436,7 @@ impl<R: Read> Reader<R> {
         let (color_type, bit_depth) = self.output_color_type();
         if buf.len() < self.output_buffer_size() {
             return Err(DecodingError::Parameter(
-                ParameterErrorKind::WrongDataSize(buf.len(), self.output_buffer_size()).into(),
+                ParameterErrorKind::ImageBufferSize(buf.len(), self.output_buffer_size()).into(),
             ));
         }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -305,7 +305,9 @@ impl<R: Read> Reader<R> {
         if self.next_frame == self.subframe_idx() {
             return Ok(());
         } else if self.next_frame == SubframeIdx::End {
-            return Err(DecodingError::Other("End of image has been reached".into()));
+            return Err(DecodingError::Parameter(
+                "End of image has been reached".into(),
+            ));
         }
 
         loop {
@@ -416,7 +418,7 @@ impl<R: Read> Reader<R> {
         // TODO 16 bit
         let (color_type, bit_depth) = self.output_color_type();
         if buf.len() < self.output_buffer_size() {
-            return Err(DecodingError::Other(
+            return Err(DecodingError::Parameter(
                 "supplied buffer is too small to hold the image".into(),
             ));
         }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -95,7 +95,7 @@ impl<R: Read> Decoder<R> {
 
     /// Limit resource usage.
     ///
-    /// Note that Your allocations, e.g. when reading into a pre-allocated buffer, is __NOT__
+    /// Note that your allocations, e.g. when reading into a pre-allocated buffer, are __NOT__
     /// considered part of the limits. Nevertheless, required intermediate buffers such as for
     /// singular lines is checked against the limit.
     ///
@@ -436,7 +436,11 @@ impl<R: Read> Reader<R> {
         let (color_type, bit_depth) = self.output_color_type();
         if buf.len() < self.output_buffer_size() {
             return Err(DecodingError::Parameter(
-                ParameterErrorKind::ImageBufferSize(buf.len(), self.output_buffer_size()).into(),
+                ParameterErrorKind::ImageBufferSize {
+                    expected: buf.len(),
+                    actual: self.output_buffer_size(),
+                }
+                .into(),
             ));
         }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -91,7 +91,13 @@ impl<R: Read> Decoder<R> {
         }
     }
 
-    /// Limit resource usage
+    /// Limit resource usage.
+    ///
+    /// Note that Your allocations, e.g. when reading into a pre-allocated buffer, is __NOT__
+    /// considered part of the limits. Nevertheless, required intermediate buffers such as for
+    /// singular lines is checked against the limit.
+    ///
+    /// Note that this is a best-effort basis.
     ///
     /// ```
     /// use std::fs::File;

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,6 +1,5 @@
 extern crate crc32fast;
 
-use std::borrow::Cow;
 use std::cmp::min;
 use std::convert::From;
 use std::default::Default;
@@ -13,8 +12,8 @@ use crc32fast::Hasher as Crc32;
 use super::zlib::ZlibStream;
 use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
 use crate::common::{
-    AnimationControl, BitDepth, BlendOp, ColorType, DisposeOp, FrameControl, Info, PixelDimensions,
-    ScaledFloat, SourceChromaticities, Unit,
+    AnimationControl, BitDepth, BlendOp, ColorType, DisposeOp, FrameControl, Info, ParameterError,
+    PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
 };
 use crate::traits::ReadBytesExt;
 
@@ -99,7 +98,7 @@ pub enum DecodingError {
     /// number of calls
     ///
     /// If you're an application you might want to signal that a bug report is appreciated.
-    Parameter(Cow<'static, str>),
+    Parameter(ParameterError),
     /// The image would have required exceeding the limits configured with the decoder.
     ///
     /// Note that Your allocations, e.g. when reading into a pre-allocated buffer, is __NOT__

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -102,7 +102,7 @@ impl ZlibStream {
             TINFLStatus::Done | TINFLStatus::HasMoreOutput | TINFLStatus::NeedsMoreInput => {
                 Ok(in_consumed)
             }
-            err => Err(DecodingError::FormatNew(
+            err => Err(DecodingError::Format(
                 FormatErrorInner::CorruptFlateStream { err }.into(),
             )),
         }
@@ -161,7 +161,7 @@ impl ZlibStream {
                     );
                 }
                 err => {
-                    return Err(DecodingError::FormatNew(
+                    return Err(DecodingError::Format(
                         FormatErrorInner::CorruptFlateStream { err }.into(),
                     ));
                 }

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -1,4 +1,4 @@
-use super::{DecodingError, CHUNCK_BUFFER_SIZE};
+use super::{stream::FormatErrorInner, DecodingError, CHUNCK_BUFFER_SIZE};
 
 use miniz_oxide::inflate::core::{decompress, inflate_flags, DecompressorOxide};
 use miniz_oxide::inflate::TINFLStatus;
@@ -102,7 +102,9 @@ impl ZlibStream {
             TINFLStatus::Done | TINFLStatus::HasMoreOutput | TINFLStatus::NeedsMoreInput => {
                 Ok(in_consumed)
             }
-            _err => Err(DecodingError::CorruptFlateStream),
+            err => Err(DecodingError::FormatNew(
+                FormatErrorInner::CorruptFlateStream { err }.into(),
+            )),
         }
     }
 
@@ -158,8 +160,10 @@ impl ZlibStream {
                         "No more forward progress made in stream decoding."
                     );
                 }
-                _err => {
-                    return Err(DecodingError::CorruptFlateStream);
+                err => {
+                    return Err(DecodingError::FormatNew(
+                        FormatErrorInner::CorruptFlateStream { err }.into(),
+                    ));
                 }
             }
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -21,6 +21,8 @@ pub type Result<T> = result::Result<T, EncodingError>;
 pub enum EncodingError {
     IoError(io::Error),
     Format(FormatError),
+    Parameter(Cow<'static, str>),
+    LimitsExceeded,
 }
 
 #[derive(Debug)]
@@ -54,6 +56,8 @@ impl fmt::Display for EncodingError {
         match self {
             IoError(err) => write!(fmt, "{}", err),
             Format(desc) => write!(fmt, "{}", desc),
+            Parameter(desc) => write!(fmt, "{}", desc),
+            LimitsExceeded => write!(fmt, "Limits are exceeded."),
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -290,7 +290,7 @@ impl<W: Write> Writer<W> {
         let data_size = in_len * self.info.height as usize;
         if data_size != data.len() {
             return Err(EncodingError::Parameter(
-                ParameterErrorKind::WrongDataSize(data_size, data.len()).into(),
+                ParameterErrorKind::ImageBufferSize(data_size, data.len()).into(),
             ));
         }
         let mut zlib = deflate::write::ZlibEncoder::new(Vec::new(), self.info.compression.clone());

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -290,7 +290,11 @@ impl<W: Write> Writer<W> {
         let data_size = in_len * self.info.height as usize;
         if data_size != data.len() {
             return Err(EncodingError::Parameter(
-                ParameterErrorKind::ImageBufferSize(data_size, data.len()).into(),
+                ParameterErrorKind::ImageBufferSize {
+                    expected: data_size,
+                    actual: data.len(),
+                }
+                .into(),
             ));
         }
         let mut zlib = deflate::write::ZlibEncoder::new(Vec::new(), self.info.compression.clone());


### PR DESCRIPTION
Reworks the error type such that

* we can add new variants easily
* the top-level variants represent different blame of failure, similar to the `image` error.
* the creation of an error no longer allocates

Addresses part of: #213 