### PR TITLE
Release 0.16.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.16.8
+
+* Fixed a bug that led to data corruption when encoding with Average filter.
+
 ## 0.16.7
 
 * Added `Encoder::set_trns` to register a transparency table to be written.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.16.7"
+version = "0.16.8"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"


### PR DESCRIPTION
A bug fix for one non-default filter type since `0.17` will likely still take a bit of time (aiming for around new year).