### PR TITLE
Fix the Avg filter for encoding

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -199,8 +199,9 @@ pub(crate) fn filter(method: FilterType, bpp: BytesPerPixel, previous: &[u8], cu
         }
         Avg => {
             for i in (bpp..len).rev() {
-                current[i] =
-                    current[i].wrapping_sub(current[i - bpp].wrapping_add(previous[i]) / 2);
+                current[i] = current[i].wrapping_sub(
+                    ((u16::from(current[i - bpp]) + u16::from(previous[i])) / 2) as u8,
+                );
             }
 
             for i in 0..bpp {


### PR DESCRIPTION
wrapping_add produces incorrectly filtered results. The sum of the left
pixel and above pixel should not overflow. This implementation mimics
that found for Avg in the `unfilter` function in the same module.

Backports to `0.16` branch.