### PR TITLE
Streaming Encoder for APNG

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1332,8 +1332,10 @@ impl<'a, W: Write> Write for StreamWriter<'a, W> {
             return Ok(0);
         }
 
-        if matches!(self.writer, Wrapper::Chunk(_)) {
-            self.new_frame()?
+        match self.writer {
+            Wrapper::Chunk(_) => self.new_frame()?,
+            Wrapper::Zlib(_) => {}
+            Wrapper::None => unreachable!(),
         }
 
         if self.to_write == 0 {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -91,7 +91,10 @@ impl fmt::Display for FormatError {
             EndReached => write!(fmt, "all the frames have been already written"),
             MissingFrames => write!(fmt, "there are still frames to be written"),
             MissingData(n) => write!(fmt, "there are still {} bytes to be written", n),
-            Unrecoverable => write!(fmt, "the writer is in an unrecoverable state"),
+            Unrecoverable => write!(
+                fmt,
+                "a previous error put the writer into an unrecoverable state"
+            ),
         }
     }
 }


### PR DESCRIPTION
I already introduced this on [my last PR](https://github.com/image-rs/image-png/pull/284). I've added some comments on the code to explain what I did.

For some reasons I thought that my implementation of the `ChunkWriter` differed a lot from the current one, but in reality they both hold at most one full chunk, and in fact the old one didn't even check if the buffer size was greater than the maximum size of a chunk (even if it wouldn't matter that much as extremely rare cases need to bufferize 2GiB).

The way it works right now is that you write data and it automatically separates each frame, and all the parameters (selected with the `set_*` methods) of the animation are kept until the current frame is being written and applied on the following ones.