### PR TITLE
Make encoder a core feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,7 @@ jobs:
       matrix:
         rust: ["1.34.2", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        features: ["", "png-encoding"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +21,22 @@ jobs:
     - name: build
       run: |
         cargo build --verbose
-        cargo doc --verbose
+  feature_check:
+    strategy:
+      matrix:
+        features: ["", "png-encoding", "png-encoding,benchmarks"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - name: check
+      run: |
+        cargo check --tests --no-default-features --features="$FEATURES"
+      env:
+        FEATURES: ${{ matrix.features }}
   mips_cross:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust: ["1.34.2", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        features: ["", "png-encoding"]
+        features: [""]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
   feature_check:
     strategy:
       matrix:
-        features: ["", "png-encoding", "png-encoding,benchmarks"]
+        features: ["", "benchmarks"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ include = [
 ]
 
 [dependencies]
-deflate = { version = "0.8.2", optional = true }
 bitflags = "1.0"
 crc32fast = "1.2.0"
+deflate = "0.9"
 [dependencies.miniz_oxide]
 version = "0.4.1"
 features = ["no_extern_crate_alloc"]
@@ -40,8 +40,6 @@ features = ["glutin"]
 default-features = false
 
 [features]
-png-encoding = ["deflate"]
-default = ["png-encoding"]
 unstable = []
 benchmarks = []
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -745,35 +745,3 @@ impl fmt::Display for ParameterError {
         }
     }
 }
-
-/// Mod to encapsulate the converters depending on the `deflate` crate.
-///
-/// Since this only contains trait impls, there is no need to make this public, they are simply
-/// available when the mod is compiled as well.
-#[cfg(feature = "png-encoding")]
-mod deflate_convert {
-    extern crate deflate;
-    use super::Compression;
-
-    impl From<deflate::Compression> for Compression {
-        fn from(c: deflate::Compression) -> Self {
-            match c {
-                deflate::Compression::Default => Compression::Default,
-                deflate::Compression::Fast => Compression::Fast,
-                deflate::Compression::Best => Compression::Best,
-            }
-        }
-    }
-
-    impl From<Compression> for deflate::CompressionOptions {
-        fn from(c: Compression) -> Self {
-            match c {
-                Compression::Default => deflate::CompressionOptions::default(),
-                Compression::Fast => deflate::CompressionOptions::fast(),
-                Compression::Best => deflate::CompressionOptions::high(),
-                Compression::Huffman => deflate::CompressionOptions::huffman_only(),
-                Compression::Rle => deflate::CompressionOptions::rle(),
-            }
-        }
-    }
-}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,3 @@
-extern crate crc32fast;
-extern crate deflate;
-
 use std::error;
 use std::fmt;
 use std::io::{self, Read, Write};

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -169,8 +169,8 @@ impl<W: Write> Encoder<W> {
     ///
     /// Accepts a `Compression` or any type that can transform into a `Compression`. Notably `deflate::Compression` and
     /// `deflate::CompressionOptions` which "just work".
-    pub fn set_compression<C: Into<Compression>>(&mut self, compression: C) {
-        self.info.compression = compression.into();
+    pub fn set_compression(&mut self, compression: Compression) {
+        self.info.compression = compression;
     }
 
     /// Set the used filter type.
@@ -283,7 +283,10 @@ impl<W: Write> Writer<W> {
                 .into(),
             ));
         }
-        let mut zlib = deflate::write::ZlibEncoder::new(Vec::new(), self.info.compression.clone());
+        let mut zlib = deflate::write::ZlibEncoder::new(
+            Vec::new(),
+            self.info.compression.clone().to_options(),
+        );
         let filter_method = self.filter;
         let adaptive_method = self.adaptive_filter;
         for line in data.chunks(in_len) {
@@ -433,7 +436,7 @@ impl<'a, W: Write> StreamWriter<'a, W> {
 
         let compression = writer.as_mut().info.compression.clone();
         let chunk_writer = ChunkWriter::new(writer, buf_len);
-        let zlib = deflate::write::ZlibEncoder::new(chunk_writer, compression);
+        let zlib = deflate::write::ZlibEncoder::new(chunk_writer, compression.to_options());
 
         StreamWriter {
             writer: zlib,
@@ -915,6 +918,22 @@ mod tests {
 
         fn flush(&mut self) -> io::Result<()> {
             self.w.flush()
+        }
+    }
+}
+
+/// Mod to encapsulate the converters depending on the `deflate` crate.
+///
+/// Since this only contains trait impls, there is no need to make this public, they are simply
+/// available when the mod is compiled as well.
+impl crate::common::Compression {
+    fn to_options(self) -> deflate::CompressionOptions {
+        match self {
+            Compression::Default => deflate::CompressionOptions::default(),
+            Compression::Fast => deflate::CompressionOptions::fast(),
+            Compression::Best => deflate::CompressionOptions::high(),
+            Compression::Huffman => deflate::CompressionOptions::huffman_only(),
+            Compression::Rle => deflate::CompressionOptions::rle(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 //! ## Encoder
 //! ### Using the encoder
 //! ```no_run
-//! # #[cfg(feature = "png-encoding")] {
 //! // For reading and opening files
 //! use std::path::Path;
 //! use std::fs::File;
@@ -52,7 +51,6 @@
 //! # }
 //! ```
 //!
-//#![cfg_attr(test, feature(test))]
 
 #![forbid(unsafe_code)]
 
@@ -62,7 +60,6 @@ extern crate bitflags;
 pub mod chunk;
 mod common;
 mod decoder;
-#[cfg(feature = "png-encoding")]
 mod encoder;
 mod filter;
 mod srgb;
@@ -73,6 +70,5 @@ pub use crate::common::*;
 pub use crate::decoder::{
     Decoded, Decoder, DecodingError, Limits, OutputInfo, Reader, StreamingDecoder,
 };
-#[cfg(feature = "png-encoding")]
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
 pub use crate::filter::{AdaptiveFilterType, FilterType};


### PR DESCRIPTION
Removes the `png-encoding` feature, always turning the functionality on.

Another goal here is to reduce the interface. In particular there was
already one new major release of `deflate` that we couldn't track without 
one of our own. The loss is that one can no longer precisely configure the 
level of compression which might be remediated with a new setter but the 
rough options should address most use cases. A semantic option (i.e. a
limit to time spent encoding) would be more actionable for a user anyways.

Since we no longer publicly depend on `deflate` this also prepares doing 
#242 later in a minor version bump.

Closes: #283 