### PR TITLE
Fix doclinks, consistently capitalize PNG in docs

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -71,7 +71,7 @@ impl ColorType {
     }
 }
 
-/// Bit depth of the png file
+/// Bit depth of the PNG file
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum BitDepth {
@@ -316,7 +316,7 @@ impl ScaledFloat {
     }
 
     /// Slightly inaccurate scaling and quantization.
-    /// Clamps the value into the representible range if it is negative of too large.
+    /// Clamps the value into the representable range if it is negative or too large.
     pub fn new(value: f32) -> Self {
         Self {
             0: Self::forward(value),
@@ -395,7 +395,9 @@ impl SrgbRenderingIntent {
 /// compression.
 ///
 /// Currently, the only filter method is adaptive filtering with any of the
-/// five filters in [crate::filter::FilterType].
+/// five filters in [`filter::FilterType`].
+///
+/// [`filter::FilterType`]: enum.FilterType.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum InfoFilterType {
@@ -441,7 +443,7 @@ impl Default for Info {
             source_gamma: None,
             frame_control: None,
             animation_control: None,
-            // Default to `deflate::Compresion::Fast` and `filter::FilterType::Sub`
+            // Default to `deflate::Compression::Fast` and `filter::FilterType::Sub`
             // to maintain backward compatible output.
             compression: Compression::Fast,
             filter: InfoFilterType::Adaptive,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -142,7 +142,7 @@ impl<R: Read> Decoder<R> {
     /// ```
     /// use std::fs::File;
     /// use png::{Decoder, Limits};
-    /// // This image is 32x32 pixels, so the deocder will allocate more than four bytes
+    /// // This image is 32x32 pixels, so the decoder will allocate more than four bytes
     /// let mut limits = Limits::default();
     /// limits.bytes = 4;
     /// let mut decoder = Decoder::new_with_limits(File::open("tests/pngsuite/basi0g01.png").unwrap(), limits);

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -343,7 +343,7 @@ struct ChunkState {
     /// Partial crc until now.
     crc: Crc32,
 
-    /// Remanining bytes to be read.
+    /// Remaining bytes to be read.
     remaining: u32,
 
     /// Non-decoded bytes in the chunk.
@@ -657,7 +657,7 @@ impl StreamingDecoder {
         let mut buf = &self.current_chunk.raw_bytes[..];
         let next_seq_no = buf.read_be()?;
 
-        // Asuming that fcTL is required before *every* fdAT-sequence
+        // Assuming that fcTL is required before *every* fdAT-sequence
         self.current_seq_no = Some(if let Some(seq_no) = self.current_seq_no {
             if next_seq_no != seq_no + 1 {
                 return Err(DecodingError::Format(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -358,14 +358,14 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    /// Create an stream writer.
+    /// Create a stream writer.
     ///
-    /// This allows you create images that do not fit in memory. The default
-    /// chunk size is 4K, use `stream_writer_with_size` to set another chuck
+    /// This allows you to create images that do not fit in memory. The default
+    /// chunk size is 4K, use `stream_writer_with_size` to set another chunk
     /// size.
     ///
-    /// This borrows the writer. This preserves it which allows manually
-    /// appending additional chunks after the image data has been written
+    /// This borrows the writer which allows for manually appending additional
+    /// chunks after the image data has been written.
     pub fn stream_writer(&mut self) -> StreamWriter<W> {
         self.stream_writer_with_size(DEFAULT_BUFFER_LENGTH)
     }
@@ -381,8 +381,8 @@ impl<W: Write> Writer<W> {
 
     /// Turn this into a stream writer for image data.
     ///
-    /// This allows you create images that do not fit in memory. The default
-    /// chunk size is 4K, use `stream_writer_with_size` to set another chuck
+    /// This allows you to create images that do not fit in memory. The default
+    /// chunk size is 4K, use `stream_writer_with_size` to set another chunk
     /// size.
     pub fn into_stream_writer(self) -> StreamWriter<'static, W> {
         self.into_stream_writer_with_size(DEFAULT_BUFFER_LENGTH)
@@ -466,7 +466,7 @@ impl<'a, W: Write> Drop for ChunkWriter<'a, W> {
     }
 }
 
-/// Streaming png writer
+/// Streaming PNG writer
 ///
 /// This may silently fail in the destructor, so it is a good idea to call
 /// [`finish`](#method.finish) or [`flush`](https://doc.rust-lang.org/stable/std/io/trait.Write.html#tymethod.flush) before dropping.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -39,6 +39,8 @@ impl FilterType {
 ///
 /// Adaptive filtering performs additional computation in an attempt to maximize
 /// the compression of the data. [`NonAdaptive`] filtering is the default.
+///
+/// [`NonAdaptive`]: enum.AdaptiveFilterType.html#variant.NonAdaptive
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AdaptiveFilterType {

--- a/src/srgb.rs
+++ b/src/srgb.rs
@@ -1,12 +1,12 @@
 use crate::{ScaledFloat, SourceChromaticities};
 
-/// Get the gamma that should be subsituted for images conforming to the sRGB color space.
+/// Get the gamma that should be substituted for images conforming to the sRGB color space.
 pub fn substitute_gamma() -> ScaledFloat {
     // Value taken from https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB
     ScaledFloat::from_scaled(45455)
 }
 
-/// Get the chromaticities that should be subsituted for images conforming to the sRGB color space.
+/// Get the chromaticities that should be substituted for images conforming to the sRGB color space.
 pub fn substitute_chromaticities() -> SourceChromaticities {
     // Values taken from https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB
     SourceChromaticities {


### PR DESCRIPTION
Fix doclinks added in #264
Make grammar fixups in Writer docs
Do a spellchecker pass