### PR TITLE
Use actions-rs toolchain action for rustc version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - run: |
-        rustup toolchain add ${{ matrix.rust }}
-        rustup default ${{ matrix.rust }}
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        override: true
     - name: build
       run: |
         cargo build --verbose


### PR DESCRIPTION
The main problem that should be addressed is that rustup will run a
self-update by default when adding a new toolchain, which won't be
allowed by the windows environment. Rely on a common action to have
gotten this right.