### PR TITLE
Add support for the sRGB chunk.

### DIFF
--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -31,6 +31,8 @@ pub const pHYs: ChunkType = ChunkType([b'p', b'H', b'Y', b's']);
 pub const cHRM: ChunkType = ChunkType([b'c', b'H', b'R', b'M']);
 /// Source system's gamma value
 pub const gAMA: ChunkType = ChunkType([b'g', b'A', b'M', b'A']);
+/// sRGB color space chunk
+pub const sRGB: ChunkType = ChunkType([b's', b'R', b'G', b'B']);
 
 // -- Extension chunks --
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -361,6 +361,38 @@ impl SourceChromaticities {
     }
 }
 
+/// The rendering intent for an sRGB image.
+///
+/// Presence of this data also indicates that the image conforms to the sRGB color space.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SrgbRenderingIntent {
+    /// For images preferring good adaptation to the output device gamut at the expense of colorimetric accuracy, such as photographs.
+    Perceptual = 0,
+    /// For images requiring colour appearance matching (relative to the output device white point), such as logos.
+    RelativeColorimetric = 1,
+    /// For images preferring preservation of saturation at the expense of hue and lightness, such as charts and graphs.
+    Saturation = 2,
+    /// For images requiring preservation of absolute colorimetry, such as previews of images destined for a different output device (proofs).
+    AbsoluteColorimetric = 3,
+}
+
+impl SrgbRenderingIntent {
+    pub(crate) fn into_raw(self) -> u8 {
+        self as u8
+    }
+
+    pub(crate) fn from_raw(raw: u8) -> Option<Self> {
+        match raw {
+            0 => Some(SrgbRenderingIntent::Perceptual),
+            1 => Some(SrgbRenderingIntent::RelativeColorimetric),
+            2 => Some(SrgbRenderingIntent::Saturation),
+            3 => Some(SrgbRenderingIntent::AbsoluteColorimetric),
+            _ => None,
+        }
+    }
+}
+
 /// PNG info struct
 #[derive(Clone, Debug)]
 pub struct Info {
@@ -371,14 +403,19 @@ pub struct Info {
     pub interlaced: bool,
     pub trns: Option<Vec<u8>>,
     pub pixel_dims: Option<PixelDimensions>,
-    /// Source system's gamma
+    /// Gamma of the source system.
     pub source_gamma: Option<ScaledFloat>,
     pub palette: Option<Vec<u8>>,
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
     pub filter: filter::FilterType,
+    /// Chromaticities of the source system.
     pub source_chromaticities: Option<SourceChromaticities>,
+    /// The rendering intent of an SRGB image.
+    ///
+    /// Presence of this value also indicates that the image conforms to the SRGB color space.
+    pub srgb: Option<SrgbRenderingIntent>,
 }
 
 impl Default for Info {
@@ -400,6 +437,7 @@ impl Default for Info {
             compression: Compression::Fast,
             filter: filter::FilterType::Sub,
             source_chromaticities: None,
+            srgb: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ mod decoder;
 #[cfg(feature = "png-encoding")]
 mod encoder;
 mod filter;
+mod srgb;
 mod traits;
 mod utils;
 

--- a/src/srgb.rs
+++ b/src/srgb.rs
@@ -1,0 +1,30 @@
+use crate::{ScaledFloat, SourceChromaticities};
+
+/// Get the gamma that should be subsituted for images conforming to the sRGB color space.
+pub fn substitute_gamma() -> ScaledFloat {
+    // Value taken from https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB
+    ScaledFloat::from_scaled(45455)
+}
+
+/// Get the chromaticities that should be subsituted for images conforming to the sRGB color space.
+pub fn substitute_chromaticities() -> SourceChromaticities {
+    // Values taken from https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB
+    SourceChromaticities {
+        white: (
+            ScaledFloat::from_scaled(31270),
+            ScaledFloat::from_scaled(32900),
+        ),
+        red: (
+            ScaledFloat::from_scaled(64000),
+            ScaledFloat::from_scaled(33000),
+        ),
+        green: (
+            ScaledFloat::from_scaled(30000),
+            ScaledFloat::from_scaled(60000),
+        ),
+        blue: (
+            ScaledFloat::from_scaled(15000),
+            ScaledFloat::from_scaled(6000),
+        ),
+    }
+}


### PR DESCRIPTION
This PR adds support for the `sRGB` chunk.

A new type `SrgbRenderingIntent` is added, and `Info` now has a `srgb: Option<SrgbRenderingIntent>` field.

If the decoder encounters an `sRGB` chunk, it sets the `srgb` field along with the `source_gamma` and `source_chromaticities` field (using predefined values). Any future `gAMA` or `cHRM` chunks are ignored (and the data from previous ones is overwritten).

The encoder adds the `sRGB` chunk along with the pre-defined `gAMA` and `cHRM` chunks if the `srgb` field is set. Manually defined `source_gamma` and `source_chromaticities` are ignored in this case.

I believe this conforms to the specification: https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB

/edit: CI failure looks like the same Windows/rustup issue, unrelated to the PR contents :( 