### PR TITLE
Fix SCREAM_CASE on ColorType variants

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -8,10 +8,10 @@ use std::{convert::TryFrom, fmt};
 #[repr(u8)]
 pub enum ColorType {
     Grayscale = 0,
-    RGB = 2,
+    Rgb = 2,
     Indexed = 3,
     GrayscaleAlpha = 4,
-    RGBA = 6,
+    Rgba = 6,
 }
 
 impl ColorType {
@@ -24,9 +24,9 @@ impl ColorType {
         use self::ColorType::*;
         match self {
             Grayscale | Indexed => 1,
-            RGB => 3,
+            Rgb => 3,
             GrayscaleAlpha => 2,
-            RGBA => 4,
+            Rgba => 4,
         }
     }
 
@@ -34,10 +34,10 @@ impl ColorType {
     pub fn from_u8(n: u8) -> Option<ColorType> {
         match n {
             0 => Some(ColorType::Grayscale),
-            2 => Some(ColorType::RGB),
+            2 => Some(ColorType::Rgb),
             3 => Some(ColorType::Indexed),
             4 => Some(ColorType::GrayscaleAlpha),
-            6 => Some(ColorType::RGBA),
+            6 => Some(ColorType::Rgba),
             _ => None,
         }
     }
@@ -66,9 +66,9 @@ impl ColorType {
         // Section 11.2.2 of the PNG standard disallows several combinations
         // of bit depth and color type
         ((bit_depth == BitDepth::One || bit_depth == BitDepth::Two || bit_depth == BitDepth::Four)
-            && (self == ColorType::RGB
+            && (self == ColorType::Rgb
                 || self == ColorType::GrayscaleAlpha
-                || self == ColorType::RGBA))
+                || self == ColorType::Rgba))
             || (bit_depth == BitDepth::Sixteen && self == ColorType::Indexed)
     }
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -572,7 +572,7 @@ impl<R: Read> Reader<R> {
                 Grayscale | GrayscaleAlpha if bit_depth < 8 => {
                     expand_gray_u8(output_buffer, get_info!(self))
                 }
-                Grayscale | RGB if trns => {
+                Grayscale | Rgb if trns => {
                     let channels = color_type.samples();
                     let trns = get_info!(self).trns.as_ref().unwrap();
                     if bit_depth == 8 {
@@ -628,9 +628,9 @@ impl<R: Read> Reader<R> {
                 let has_trns = info.trns.is_some();
                 match info.color_type {
                     Grayscale if has_trns => GrayscaleAlpha,
-                    RGB if has_trns => RGBA,
-                    Indexed if has_trns => RGBA,
-                    Indexed => RGB,
+                    Rgb if has_trns => Rgba,
+                    Indexed if has_trns => Rgba,
+                    Indexed => Rgb,
                     ct => ct,
                 }
             } else {
@@ -691,9 +691,9 @@ impl<R: Read> Reader<R> {
         // The color type and depth representing the decoded line
         // TODO 16 bit
         let (color, depth) = match info.color_type {
-            Indexed if trns && t.contains(Transformations::EXPAND) => (RGBA, expanded),
-            Indexed if t.contains(Transformations::EXPAND) => (RGB, expanded),
-            RGB if trns && t.contains(Transformations::EXPAND) => (RGBA, expanded),
+            Indexed if trns && t.contains(Transformations::EXPAND) => (Rgba, expanded),
+            Indexed if t.contains(Transformations::EXPAND) => (Rgb, expanded),
+            Rgb if trns && t.contains(Transformations::EXPAND) => (Rgba, expanded),
             Grayscale if trns && t.contains(Transformations::EXPAND) => (GrayscaleAlpha, expanded),
             Grayscale if t.contains(Transformations::EXPAND) => (Grayscale, expanded),
             GrayscaleAlpha if t.contains(Transformations::EXPAND) => (GrayscaleAlpha, expanded),

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -732,7 +732,6 @@ impl StreamingDecoder {
     }
 
     fn parse_trns(&mut self) -> Result<Decoded, DecodingError> {
-        use crate::common::ColorType::*;
         let (color_type, bit_depth) = {
             let info = self.get_info_or_err()?;
             (info.color_type, info.bit_depth as u8)
@@ -750,7 +749,7 @@ impl StreamingDecoder {
         info.trns = Some(vec);
         let vec = info.trns.as_mut().unwrap();
         match color_type {
-            Grayscale => {
+            ColorType::Grayscale => {
                 if len < 2 {
                     return Err(DecodingError::Format(
                         FormatErrorInner::ShortPalette { expected: 2, len }.into(),
@@ -762,7 +761,7 @@ impl StreamingDecoder {
                 }
                 Ok(Decoded::Nothing)
             }
-            RGB => {
+            ColorType::Rgb => {
                 if len < 6 {
                     return Err(DecodingError::Format(
                         FormatErrorInner::ShortPalette { expected: 6, len }.into(),
@@ -776,7 +775,7 @@ impl StreamingDecoder {
                 }
                 Ok(Decoded::Nothing)
             }
-            Indexed => {
+            ColorType::Indexed => {
                 // FIXME: what's going on here??
                 let _ = info.palette.as_ref().ok_or_else(|| {
                     DecodingError::Format(FormatErrorInner::AfterPlte { kind: chunk::tRNS }.into())

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -679,7 +679,7 @@ mod tests {
         let writer = Cursor::new(output);
         let mut encoder = Encoder::new(writer, width as u32, height as u32);
         encoder.set_depth(BitDepth::Eight);
-        encoder.set_color(ColorType::RGB);
+        encoder.set_color(ColorType::Rgb);
         let mut png_writer = encoder.write_header()?;
 
         let correct_image_size = width * height * 3;
@@ -718,7 +718,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::One);
-        encoder.set_color(ColorType::RGB);
+        encoder.set_color(ColorType::Rgb);
         assert!(encoder.write_header().is_err());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -728,12 +728,12 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::One);
-        encoder.set_color(ColorType::RGBA);
+        encoder.set_color(ColorType::Rgba);
         assert!(encoder.write_header().is_err());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Two);
-        encoder.set_color(ColorType::RGB);
+        encoder.set_color(ColorType::Rgb);
         assert!(encoder.write_header().is_err());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -743,12 +743,12 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Two);
-        encoder.set_color(ColorType::RGBA);
+        encoder.set_color(ColorType::Rgba);
         assert!(encoder.write_header().is_err());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Four);
-        encoder.set_color(ColorType::RGB);
+        encoder.set_color(ColorType::Rgb);
         assert!(encoder.write_header().is_err());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -758,7 +758,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Four);
-        encoder.set_color(ColorType::RGBA);
+        encoder.set_color(ColorType::Rgba);
         assert!(encoder.write_header().is_err());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -813,7 +813,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Eight);
-        encoder.set_color(ColorType::RGB);
+        encoder.set_color(ColorType::Rgb);
         assert!(encoder.write_header().is_ok());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -828,7 +828,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Eight);
-        encoder.set_color(ColorType::RGBA);
+        encoder.set_color(ColorType::Rgba);
         assert!(encoder.write_header().is_ok());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -838,7 +838,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Sixteen);
-        encoder.set_color(ColorType::RGB);
+        encoder.set_color(ColorType::Rgb);
         assert!(encoder.write_header().is_ok());
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
@@ -848,7 +848,7 @@ mod tests {
 
         let mut encoder = Encoder::new(&mut writer, 1, 1);
         encoder.set_depth(BitDepth::Sixteen);
-        encoder.set_color(ColorType::RGBA);
+        encoder.set_color(ColorType::Rgba);
         assert!(encoder.write_header().is_ok());
 
         Ok(())
@@ -862,7 +862,7 @@ mod tests {
             let mut buffer = vec![];
             let mut encoder = Encoder::new(&mut buffer, 4, 4);
             encoder.set_depth(BitDepth::Eight);
-            encoder.set_color(ColorType::RGB);
+            encoder.set_color(ColorType::Rgb);
             encoder.set_filter(filter);
             encoder.write_header()?.write_image_data(&pixel)?;
 
@@ -894,7 +894,7 @@ mod tests {
             let mut buffer = vec![];
             let mut encoder = Encoder::new(&mut buffer, 4, 4);
             encoder.set_depth(BitDepth::Eight);
-            encoder.set_color(ColorType::RGB);
+            encoder.set_color(ColorType::Rgb);
             encoder.set_filter(FilterType::Avg);
             if let Some(gamma) = gamma {
                 encoder.set_source_gamma(gamma);


### PR DESCRIPTION
Part of #213. A similar change was done in `image` in `0.23`.