### PR TITLE
Add APNG Encoding

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -139,37 +139,27 @@ impl<W: Write> Encoder<W> {
         }
     }
 
-    pub fn new_animated(
-        w: W,
-        width: u32,
-        height: u32,
-        num_frames: u32,
-        num_plays: u32,
-        sep_def_img: bool,
-    ) -> Encoder<W> {
+    pub fn set_animated(&mut self, num_frames: u32, num_plays: u32) {
         let actl = AnimationControl {
             num_frames,
             num_plays,
         };
         let fctl = FrameControl {
             sequence_number: 0,
-            width,
-            height,
+            width: self.info.width,
+            height: self.info.height,
             ..Default::default()
         };
-        let info = Info {
-            width,
-            height,
-            animation_control: Some(actl),
-            frame_control: Some(fctl),
-            ..Default::default()
-        };
-        Encoder {
-            w,
-            info,
-            filter: FilterType::default(),
-            adaptive_filter: AdaptiveFilterType::default(),
-            sep_def_img,
+        self.info.animation_control = Some(actl);
+        self.info.frame_control = Some(fctl);
+    }
+
+    pub fn set_sep_def_img(&mut self, sep_def_img: bool) -> Result<()> {
+        if self.info.animation_control.is_none() {
+            self.sep_def_img = sep_def_img;
+            Ok(())
+        } else {
+            Err(EncodingError::Format(FormatErrorKind::NotAnimated.into()))
         }
     }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -439,7 +439,7 @@ impl<W: Write> Writer<W> {
                 let mut alldata = vec![0u8; 4 + MAX_fdAT_CHUNK_LEN as usize];
                 for chunk in zlib_encoded.chunks(MAX_fdAT_CHUNK_LEN as usize) {
                     alldata[..4].copy_from_slice(&fctl.sequence_number.to_be_bytes());
-                    alldata[4..].copy_from_slice(chunk);
+                    alldata[4..][..chunk.len()].copy_from_slice(chunk);
                     write_chunk(&mut self.w, chunk::fdAT, &alldata[..4 + chunk.len()])?;
                     fctl.sequence_number += 1;
                 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -426,7 +426,8 @@ impl<W: Write> Writer<W> {
                     self.write_chunk(chunk::IDAT, &chunk)?;
                 }
             } else {
-                let mut alldata = vec![0u8; 4 + MAX_fdAT_CHUNK_LEN as usize];
+                let buff_size = zlib_encoded.len().min(MAX_fdAT_CHUNK_LEN as usize);
+                let mut alldata = vec![0u8; 4 + buff_size];
                 for chunk in zlib_encoded.chunks(MAX_fdAT_CHUNK_LEN as usize) {
                     alldata[..4].copy_from_slice(&fctl.sequence_number.to_be_bytes());
                     alldata[4..][..chunk.len()].copy_from_slice(chunk);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -365,8 +365,8 @@ impl<W: Write> Writer<W> {
 
     /// Writes the image data.
     pub fn write_image_data(&mut self, data: &[u8]) -> Result<()> {
-        const MAX_IDAT_CHUNK_LEN: u32 = (1u32 << 31) - 1;
-        const MAX_fdAT_CHUNK_LEN: u32 = u32::MAX - 4;
+        const MAX_IDAT_CHUNK_LEN: u32 = std::u32::MAX >> 1;
+        const MAX_fdAT_CHUNK_LEN: u32 = (std::u32::MAX >> 1) - 4;
 
         if self.info.color_type == ColorType::Indexed && self.info.palette.is_none() {
             return Err(EncodingError::Format(FormatErrorKind::NoPalette.into()));

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -576,7 +576,7 @@ impl<W: Write> Writer<W> {
     ///
     // ??? TODO ???
     // - The next frame is the default image
-    pub fn set_frame_dimesion(&mut self, width: u32, height: u32) -> Result<()> {
+    pub fn set_frame_dimension(&mut self, width: u32, height: u32) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             if Some(width) > self.info.width.checked_sub(fctl.x_offset)
                 || Some(height) > self.info.height.checked_sub(fctl.y_offset)
@@ -629,7 +629,7 @@ impl<W: Write> Writer<W> {
     /// This method will return an error if the image is not animated.
     ///
     /// [`reset_frame_position`]: struct.Writer.html#method.reset_frame_position
-    pub fn reset_frame_dimesion(&mut self) -> Result<()> {
+    pub fn reset_frame_dimension(&mut self) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.width = self.info.width - fctl.x_offset;
             fctl.height = self.info.height - fctl.y_offset;


### PR DESCRIPTION
This is the new pull request, I went back with only `Writer` and `StreamWriter` and currently only the first one is able to encode APNG animations. I did some tests and it's working fine (didn't test frames smaller than the image).

Now for the `StreamEncoder` I was thinking that it could be done in two ways:
1) the `finish` method returns the `ChunkOutput` so that by reusing the `Writer` it's possible to encode multiple frames
2) Modify how the `ChunkWriter` works and make it store an entire chunk before flushing, and after flushing allow to change the `FrameControl`; then on the `StreamWriter` it would be possible to seamlessly encode every frame including the separate default image.

You can have a look at the second approach here [encoder.rs](https://github.com/Rimpampa/image-png/blob/encoder/src/encoder.rs).

The first one just needs to expose the `ChunkOutput` which shouldn't be much of a problem, considering also that switching from `AsMut` to `DerefMut` would make it even more silent. On the other hand implementing the second one would require a lot of changes that might not be what we want, but would make the public interface (imo) a lot nicer. I still don't know if limiting the buffer size to the maximum size of a chunk is a bad thing, where would be needed to bufferize more than 2GB of data? But regardless if we want in the future to implement the `PartialChunkData` thing you were talking about a solution like this will be needed because, as you already pointed out, it's impossible to know the chunk size in advance it follows that it must be the last thing to be written, but because it must preceed the chunk data, all the data must be bufferized before it gets written.