### PR TITLE
Tweak the Info struct

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -457,19 +457,6 @@ impl SrgbRenderingIntent {
     }
 }
 
-/// A single-byte integer that represents the filtering method applied before
-/// compression.
-///
-/// Currently, the only filter method is adaptive filtering with any of the
-/// five filters in [`filter::FilterType`].
-///
-/// [`filter::FilterType`]: enum.FilterType.html
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum InfoFilterType {
-    Adaptive = 0,
-}
-
 /// PNG info struct
 #[derive(Clone, Debug)]
 pub struct Info<'a> {
@@ -489,7 +476,6 @@ pub struct Info<'a> {
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
     pub compression: Compression,
-    pub filter: InfoFilterType,
     /// Chromaticities of the source system.
     pub source_chromaticities: Option<SourceChromaticities>,
     /// The rendering intent of an SRGB image.

--- a/src/common.rs
+++ b/src/common.rs
@@ -483,7 +483,9 @@ pub struct Info<'a> {
     /// Presence of this value also indicates that the image conforms to the SRGB color space.
     pub srgb: Option<SrgbRenderingIntent>,
     /// The ICC profile for the image.
-    pub icc_profile: Option<Vec<u8>>,
+    pub icc_profile: Option<Cow<'a, [u8]>>,
+    /// Private field to mark the struct as non-exhaustive.
+    _extensible: (),
 }
 
 impl Default for Info<'_> {
@@ -503,15 +505,24 @@ impl Default for Info<'_> {
             // Default to `deflate::Compression::Fast` and `filter::FilterType::Sub`
             // to maintain backward compatible output.
             compression: Compression::Fast,
-            filter: InfoFilterType::Adaptive,
             source_chromaticities: None,
             srgb: None,
             icc_profile: None,
+            _extensible: (),
         }
     }
 }
 
 impl Info<'_> {
+    /// A utility constructor for a default info with width and height.
+    pub fn with_size(width: u32, height: u32) -> Self {
+        Info {
+            width,
+            height,
+            ..Default::default()
+        }
+    }
+
     /// Size of the image, width then height.
     pub fn size(&self) -> (u32, u32) {
         (self.width, self.height)
@@ -584,6 +595,10 @@ impl Info<'_> {
             .raw_row_length_from_width(self.bit_depth, width)
     }
 
+    /// Encode this header to the writer.
+    ///
+    /// Note that this does _not_ include the PNG signature, it starts with the IHDR chunk and then
+    /// includes other chunks that were added to the header.
     pub fn encode<W: Write>(&self, mut w: W) -> encoder::Result<()> {
         // Encode the IHDR chunk
         let mut data = [0; 13];

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -951,7 +951,7 @@ impl StreamingDecoder {
                 buf = &buf[consumed_bytes..];
             }
 
-            self.info.as_mut().unwrap().icc_profile = Some(profile);
+            self.info.as_mut().unwrap().icc_profile = Some(Cow::Owned(profile));
             Ok(Decoded::Nothing)
         }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -127,14 +127,9 @@ pub struct Encoder<'a, W: Write> {
 
 impl<'a, W: Write> Encoder<'a, W> {
     pub fn new(w: W, width: u32, height: u32) -> Encoder<'static, W> {
-        let info = Info {
-            width,
-            height,
-            ..Default::default()
-        };
         Encoder {
             w,
-            info,
+            info: Info::with_size(width, height),
             filter: FilterType::default(),
             adaptive_filter: AdaptiveFilterType::default(),
             sep_def_img: false,
@@ -415,16 +410,15 @@ impl PartialInfo {
     /// Converts this partial info to an owned Info struct,
     /// setting missing values to their defaults
     fn to_info(&self) -> Info<'static> {
-        Info {
-            width: self.width,
-            height: self.height,
-            bit_depth: self.bit_depth,
-            color_type: self.color_type,
-            frame_control: self.frame_control,
-            animation_control: self.animation_control,
-            compression: self.compression,
-            ..Default::default()
-        }
+        let mut info = Info::default();
+        info.width = self.width;
+        info.height = self.height;
+        info.bit_depth = self.bit_depth;
+        info.color_type = self.color_type;
+        info.frame_control = self.frame_control;
+        info.animation_control = self.animation_control;
+        info.compression = self.compression;
+        info
     }
 }
 


### PR DESCRIPTION
It is now non-exhaustive which simplifies adding more information in the future. The borrowed option is also available for the icc chunk. The `InfoFilterType`, which has long been replaced for its encoding purpose, is removed.