### PR TITLE
Add Adaptive filtering method for encoding

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -274,11 +274,11 @@ pub struct AnimationControl {
 /// The type and strength of applied compression.
 #[derive(Debug, Clone)]
 pub enum Compression {
-    /// Default level  
+    /// Default level
     Default,
     /// Fast minimal compression
     Fast,
-    /// Higher compression level  
+    /// Higher compression level
     ///
     /// Best in this context isn't actually the highest possible level
     /// the encoder can do, but is meant to emulate the `Best` setting in the `Flate2`
@@ -409,7 +409,7 @@ pub struct Info {
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
-    pub filter: filter::FilterType,
+    pub filter: Option<filter::FilterType>,
     /// Chromaticities of the source system.
     pub source_chromaticities: Option<SourceChromaticities>,
     /// The rendering intent of an SRGB image.
@@ -435,7 +435,7 @@ impl Default for Info {
             // Default to `deflate::Compresion::Fast` and `filter::FilterType::Sub`
             // to maintain backward compatible output.
             compression: Compression::Fast,
-            filter: filter::FilterType::Sub,
+            filter: Some(filter::FilterType::Sub),
             source_chromaticities: None,
             srgb: None,
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,4 @@
 //! Common types shared between the encoder and decoder
-use crate::filter;
-
 use std::{convert::TryFrom, fmt};
 
 /// Describes the layout of samples in a pixel
@@ -393,6 +391,17 @@ impl SrgbRenderingIntent {
     }
 }
 
+/// A single-byte integer that represents the filtering method applied before
+/// compression.
+///
+/// Currently, the only filter method is adaptive filtering with any of the
+/// five filters in [crate::filter::FilterType].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum InfoFilterType {
+    Adaptive = 0,
+}
+
 /// PNG info struct
 #[derive(Clone, Debug)]
 pub struct Info {
@@ -409,7 +418,7 @@ pub struct Info {
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
-    pub filter: Option<filter::FilterType>,
+    pub filter: InfoFilterType,
     /// Chromaticities of the source system.
     pub source_chromaticities: Option<SourceChromaticities>,
     /// The rendering intent of an SRGB image.
@@ -435,7 +444,7 @@ impl Default for Info {
             // Default to `deflate::Compresion::Fast` and `filter::FilterType::Sub`
             // to maintain backward compatible output.
             compression: Compression::Fast,
-            filter: Some(filter::FilterType::Sub),
+            filter: InfoFilterType::Adaptive,
             source_chromaticities: None,
             srgb: None,
         }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -35,6 +35,10 @@ impl FilterType {
     }
 }
 
+/// The filtering method for preprocessing scanline data before compression.
+///
+/// Adaptive filtering performs additional computation in an attempt to maximize
+/// the compression of the data. [`NonAdaptive`] filtering is the default.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AdaptiveFilterType {
@@ -198,40 +202,98 @@ pub(crate) fn unfilter(
     }
 }
 
-fn sub(bpp: usize, len: usize, current: &mut [u8]) {
-    for i in (bpp..len).rev() {
-        current[i] = current[i].wrapping_sub(current[i - bpp]);
+fn filter_internal(
+    method: FilterType,
+    bpp: usize,
+    len: usize,
+    previous: &[u8],
+    current: &mut [u8],
+) -> FilterType {
+    use self::FilterType::*;
+
+    match method {
+        NoFilter => NoFilter,
+        Sub => {
+            for i in (bpp..len).rev() {
+                current[i] = current[i].wrapping_sub(current[i - bpp]);
+            }
+            Sub
+        }
+        Up => {
+            for i in 0..len {
+                current[i] = current[i].wrapping_sub(previous[i]);
+            }
+            Up
+        }
+        Avg => {
+            for i in (bpp..len).rev() {
+                current[i] = current[i].wrapping_sub(
+                    ((u16::from(current[i - bpp]) + u16::from(previous[i])) / 2) as u8,
+                );
+            }
+
+            for i in 0..bpp {
+                current[i] = current[i].wrapping_sub(previous[i] / 2);
+            }
+            Avg
+        }
+        Paeth => {
+            for i in (bpp..len).rev() {
+                current[i] = current[i].wrapping_sub(filter_paeth(
+                    current[i - bpp],
+                    previous[i],
+                    previous[i - bpp],
+                ));
+            }
+
+            for i in 0..bpp {
+                current[i] = current[i].wrapping_sub(filter_paeth(0, previous[i], 0));
+            }
+            Paeth
+        }
     }
 }
 
-fn up(len: usize, previous: &[u8], current: &mut [u8]) {
-    for i in 0..len {
-        current[i] = current[i].wrapping_sub(previous[i]);
-    }
-}
+pub(crate) fn filter(
+    method: FilterType,
+    adaptive: AdaptiveFilterType,
+    bpp: BytesPerPixel,
+    previous: &[u8],
+    current: &mut [u8],
+) -> FilterType {
+    use FilterType::*;
+    let bpp = bpp.into_usize();
+    let len = current.len();
 
-fn avg(bpp: usize, len: usize, previous: &[u8], current: &mut [u8]) {
-    for i in (bpp..len).rev() {
-        current[i] = current[i]
-            .wrapping_sub(((u16::from(current[i - bpp]) + u16::from(previous[i])) / 2) as u8);
-    }
+    match adaptive {
+        AdaptiveFilterType::NonAdaptive => filter_internal(method, bpp, len, previous, current),
+        AdaptiveFilterType::Adaptive => {
+            // Filter the current buffer with each filter type. Sum the absolute
+            // values of each filtered buffer treating the bytes as signed
+            // integers. Choose the filter with the smallest sum.
+            let mut filtered_buffer = vec![0; len];
+            filtered_buffer.copy_from_slice(&current);
+            let mut scratch = vec![0; len];
 
-    for i in 0..bpp {
-        current[i] = current[i].wrapping_sub(previous[i] / 2);
-    }
-}
+            // Initialize min_sum with the NoFilter buffer sum
+            let mut min_sum: usize = sum_buffer(&filtered_buffer);
+            let mut filter_choice = FilterType::NoFilter;
 
-fn paeth(bpp: usize, len: usize, previous: &[u8], current: &mut [u8]) {
-    for i in (bpp..len).rev() {
-        current[i] = current[i].wrapping_sub(filter_paeth(
-            current[i - bpp],
-            previous[i],
-            previous[i - bpp],
-        ));
-    }
+            for &filter in [Sub, Up, Avg, Paeth].iter() {
+                scratch.copy_from_slice(&current);
+                filter_internal(filter, bpp, len, previous, &mut scratch);
+                let sum = sum_buffer(&scratch);
+                if sum < min_sum {
+                    min_sum = sum;
+                    filter_choice = filter;
+                    core::mem::swap(&mut filtered_buffer, &mut scratch);
+                }
+            }
 
-    for i in 0..bpp {
-        current[i] = current[i].wrapping_sub(filter_paeth(0, previous[i], 0));
+            current.copy_from_slice(&filtered_buffer);
+
+            filter_choice
+        }
     }
 }
 
@@ -241,91 +303,9 @@ fn sum_buffer(buf: &[u8]) -> usize {
         .fold(0, |acc, &x| acc.saturating_add((x as i8).abs() as usize))
 }
 
-pub(crate) fn filter(
-    method: Option<FilterType>,
-    bpp: BytesPerPixel,
-    previous: &[u8],
-    current: &mut [u8],
-) -> FilterType {
-    use self::FilterType::*;
-    let bpp = bpp.into_usize();
-    let len = current.len();
-
-    match method {
-        Some(NoFilter) => NoFilter,
-        Some(Sub) => {
-            sub(bpp, len, current);
-            Sub
-        }
-        Some(Up) => {
-            up(len, previous, current);
-            Up
-        }
-        Some(Avg) => {
-            avg(bpp, len, previous, current);
-            Avg
-        }
-        Some(Paeth) => {
-            paeth(bpp, len, previous, current);
-            Paeth
-        }
-        None => {
-            // Filter the current buffer with each filter type. Sum the absolute
-            // values of each filtered buffer treating the bytes as signed
-            // integers. Choose the filter with the smallest sum.
-            let mut filtered_buffer = vec![0; len];
-            filtered_buffer.copy_from_slice(&current);
-            let mut scratch = vec![0; len];
-            scratch.copy_from_slice(&current);
-            let mut filter_type = NoFilter;
-
-            // Initialize min_sum with the NoFilter buffer sum
-            let mut min_sum: usize = sum_buffer(&filtered_buffer);
-
-            sub(bpp, len, &mut scratch);
-            let sum = sum_buffer(&scratch);
-            if sum < min_sum {
-                min_sum = sum;
-                filter_type = Sub;
-                core::mem::swap(&mut filtered_buffer, &mut scratch);
-            }
-
-            scratch.copy_from_slice(&current);
-            up(len, previous, &mut scratch);
-            let sum = sum_buffer(&scratch);
-            if sum < min_sum {
-                min_sum = sum;
-                filter_type = Up;
-                core::mem::swap(&mut filtered_buffer, &mut scratch);
-            }
-
-            scratch.copy_from_slice(&current);
-            avg(bpp, len, previous, &mut scratch);
-            let sum = sum_buffer(&scratch);
-            if sum < min_sum {
-                min_sum = sum;
-                filter_type = Avg;
-                core::mem::swap(&mut filtered_buffer, &mut scratch);
-            }
-
-            scratch.copy_from_slice(&current);
-            paeth(bpp, len, previous, &mut scratch);
-            let sum = sum_buffer(&scratch);
-            if sum < min_sum {
-                filter_type = Paeth;
-                core::mem::swap(&mut filtered_buffer, &mut scratch);
-            }
-
-            current.copy_from_slice(&filtered_buffer);
-
-            filter_type
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
-    use super::{filter, unfilter, BytesPerPixel, FilterType};
+    use super::{filter, unfilter, AdaptiveFilterType, BytesPerPixel, FilterType};
     use core::iter;
 
     #[test]
@@ -335,9 +315,10 @@ mod test {
         let previous: Vec<_> = iter::repeat(1).take(LEN.into()).collect();
         let mut current: Vec<_> = (0..LEN).collect();
         let expected = current.clone();
+        let adaptive = AdaptiveFilterType::NonAdaptive;
 
         let mut roundtrip = |kind, bpp: BytesPerPixel| {
-            filter(Some(kind), bpp, &previous, &mut current);
+            filter(kind, adaptive, bpp, &previous, &mut current);
             unfilter(kind, bpp, &previous, &mut current).expect("Unfilter worked");
             assert_eq!(
                 current, expected,
@@ -377,9 +358,10 @@ mod test {
         let previous: Vec<_> = (0..LEN).collect();
         let mut current: Vec<_> = (0..LEN).collect();
         let expected = current.clone();
+        let adaptive = AdaptiveFilterType::NonAdaptive;
 
         let mut roundtrip = |kind, bpp: BytesPerPixel| {
-            filter(Some(kind), bpp, &previous, &mut current);
+            filter(kind, adaptive, bpp, &previous, &mut current);
             unfilter(kind, bpp, &previous, &mut current).expect("Unfilter worked");
             assert_eq!(
                 current, expected,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -15,6 +15,12 @@ pub enum FilterType {
     Paeth = 4,
 }
 
+impl Default for FilterType {
+    fn default() -> Self {
+        FilterType::Sub
+    }
+}
+
 impl FilterType {
     /// u8 -> Self. Temporary solution until Rust provides a canonical one.
     pub fn from_u8(n: u8) -> Option<FilterType> {
@@ -26,6 +32,19 @@ impl FilterType {
             4 => Some(FilterType::Paeth),
             _ => None,
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum AdaptiveFilterType {
+    Adaptive,
+    NonAdaptive,
+}
+
+impl Default for AdaptiveFilterType {
+    fn default() -> Self {
+        AdaptiveFilterType::NonAdaptive
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,4 +75,4 @@ pub use crate::decoder::{
 };
 #[cfg(feature = "png-encoding")]
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
-pub use crate::filter::FilterType;
+pub use crate::filter::{AdaptiveFilterType, FilterType};


### PR DESCRIPTION
Implement Adaptive filtering which uses the heuristic described in
the PNG standard. For each line, all five filter algorithms are executed
on the buffer. Filtered bytes are then summed by the absolute value of
their i8 representation. The filter with the lowest sum is selected as
the "best" filter for that row of pixels.

Closes #208 

---

~~I've taken into account the feedback from https://github.com/image-rs/image-png/issues/208#issuecomment-739967796 to pass `Option<FilterType>` around and return a `FilterType` from `filter` instead of a u8. Adaptive is not added as part of the `FilterType` enum; instead, it is represented as `None`.~~