### PR TITLE
Fix the Avg filter for encoding

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -198,8 +198,9 @@ pub(crate) fn filter(method: FilterType, bpp: BytesPerPixel, previous: &[u8], cu
         }
         Avg => {
             for i in (bpp..len).rev() {
-                current[i] =
-                    current[i].wrapping_sub(current[i - bpp].wrapping_add(previous[i]) / 2);
+                current[i] = current[i].wrapping_sub(
+                    ((u16::from(current[i - bpp]) + u16::from(previous[i])) / 2) as u8,
+                );
             }
 
             for i in 0..bpp {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -269,4 +269,46 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn roundtrip_ascending_previous_line() {
+        // A multiple of 8, 6, 4, 3, 2, 1
+        const LEN: u8 = 240;
+        let previous: Vec<_> = (0..LEN).collect();
+        let mut current: Vec<_> = (0..LEN).collect();
+        let expected = current.clone();
+
+        let mut roundtrip = |kind, bpp: BytesPerPixel| {
+            filter(kind, bpp, &previous, &mut current);
+            unfilter(kind, bpp, &previous, &mut current).expect("Unfilter worked");
+            assert_eq!(
+                current, expected,
+                "Filtering {:?} with {:?} does not roundtrip",
+                bpp, kind
+            );
+        };
+
+        let filters = [
+            FilterType::NoFilter,
+            FilterType::Sub,
+            FilterType::Up,
+            FilterType::Avg,
+            FilterType::Paeth,
+        ];
+
+        let bpps = [
+            BytesPerPixel::One,
+            BytesPerPixel::Two,
+            BytesPerPixel::Three,
+            BytesPerPixel::Four,
+            BytesPerPixel::Six,
+            BytesPerPixel::Eight,
+        ];
+
+        for &filter in filters.iter() {
+            for &bpp in bpps.iter() {
+                roundtrip(filter, bpp);
+            }
+        }
+    }
 }


### PR DESCRIPTION
wrapping_add produces incorrect filter results for Average. The sum of the left pixel and above pixel should not overflow and wrap around. This change mimics the implementation used in `unfilter` for Avg in `filter.rs` where the byte values are converted to u16 for addition.

> The subtraction of the predicted value from the raw byte must be done modulo 256, so that both the inputs and outputs fit into bytes. However, the sum Raw(x-bpp)+Prior(x) must be formed without overflow (using at least nine-bit arithmetic). floor() indicates that the result of the division is rounded to the next lower integer if fractional; in other words, it is an integer division or right shift operation.

6.5. Filter type 3: Average  
https://www.w3.org/TR/PNG-Filters.html
