### PR TITLE
Fix examples and doctests for renamed ColorType variants.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
     - run: rustup default stable
     - name: test
       run: >
-        cargo test -v --tests --benches --all-features
+        cargo test -v --all-targets --all-features
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -56,10 +56,10 @@ fn display_image_type(bits: u8, color: png::ColorType) -> String {
         bits,
         match color {
             Grayscale => "grayscale",
-            RGB => "RGB",
+            Rgb => "RGB",
             Indexed => "palette",
             GrayscaleAlpha => "grayscale+alpha",
-            RGBA => "RGB+alpha",
+            Rgba => "RGB+alpha",
         }
     )
 }
@@ -68,10 +68,10 @@ fn final_channels(c: png::ColorType, trns: bool) -> u8 {
     use png::ColorType::*;
     match c {
         Grayscale => 1 + if trns { 1 } else { 0 },
-        RGB => 3,
+        Rgb => 3,
         Indexed => 3 + if trns { 1 } else { 0 },
         GrayscaleAlpha => 2,
-        RGBA => 4,
+        Rgba => 4,
     }
 }
 fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {

--- a/examples/show.rs
+++ b/examples/show.rs
@@ -22,8 +22,8 @@ fn load_image(path: &path::PathBuf) -> io::Result<RawImage2d<'static, u8>> {
     reader.next_frame(&mut img_data)?;
 
     let (data, format) = match info.color_type {
-        RGB => (img_data, ClientFormat::U8U8U8),
-        RGBA => (img_data, ClientFormat::U8U8U8U8),
+        Rgb => (img_data, ClientFormat::U8U8U8),
+        Rgba => (img_data, ClientFormat::U8U8U8U8),
         Grayscale => (
             {
                 let mut vec = Vec::with_capacity(img_data.len() * 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
 //! let ref mut w = BufWriter::new(file);
 //!
 //! let mut encoder = png::Encoder::new(w, 2, 1); // Width is 2 pixels and height is 1.
-//! encoder.set_color(png::ColorType::RGBA);
+//! encoder.set_color(png::ColorType::Rgba);
 //! encoder.set_depth(png::BitDepth::Eight);
 //! encoder.set_trns(vec!(0xFFu8, 0xFFu8, 0xFFu8, 0xFFu8));
 //! encoder.set_source_gamma(png::ScaledFloat::from_scaled(45455)); // 1.0 / 2.2, scaled by 100000


### PR DESCRIPTION
This PR fixes the doc-tests and examples for the renamed `ColorType` variants. Additionally, it adds `--all-targets` to the github workflow to ensure they're tested by CI.