### PR TITLE
Accept Cow<'a, [u8]> for PLTE and tRNS data

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 //! Common types shared between the encoder and decoder
 use crate::{chunk, encoder};
 use io::Write;
-use std::{convert::TryFrom, fmt, io};
+use std::{borrow::Cow, convert::TryFrom, fmt, io};
 
 /// Describes how a pixel is encoded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -472,7 +472,7 @@ pub enum InfoFilterType {
 
 /// PNG info struct
 #[derive(Clone, Debug)]
-pub struct Info {
+pub struct Info<'a> {
     pub width: u32,
     pub height: u32,
     pub bit_depth: BitDepth,
@@ -480,12 +480,12 @@ pub struct Info {
     pub color_type: ColorType,
     pub interlaced: bool,
     /// The image's `tRNS` chunk, if present; contains the alpha channel of the image's palette, 1 byte per entry.
-    pub trns: Option<Vec<u8>>,
+    pub trns: Option<Cow<'a, [u8]>>,
     pub pixel_dims: Option<PixelDimensions>,
     /// Gamma of the source system.
     pub source_gamma: Option<ScaledFloat>,
     /// The image's `PLTE` chunk, if present; contains the RGB channels (in that order) of the image's palettes, 3 bytes per entry (1 per channel).
-    pub palette: Option<Vec<u8>>,
+    pub palette: Option<Cow<'a, [u8]>>,
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
@@ -500,8 +500,8 @@ pub struct Info {
     pub icc_profile: Option<Vec<u8>>,
 }
 
-impl Default for Info {
-    fn default() -> Info {
+impl Default for Info<'_> {
+    fn default() -> Info<'static> {
         Info {
             width: 0,
             height: 0,
@@ -525,7 +525,7 @@ impl Default for Info {
     }
 }
 
-impl Info {
+impl Info<'_> {
     /// Size of the image, width then height.
     pub fn size(&self) -> (u32, u32) {
         (self.width, self.height)

--- a/src/common.rs
+++ b/src/common.rs
@@ -472,7 +472,7 @@ pub enum InfoFilterType {
 
 /// PNG info struct
 #[derive(Clone, Debug)]
-pub struct Info {
+pub struct Info<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
     pub width: u32,
     pub height: u32,
     pub bit_depth: BitDepth,
@@ -480,12 +480,12 @@ pub struct Info {
     pub color_type: ColorType,
     pub interlaced: bool,
     /// The image's `tRNS` chunk, if present; contains the alpha channel of the image's palette, 1 byte per entry.
-    pub trns: Option<Vec<u8>>,
+    pub trns: Option<T>,
     pub pixel_dims: Option<PixelDimensions>,
     /// Gamma of the source system.
     pub source_gamma: Option<ScaledFloat>,
     /// The image's `PLTE` chunk, if present; contains the RGB channels (in that order) of the image's palettes, 3 bytes per entry (1 per channel).
-    pub palette: Option<Vec<u8>>,
+    pub palette: Option<P>,
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
@@ -497,11 +497,11 @@ pub struct Info {
     /// Presence of this value also indicates that the image conforms to the SRGB color space.
     pub srgb: Option<SrgbRenderingIntent>,
     /// The ICC profile for the image.
-    pub icc_profile: Option<Vec<u8>>,
+    pub icc_profile: Option<I>,
 }
 
-impl Default for Info {
-    fn default() -> Info {
+impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Default for Info<P, T, I> {
+    fn default() -> Info<P, T, I> {
         Info {
             width: 0,
             height: 0,
@@ -525,7 +525,7 @@ impl Default for Info {
     }
 }
 
-impl Info {
+impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Info<P, T, I> {
     /// Size of the image, width then height.
     pub fn size(&self) -> (u32, u32) {
         (self.width, self.height)
@@ -609,11 +609,11 @@ impl Info {
         encoder::write_chunk(&mut w, chunk::IHDR, &data)?;
 
         if let Some(p) = &self.palette {
-            encoder::write_chunk(&mut w, chunk::PLTE, p)?;
+            encoder::write_chunk(&mut w, chunk::PLTE, p.as_ref())?;
         };
 
         if let Some(t) = &self.trns {
-            encoder::write_chunk(&mut w, chunk::tRNS, t)?;
+            encoder::write_chunk(&mut w, chunk::tRNS, t.as_ref())?;
         }
 
         // If specified, the sRGB information overrides the source gamma and chromaticities.

--- a/src/common.rs
+++ b/src/common.rs
@@ -302,7 +302,7 @@ impl AnimationControl {
 }
 
 /// The type and strength of applied compression.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Compression {
     /// Default level
     Default,

--- a/src/common.rs
+++ b/src/common.rs
@@ -472,7 +472,7 @@ pub enum InfoFilterType {
 
 /// PNG info struct
 #[derive(Clone, Debug)]
-pub struct Info<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
+pub struct Info {
     pub width: u32,
     pub height: u32,
     pub bit_depth: BitDepth,
@@ -480,12 +480,12 @@ pub struct Info<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
     pub color_type: ColorType,
     pub interlaced: bool,
     /// The image's `tRNS` chunk, if present; contains the alpha channel of the image's palette, 1 byte per entry.
-    pub trns: Option<T>,
+    pub trns: Option<Vec<u8>>,
     pub pixel_dims: Option<PixelDimensions>,
     /// Gamma of the source system.
     pub source_gamma: Option<ScaledFloat>,
     /// The image's `PLTE` chunk, if present; contains the RGB channels (in that order) of the image's palettes, 3 bytes per entry (1 per channel).
-    pub palette: Option<P>,
+    pub palette: Option<Vec<u8>>,
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
@@ -497,11 +497,11 @@ pub struct Info<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
     /// Presence of this value also indicates that the image conforms to the SRGB color space.
     pub srgb: Option<SrgbRenderingIntent>,
     /// The ICC profile for the image.
-    pub icc_profile: Option<I>,
+    pub icc_profile: Option<Vec<u8>>,
 }
 
-impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Default for Info<P, T, I> {
-    fn default() -> Info<P, T, I> {
+impl Default for Info {
+    fn default() -> Info {
         Info {
             width: 0,
             height: 0,
@@ -525,7 +525,7 @@ impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Default for Info<P, T, I> {
     }
 }
 
-impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Info<P, T, I> {
+impl Info {
     /// Size of the image, width then height.
     pub fn size(&self) -> (u32, u32) {
         (self.width, self.height)
@@ -609,11 +609,11 @@ impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Info<P, T, I> {
         encoder::write_chunk(&mut w, chunk::IHDR, &data)?;
 
         if let Some(p) = &self.palette {
-            encoder::write_chunk(&mut w, chunk::PLTE, p.as_ref())?;
+            encoder::write_chunk(&mut w, chunk::PLTE, p)?;
         };
 
         if let Some(t) = &self.trns {
-            encoder::write_chunk(&mut w, chunk::tRNS, t.as_ref())?;
+            encoder::write_chunk(&mut w, chunk::tRNS, t)?;
         }
 
         // If specified, the sRGB information overrides the source gamma and chromaticities.

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -833,10 +833,7 @@ impl SubframeInfo {
     }
 }
 
-fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
-    buffer: &mut [u8],
-    info: &Info<P, T, I>,
-) -> Result<(), DecodingError> {
+fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut [u8], info: &Info<P, T, I>) -> Result<(), DecodingError> {
     if let Some(palette) = info.palette.as_ref() {
         if let BitDepth::Sixteen = info.bit_depth {
             // This should have been caught earlier but let's check again. Can't hurt.
@@ -852,8 +849,7 @@ fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
             if let Some(ref trns) = info.trns {
                 utils::unpack_bits(buffer, 4, info.bit_depth as u8, |i, chunk| {
                     let (rgb, a) = (
-                        palette
-                            .as_ref()
+                        palette.as_ref()
                             .get(3 * i as usize..3 * i as usize + 3)
                             .unwrap_or(&black),
                         trns.as_ref().get(i as usize).unwrap_or(&0xFF),
@@ -865,8 +861,7 @@ fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
                 });
             } else {
                 utils::unpack_bits(buffer, 3, info.bit_depth as u8, |i, chunk| {
-                    let rgb = palette
-                        .as_ref()
+                    let rgb = palette.as_ref()
                         .get(3 * i as usize..3 * i as usize + 3)
                         .unwrap_or(&black);
                     chunk[0] = rgb[0];
@@ -883,10 +878,7 @@ fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
     }
 }
 
-fn expand_gray_u8<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
-    buffer: &mut [u8],
-    info: &Info<P, T, I>,
-) {
+fn expand_gray_u8<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut [u8], info: &Info<P, T, I>) {
     let rescale = true;
     let scaling_factor = if rescale {
         (255) / ((1u16 << info.bit_depth as u8) - 1) as u8

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,8 +1,8 @@
 mod stream;
 mod zlib;
 
-use self::stream::{FormatErrorInner, CHUNCK_BUFFER_SIZE};
 pub use self::stream::{Decoded, DecodingError, StreamingDecoder};
+use self::stream::{FormatErrorInner, CHUNCK_BUFFER_SIZE};
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::mem;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -833,7 +833,10 @@ impl SubframeInfo {
     }
 }
 
-fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut [u8], info: &Info<P, T, I>) -> Result<(), DecodingError> {
+fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
+    buffer: &mut [u8],
+    info: &Info<P, T, I>,
+) -> Result<(), DecodingError> {
     if let Some(palette) = info.palette.as_ref() {
         if let BitDepth::Sixteen = info.bit_depth {
             // This should have been caught earlier but let's check again. Can't hurt.
@@ -849,7 +852,8 @@ fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut 
             if let Some(ref trns) = info.trns {
                 utils::unpack_bits(buffer, 4, info.bit_depth as u8, |i, chunk| {
                     let (rgb, a) = (
-                        palette.as_ref()
+                        palette
+                            .as_ref()
                             .get(3 * i as usize..3 * i as usize + 3)
                             .unwrap_or(&black),
                         trns.as_ref().get(i as usize).unwrap_or(&0xFF),
@@ -861,7 +865,8 @@ fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut 
                 });
             } else {
                 utils::unpack_bits(buffer, 3, info.bit_depth as u8, |i, chunk| {
-                    let rgb = palette.as_ref()
+                    let rgb = palette
+                        .as_ref()
                         .get(3 * i as usize..3 * i as usize + 3)
                         .unwrap_or(&black);
                     chunk[0] = rgb[0];
@@ -878,7 +883,10 @@ fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut 
     }
 }
 
-fn expand_gray_u8<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut [u8], info: &Info<P, T, I>) {
+fn expand_gray_u8<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(
+    buffer: &mut [u8],
+    info: &Info<P, T, I>,
+) {
     let rescale = true;
     let scaling_factor = if rescale {
         (255) / ((1u16 << info.bit_depth as u8) - 1) as u8

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -159,7 +159,7 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Reads all meta data until the first IDAT chunk
-    pub fn read_info(self) -> Result<(OutputInfo, Reader<'static, R>), DecodingError> {
+    pub fn read_info(self) -> Result<(OutputInfo, Reader<R>), DecodingError> {
         let mut r = Reader::new(self.r, StreamingDecoder::new(), self.transform, self.limits);
         r.init()?;
 
@@ -203,13 +203,13 @@ impl<R: Read> Decoder<R> {
     }
 }
 
-struct ReadDecoder<'a, R: Read> {
+struct ReadDecoder<R: Read> {
     reader: BufReader<R>,
-    decoder: StreamingDecoder<'a>,
+    decoder: StreamingDecoder,
     at_eof: bool,
 }
 
-impl<R: Read> ReadDecoder<'_, R> {
+impl<R: Read> ReadDecoder<R> {
     /// Returns the next decoded chunk. If the chunk is an ImageData chunk, its contents are written
     /// into image_data.
     fn decode_next(&mut self, image_data: &mut Vec<u8>) -> Result<Option<Decoded>, DecodingError> {
@@ -267,8 +267,8 @@ impl<R: Read> ReadDecoder<'_, R> {
 /// PNG reader (mostly high-level interface)
 ///
 /// Provides a high level that iterates over lines or whole images.
-pub struct Reader<'a, R: Read> {
-    decoder: ReadDecoder<'a, R>,
+pub struct Reader<R: Read> {
+    decoder: ReadDecoder<R>,
     bpp: BytesPerPixel,
     subframe: SubframeInfo,
     /// Number of frame control chunks read.
@@ -329,7 +329,7 @@ macro_rules! get_info(
     }
 );
 
-impl<R: Read> Reader<'_, R> {
+impl<R: Read> Reader<R> {
     /// Creates a new PNG reader
     fn new(r: R, d: StreamingDecoder, t: Transformations, limits: Limits) -> Reader<R> {
         Reader {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -259,7 +259,7 @@ impl<R: Read> ReadDecoder<R> {
         ))
     }
 
-    fn info(&self) -> Option<&Info> {
+    fn info(&self) -> Option<&Info<Vec<u8>, Vec<u8>, Vec<u8>>> {
         get_info(&self.decoder)
     }
 }
@@ -412,7 +412,7 @@ impl<R: Read> Reader<R> {
     /// Get information on the image.
     ///
     /// The structure will change as new frames of an animated image are decoded.
-    pub fn info(&self) -> &Info {
+    pub fn info(&self) -> &Info<Vec<u8>, Vec<u8>, Vec<u8>> {
         self.decoder.info().unwrap()
     }
 
@@ -809,7 +809,7 @@ impl SubframeInfo {
         }
     }
 
-    fn new(info: &Info) -> Self {
+    fn new<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(info: &Info<P, T, I>) -> Self {
         // The apng fctnl overrides width and height.
         // All other data is set by the main info struct.
         let (width, height) = if let Some(fc) = info.frame_control {
@@ -833,7 +833,7 @@ impl SubframeInfo {
     }
 }
 
-fn expand_paletted(buffer: &mut [u8], info: &Info) -> Result<(), DecodingError> {
+fn expand_paletted<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut [u8], info: &Info<P, T, I>) -> Result<(), DecodingError> {
     if let Some(palette) = info.palette.as_ref() {
         if let BitDepth::Sixteen = info.bit_depth {
             // This should have been caught earlier but let's check again. Can't hurt.
@@ -849,19 +849,19 @@ fn expand_paletted(buffer: &mut [u8], info: &Info) -> Result<(), DecodingError> 
             if let Some(ref trns) = info.trns {
                 utils::unpack_bits(buffer, 4, info.bit_depth as u8, |i, chunk| {
                     let (rgb, a) = (
-                        palette
+                        palette.as_ref()
                             .get(3 * i as usize..3 * i as usize + 3)
                             .unwrap_or(&black),
-                        *trns.get(i as usize).unwrap_or(&0xFF),
+                        trns.as_ref().get(i as usize).unwrap_or(&0xFF),
                     );
                     chunk[0] = rgb[0];
                     chunk[1] = rgb[1];
                     chunk[2] = rgb[2];
-                    chunk[3] = a;
+                    chunk[3] = *a;
                 });
             } else {
                 utils::unpack_bits(buffer, 3, info.bit_depth as u8, |i, chunk| {
-                    let rgb = palette
+                    let rgb = palette.as_ref()
                         .get(3 * i as usize..3 * i as usize + 3)
                         .unwrap_or(&black);
                     chunk[0] = rgb[0];
@@ -878,7 +878,7 @@ fn expand_paletted(buffer: &mut [u8], info: &Info) -> Result<(), DecodingError> 
     }
 }
 
-fn expand_gray_u8(buffer: &mut [u8], info: &Info) {
+fn expand_gray_u8<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>>(buffer: &mut [u8], info: &Info<P, T, I>) {
     let rescale = true;
     let scaling_factor = if rescale {
         (255) / ((1u16 << info.bit_depth as u8) - 1) as u8
@@ -887,7 +887,7 @@ fn expand_gray_u8(buffer: &mut [u8], info: &Info) {
     };
     if let Some(ref trns) = info.trns {
         utils::unpack_bits(buffer, 2, info.bit_depth as u8, |pixel, chunk| {
-            if pixel == trns[0] {
+            if pixel == trns.as_ref()[0] {
                 chunk[1] = 0
             } else {
                 chunk[1] = 0xFF

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,11 +1,11 @@
 extern crate crc32fast;
 
-use std::{borrow::Cow, cmp::min};
 use std::convert::From;
 use std::default::Default;
 use std::error;
 use std::fmt;
 use std::io;
+use std::{borrow::Cow, cmp::min};
 
 use crc32fast::Hasher as Crc32;
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,6 +1,6 @@
 extern crate crc32fast;
 
-use std::cmp::min;
+use std::{borrow::Cow, cmp::min};
 use std::convert::From;
 use std::default::Default;
 use std::error;
@@ -321,13 +321,13 @@ impl From<DecodingError> for io::Error {
 }
 
 /// PNG StreamingDecoder (low-level interface)
-pub struct StreamingDecoder {
+pub struct StreamingDecoder<'a> {
     state: Option<State>,
     current_chunk: ChunkState,
     /// The inflater state handling consecutive `IDAT` and `fdAT` chunks.
     inflater: ZlibStream,
     /// The complete image info read from all prior chunks.
-    info: Option<Info>,
+    pub(crate) info: Option<Info<'a>>,
     /// The animation chunk sequence number.
     current_seq_no: Option<u32>,
     /// Stores where in decoding an `fdAT` chunk we are.
@@ -350,11 +350,11 @@ struct ChunkState {
     raw_bytes: Vec<u8>,
 }
 
-impl StreamingDecoder {
+impl<'a> StreamingDecoder<'a> {
     /// Creates a new StreamingDecoder
     ///
     /// Allocates the internal buffers.
-    pub fn new() -> StreamingDecoder {
+    pub fn new() -> StreamingDecoder<'static> {
         StreamingDecoder {
             state: Some(State::Signature(0, [0; 7])),
             current_chunk: ChunkState::default(),
@@ -403,8 +403,8 @@ impl StreamingDecoder {
         Ok((len - buf.len(), Decoded::Nothing))
     }
 
-    fn next_state<'a>(
-        &'a mut self,
+    fn next_state<'b>(
+        &'b mut self,
         buf: &[u8],
         image_data: &mut Vec<u8>,
     ) -> Result<(usize, Decoded), DecodingError> {
@@ -737,7 +737,7 @@ impl StreamingDecoder {
 
     fn parse_plte(&mut self) -> Result<Decoded, DecodingError> {
         if let Some(info) = self.info.as_mut() {
-            info.palette = Some(self.current_chunk.raw_bytes.clone())
+            info.palette = Some(Cow::Owned(self.current_chunk.raw_bytes.clone()))
         }
         Ok(Decoded::Nothing)
     }
@@ -747,7 +747,7 @@ impl StreamingDecoder {
             let info = self.get_info_or_err()?;
             (info.color_type, info.bit_depth as u8)
         };
-        let vec = self.current_chunk.raw_bytes.clone();
+        let mut vec = self.current_chunk.raw_bytes.clone();
         let len = vec.len();
         let info = match self.info {
             Some(ref mut info) => info,
@@ -757,8 +757,6 @@ impl StreamingDecoder {
                 ))
             }
         };
-        info.trns = Some(vec);
-        let vec = info.trns.as_mut().unwrap();
         match color_type {
             ColorType::Grayscale => {
                 if len < 2 {
@@ -770,6 +768,7 @@ impl StreamingDecoder {
                     vec[0] = vec[1];
                     vec.truncate(1);
                 }
+                info.trns = Some(Cow::Owned(vec));
                 Ok(Decoded::Nothing)
             }
             ColorType::Rgb => {
@@ -784,6 +783,7 @@ impl StreamingDecoder {
                     vec[2] = vec[5];
                     vec.truncate(3);
                 }
+                info.trns = Some(Cow::Owned(vec));
                 Ok(Decoded::Nothing)
             }
             ColorType::Indexed => {
@@ -791,6 +791,7 @@ impl StreamingDecoder {
                 let _ = info.palette.as_ref().ok_or_else(|| {
                     DecodingError::Format(FormatErrorInner::AfterPlte { kind: chunk::tRNS }.into())
                 });
+                info.trns = Some(Cow::Owned(vec));
                 Ok(Decoded::Nothing)
             }
             c => Err(DecodingError::Format(
@@ -1019,7 +1020,7 @@ impl StreamingDecoder {
     }
 }
 
-impl Info {
+impl Info<'_> {
     fn validate(&self, fc: &FrameControl) -> Result<(), DecodingError> {
         // Validate mathematically: fc.width + fc.x_offset <= self.width
         let in_x_bounds = Some(fc.width) <= self.width.checked_sub(fc.x_offset);
@@ -1037,7 +1038,7 @@ impl Info {
     }
 }
 
-impl Default for StreamingDecoder {
+impl Default for StreamingDecoder<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -1052,11 +1053,6 @@ impl Default for ChunkState {
             raw_bytes: Vec::with_capacity(CHUNCK_BUFFER_SIZE),
         }
     }
-}
-
-#[inline(always)]
-pub fn get_info(d: &StreamingDecoder) -> Option<&Info> {
-    d.info.as_ref()
 }
 
 #[cfg(test)]

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -403,8 +403,8 @@ impl StreamingDecoder {
         Ok((len - buf.len(), Decoded::Nothing))
     }
 
-    fn next_state<'b>(
-        &'b mut self,
+    fn next_state<'a>(
+        &'a mut self,
         buf: &[u8],
         image_data: &mut Vec<u8>,
     ) -> Result<(usize, Decoded), DecodingError> {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -327,7 +327,7 @@ pub struct StreamingDecoder {
     /// The inflater state handling consecutive `IDAT` and `fdAT` chunks.
     inflater: ZlibStream,
     /// The complete image info read from all prior chunks.
-    info: Option<Info>,
+    info: Option<Info<Vec<u8>, Vec<u8>, Vec<u8>>>,
     /// The animation chunk sequence number.
     current_seq_no: Option<u32>,
     /// Stores where in decoding an `fdAT` chunk we are.
@@ -648,7 +648,7 @@ impl StreamingDecoder {
         }
     }
 
-    fn get_info_or_err(&self) -> Result<&Info, DecodingError> {
+    fn get_info_or_err(&self) -> Result<&Info<Vec<u8>, Vec<u8>, Vec<u8>>, DecodingError> {
         self.info
             .as_ref()
             .ok_or_else(|| DecodingError::Format(FormatErrorInner::MissingIhdr.into()))
@@ -1019,7 +1019,7 @@ impl StreamingDecoder {
     }
 }
 
-impl Info {
+impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Info<P, T, I> {
     fn validate(&self, fc: &FrameControl) -> Result<(), DecodingError> {
         // Validate mathematically: fc.width + fc.x_offset <= self.width
         let in_x_bounds = Some(fc.width) <= self.width.checked_sub(fc.x_offset);
@@ -1055,7 +1055,7 @@ impl Default for ChunkState {
 }
 
 #[inline(always)]
-pub fn get_info(d: &StreamingDecoder) -> Option<&Info> {
+pub fn get_info(d: &StreamingDecoder) -> Option<&Info<Vec<u8>, Vec<u8>, Vec<u8>>> {
     d.info.as_ref()
 }
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -321,13 +321,13 @@ impl From<DecodingError> for io::Error {
 }
 
 /// PNG StreamingDecoder (low-level interface)
-pub struct StreamingDecoder<'a> {
+pub struct StreamingDecoder {
     state: Option<State>,
     current_chunk: ChunkState,
     /// The inflater state handling consecutive `IDAT` and `fdAT` chunks.
     inflater: ZlibStream,
     /// The complete image info read from all prior chunks.
-    pub(crate) info: Option<Info<'a>>,
+    pub(crate) info: Option<Info<'static>>,
     /// The animation chunk sequence number.
     current_seq_no: Option<u32>,
     /// Stores where in decoding an `fdAT` chunk we are.
@@ -350,11 +350,11 @@ struct ChunkState {
     raw_bytes: Vec<u8>,
 }
 
-impl<'a> StreamingDecoder<'a> {
+impl StreamingDecoder {
     /// Creates a new StreamingDecoder
     ///
     /// Allocates the internal buffers.
-    pub fn new() -> StreamingDecoder<'static> {
+    pub fn new() -> StreamingDecoder {
         StreamingDecoder {
             state: Some(State::Signature(0, [0; 7])),
             current_chunk: ChunkState::default(),
@@ -1038,7 +1038,7 @@ impl Info<'_> {
     }
 }
 
-impl Default for StreamingDecoder<'_> {
+impl Default for StreamingDecoder {
     fn default() -> Self {
         Self::new()
     }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -327,7 +327,7 @@ pub struct StreamingDecoder {
     /// The inflater state handling consecutive `IDAT` and `fdAT` chunks.
     inflater: ZlibStream,
     /// The complete image info read from all prior chunks.
-    info: Option<Info<Vec<u8>, Vec<u8>, Vec<u8>>>,
+    info: Option<Info>,
     /// The animation chunk sequence number.
     current_seq_no: Option<u32>,
     /// Stores where in decoding an `fdAT` chunk we are.
@@ -648,7 +648,7 @@ impl StreamingDecoder {
         }
     }
 
-    fn get_info_or_err(&self) -> Result<&Info<Vec<u8>, Vec<u8>, Vec<u8>>, DecodingError> {
+    fn get_info_or_err(&self) -> Result<&Info, DecodingError> {
         self.info
             .as_ref()
             .ok_or_else(|| DecodingError::Format(FormatErrorInner::MissingIhdr.into()))
@@ -1019,7 +1019,7 @@ impl StreamingDecoder {
     }
 }
 
-impl<P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Info<P, T, I> {
+impl Info {
     fn validate(&self, fc: &FrameControl) -> Result<(), DecodingError> {
         // Validate mathematically: fc.width + fc.x_offset <= self.width
         let in_x_bounds = Some(fc.width) <= self.width.checked_sub(fc.x_offset);
@@ -1055,7 +1055,7 @@ impl Default for ChunkState {
 }
 
 #[inline(always)]
-pub fn get_info(d: &StreamingDecoder) -> Option<&Info<Vec<u8>, Vec<u8>, Vec<u8>>> {
+pub fn get_info(d: &StreamingDecoder) -> Option<&Info> {
     d.info.as_ref()
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,8 +1,8 @@
-use std::{borrow::Cow, error};
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::mem;
 use std::result;
+use std::{borrow::Cow, error};
 
 use crc32fast::Hasher as Crc32;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -220,12 +220,7 @@ pub(crate) fn write_chunk<W: Write>(mut w: W, name: chunk::ChunkType, data: &[u8
 }
 
 impl<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Writer<W, P, T, I> {
-    fn new(
-        w: W,
-        info: Info<P, T, I>,
-        filter: FilterType,
-        adaptive_filter: AdaptiveFilterType,
-    ) -> Writer<W, P, T, I> {
+    fn new(w: W, info: Info<P, T, I>, filter: FilterType, adaptive_filter: AdaptiveFilterType) -> Writer<W, P, T, I> {
         Writer {
             w,
             info,
@@ -375,9 +370,7 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> ChunkWriter<'
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<W, P, T, I>>
-    for ChunkOutput<'a, W, P, T, I>
-{
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<W, P, T, I>> for ChunkOutput<'a, W, P, T, I> {
     fn as_mut(&mut self) -> &mut Writer<W, P, T, I> {
         match self {
             ChunkOutput::Borrowed(writer) => writer,
@@ -386,9 +379,7 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write
-    for ChunkWriter<'a, W, P, T, I>
-{
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for ChunkWriter<'a, W, P, T, I> {
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.read(&mut self.buffer[self.index..])?;
         self.index += written;
@@ -414,9 +405,7 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop
-    for ChunkWriter<'a, W, P, T, I>
-{
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for ChunkWriter<'a, W, P, T, I> {
     fn drop(&mut self) {
         let _ = self.flush();
     }
@@ -437,10 +426,7 @@ pub struct StreamWriter<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[
 }
 
 impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> StreamWriter<'a, W, P, T, I> {
-    fn new(
-        mut writer: ChunkOutput<'a, W, P, T, I>,
-        buf_len: usize,
-    ) -> StreamWriter<'a, W, P, T, I> {
+    fn new(mut writer: ChunkOutput<'a, W, P, T, I>, buf_len: usize) -> StreamWriter<'a, W, P, T, I> {
         let bpp = writer.as_mut().info.bpp_in_prediction();
         let in_len = writer.as_mut().info.raw_row_length() - 1;
         let filter = writer.as_mut().filter;
@@ -470,9 +456,7 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> StreamWriter<
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write
-    for StreamWriter<'a, W, P, T, I>
-{
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for StreamWriter<'a, W, P, T, I> {
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.read(&mut self.curr_buf[self.index..])?;
         self.index += written;
@@ -504,9 +488,7 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop
-    for StreamWriter<'a, W, P, T, I>
-{
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for StreamWriter<'a, W, P, T, I> {
     fn drop(&mut self) {
         let _ = self.flush();
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -220,7 +220,12 @@ pub(crate) fn write_chunk<W: Write>(mut w: W, name: chunk::ChunkType, data: &[u8
 }
 
 impl<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Writer<W, P, T, I> {
-    fn new(w: W, info: Info<P, T, I>, filter: FilterType, adaptive_filter: AdaptiveFilterType) -> Writer<W, P, T, I> {
+    fn new(
+        w: W,
+        info: Info<P, T, I>,
+        filter: FilterType,
+        adaptive_filter: AdaptiveFilterType,
+    ) -> Writer<W, P, T, I> {
         Writer {
             w,
             info,
@@ -370,7 +375,9 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> ChunkWriter<'
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<W, P, T, I>> for ChunkOutput<'a, W, P, T, I> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<W, P, T, I>>
+    for ChunkOutput<'a, W, P, T, I>
+{
     fn as_mut(&mut self) -> &mut Writer<W, P, T, I> {
         match self {
             ChunkOutput::Borrowed(writer) => writer,
@@ -379,7 +386,9 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for ChunkWriter<'a, W, P, T, I> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write
+    for ChunkWriter<'a, W, P, T, I>
+{
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.read(&mut self.buffer[self.index..])?;
         self.index += written;
@@ -405,7 +414,9 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for Chu
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for ChunkWriter<'a, W, P, T, I> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop
+    for ChunkWriter<'a, W, P, T, I>
+{
     fn drop(&mut self) {
         let _ = self.flush();
     }
@@ -426,7 +437,10 @@ pub struct StreamWriter<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[
 }
 
 impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> StreamWriter<'a, W, P, T, I> {
-    fn new(mut writer: ChunkOutput<'a, W, P, T, I>, buf_len: usize) -> StreamWriter<'a, W, P, T, I> {
+    fn new(
+        mut writer: ChunkOutput<'a, W, P, T, I>,
+        buf_len: usize,
+    ) -> StreamWriter<'a, W, P, T, I> {
         let bpp = writer.as_mut().info.bpp_in_prediction();
         let in_len = writer.as_mut().info.raw_row_length() - 1;
         let filter = writer.as_mut().filter;
@@ -456,7 +470,9 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> StreamWriter<
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for StreamWriter<'a, W, P, T, I> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write
+    for StreamWriter<'a, W, P, T, I>
+{
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.read(&mut self.curr_buf[self.index..])?;
         self.index += written;
@@ -488,7 +504,9 @@ impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for Str
     }
 }
 
-impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for StreamWriter<'a, W, P, T, I> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop
+    for StreamWriter<'a, W, P, T, I>
+{
     fn drop(&mut self) {
         let _ = self.flush();
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -97,15 +97,15 @@ impl From<FormatErrorKind> for FormatError {
 }
 
 /// PNG Encoder
-pub struct Encoder<W: Write> {
+pub struct Encoder<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
     w: W,
-    info: Info,
+    info: Info<P, T, I>,
     filter: FilterType,
     adaptive_filter: AdaptiveFilterType,
 }
 
-impl<W: Write> Encoder<W> {
-    pub fn new(w: W, width: u32, height: u32) -> Encoder<W> {
+impl<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Encoder<W, P, T, I> {
+    pub fn new(w: W, width: u32, height: u32) -> Encoder<W, P, T, I> {
         let mut info = Info::default();
         info.width = width;
         info.height = height;
@@ -117,11 +117,11 @@ impl<W: Write> Encoder<W> {
         }
     }
 
-    pub fn set_palette(&mut self, palette: Vec<u8>) {
+    pub fn set_palette(&mut self, palette: P) {
         self.info.palette = Some(palette);
     }
 
-    pub fn set_trns(&mut self, trns: Vec<u8>) {
+    pub fn set_trns(&mut self, trns: T) {
         self.info.trns = Some(trns);
     }
 
@@ -147,7 +147,7 @@ impl<W: Write> Encoder<W> {
         self.info.srgb = Some(rendering_intent);
     }
 
-    pub fn write_header(self) -> Result<Writer<W>> {
+    pub fn write_header(self) -> Result<Writer<W, P, T, I>> {
         Writer::new(self.w, self.info, self.filter, self.adaptive_filter).init()
     }
 
@@ -199,9 +199,9 @@ impl<W: Write> Encoder<W> {
 }
 
 /// PNG writer
-pub struct Writer<W: Write> {
+pub struct Writer<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
     w: W,
-    info: Info,
+    info: Info<P, T, I>,
     filter: FilterType,
     adaptive_filter: AdaptiveFilterType,
 }
@@ -219,8 +219,8 @@ pub(crate) fn write_chunk<W: Write>(mut w: W, name: chunk::ChunkType, data: &[u8
     Ok(())
 }
 
-impl<W: Write> Writer<W> {
-    fn new(w: W, info: Info, filter: FilterType, adaptive_filter: AdaptiveFilterType) -> Writer<W> {
+impl<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Writer<W, P, T, I> {
+    fn new(w: W, info: Info<P, T, I>, filter: FilterType, adaptive_filter: AdaptiveFilterType) -> Writer<W, P, T, I> {
         Writer {
             w,
             info,
@@ -311,7 +311,7 @@ impl<W: Write> Writer<W> {
     ///
     /// This borrows the writer which allows for manually appending additional
     /// chunks after the image data has been written.
-    pub fn stream_writer(&mut self) -> StreamWriter<W> {
+    pub fn stream_writer(&mut self) -> StreamWriter<W, P, T, I> {
         self.stream_writer_with_size(DEFAULT_BUFFER_LENGTH)
     }
 
@@ -320,7 +320,7 @@ impl<W: Write> Writer<W> {
     /// See [`stream_writer`].
     ///
     /// [`stream_writer`]: #fn.stream_writer
-    pub fn stream_writer_with_size(&mut self, size: usize) -> StreamWriter<W> {
+    pub fn stream_writer_with_size(&mut self, size: usize) -> StreamWriter<W, P, T, I> {
         StreamWriter::new(ChunkOutput::Borrowed(self), size)
     }
 
@@ -329,7 +329,7 @@ impl<W: Write> Writer<W> {
     /// This allows you to create images that do not fit in memory. The default
     /// chunk size is 4K, use `stream_writer_with_size` to set another chunk
     /// size.
-    pub fn into_stream_writer(self) -> StreamWriter<'static, W> {
+    pub fn into_stream_writer(self) -> StreamWriter<'static, W, P, T, I> {
         self.into_stream_writer_with_size(DEFAULT_BUFFER_LENGTH)
     }
 
@@ -338,30 +338,30 @@ impl<W: Write> Writer<W> {
     /// See [`into_stream_writer`].
     ///
     /// [`into_stream_writer`]: #fn.into_stream_writer
-    pub fn into_stream_writer_with_size(self, size: usize) -> StreamWriter<'static, W> {
+    pub fn into_stream_writer_with_size(self, size: usize) -> StreamWriter<'static, W, P, T, I> {
         StreamWriter::new(ChunkOutput::Owned(self), size)
     }
 }
 
-impl<W: Write> Drop for Writer<W> {
+impl<W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for Writer<W, P, T, I> {
     fn drop(&mut self) {
         let _ = self.write_chunk(chunk::IEND, &[]);
     }
 }
 
-struct ChunkWriter<'a, W: Write> {
-    writer: ChunkOutput<'a, W>,
+struct ChunkWriter<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
+    writer: ChunkOutput<'a, W, P, T, I>,
     buffer: Vec<u8>,
     index: usize,
 }
 
-enum ChunkOutput<'a, W: Write> {
-    Borrowed(&'a mut Writer<W>),
-    Owned(Writer<W>),
+enum ChunkOutput<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
+    Borrowed(&'a mut Writer<W, P, T, I>),
+    Owned(Writer<W, P, T, I>),
 }
 
-impl<'a, W: Write> ChunkWriter<'a, W> {
-    fn new(writer: ChunkOutput<'a, W>, buf_len: usize) -> ChunkWriter<'a, W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> ChunkWriter<'a, W, P, T, I> {
+    fn new(writer: ChunkOutput<'a, W, P, T, I>, buf_len: usize) -> ChunkWriter<'a, W, P, T, I> {
         ChunkWriter {
             writer,
             buffer: vec![0; buf_len],
@@ -370,8 +370,8 @@ impl<'a, W: Write> ChunkWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> AsMut<Writer<W>> for ChunkOutput<'a, W> {
-    fn as_mut(&mut self) -> &mut Writer<W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> AsMut<Writer<W, P, T, I>> for ChunkOutput<'a, W, P, T, I> {
+    fn as_mut(&mut self) -> &mut Writer<W, P, T, I> {
         match self {
             ChunkOutput::Borrowed(writer) => writer,
             ChunkOutput::Owned(writer) => writer,
@@ -379,7 +379,7 @@ impl<'a, W: Write> AsMut<Writer<W>> for ChunkOutput<'a, W> {
     }
 }
 
-impl<'a, W: Write> Write for ChunkWriter<'a, W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for ChunkWriter<'a, W, P, T, I> {
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.read(&mut self.buffer[self.index..])?;
         self.index += written;
@@ -405,7 +405,7 @@ impl<'a, W: Write> Write for ChunkWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> Drop for ChunkWriter<'a, W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for ChunkWriter<'a, W, P, T, I> {
     fn drop(&mut self) {
         let _ = self.flush();
     }
@@ -415,8 +415,8 @@ impl<'a, W: Write> Drop for ChunkWriter<'a, W> {
 ///
 /// This may silently fail in the destructor, so it is a good idea to call
 /// [`finish`](#method.finish) or [`flush`](https://doc.rust-lang.org/stable/std/io/trait.Write.html#tymethod.flush) before dropping.
-pub struct StreamWriter<'a, W: Write> {
-    writer: deflate::write::ZlibEncoder<ChunkWriter<'a, W>>,
+pub struct StreamWriter<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> {
+    writer: deflate::write::ZlibEncoder<ChunkWriter<'a, W, P, T, I>>,
     prev_buf: Vec<u8>,
     curr_buf: Vec<u8>,
     index: usize,
@@ -425,8 +425,8 @@ pub struct StreamWriter<'a, W: Write> {
     adaptive_filter: AdaptiveFilterType,
 }
 
-impl<'a, W: Write> StreamWriter<'a, W> {
-    fn new(mut writer: ChunkOutput<'a, W>, buf_len: usize) -> StreamWriter<'a, W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> StreamWriter<'a, W, P, T, I> {
+    fn new(mut writer: ChunkOutput<'a, W, P, T, I>, buf_len: usize) -> StreamWriter<'a, W, P, T, I> {
         let bpp = writer.as_mut().info.bpp_in_prediction();
         let in_len = writer.as_mut().info.raw_row_length() - 1;
         let filter = writer.as_mut().filter;
@@ -456,7 +456,7 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> Write for StreamWriter<'a, W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Write for StreamWriter<'a, W, P, T, I> {
     fn write(&mut self, mut buf: &[u8]) -> io::Result<usize> {
         let written = buf.read(&mut self.curr_buf[self.index..])?;
         self.index += written;
@@ -488,7 +488,7 @@ impl<'a, W: Write> Write for StreamWriter<'a, W> {
     }
 }
 
-impl<'a, W: Write> Drop for StreamWriter<'a, W> {
+impl<'a, W: Write, P: AsRef<[u8]>, T: AsRef<[u8]>, I: AsRef<[u8]>> Drop for StreamWriter<'a, W, P, T, I> {
     fn drop(&mut self) {
         let _ = self.flush();
     }


### PR DESCRIPTION
Currently, a user of this crate, when encoding a PNG file with custom PLTE or tRNS data, is forced to pass that data as an owned Vec<u8>. However, the internals of this library do not really need an owned vector, just something that can be converted to a byte slice, and the requirement of a Vec may introduce unneeded copies and allocations in client code.

Fix the situation by accepting a `Cow<'a, [u8]>` instead, which will allow the library to clone the data to get ownership of it if needs it in the future.