### PR TITLE
Improve ergonomics of encoder set_palette and set_trns methods

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -172,12 +172,16 @@ impl<'a, W: Write> Encoder<'a, W> {
         }
     }
 
-    pub fn set_palette(&mut self, palette: Cow<'a, [u8]>) {
-        self.info.palette = Some(palette);
+    /// Sets the raw byte contents of the PLTE chunk. This method accepts
+    /// both borrowed and owned byte data.
+    pub fn set_palette<T: Into<Cow<'a, [u8]>>>(&mut self, palette: T) {
+        self.info.palette = Some(palette.into());
     }
 
-    pub fn set_trns(&mut self, trns: Cow<'a, [u8]>) {
-        self.info.trns = Some(trns);
+    /// Sets the raw byte contents of the tRNS chunk. This method accepts
+    /// both borrowed and owned byte data.
+    pub fn set_trns<T: Into<Cow<'a, [u8]>>>(&mut self, trns: T) {
+        self.info.trns = Some(trns.into());
     }
 
     /// Set the display gamma of the source system on which the image was generated or last edited.
@@ -1077,7 +1081,7 @@ mod tests {
                 let mut encoder = Encoder::new(&mut out, info.width, info.height);
                 encoder.set_depth(BitDepth::from_u8(bit_depth).unwrap());
                 encoder.set_color(ColorType::Indexed);
-                encoder.set_palette(Cow::Borrowed(palette));
+                encoder.set_palette(palette.as_ref());
 
                 let mut writer = encoder.write_header().unwrap();
                 writer.write_image_data(&indexed_data).unwrap();


### PR DESCRIPTION
After #288 was merged, several people expressed their desire for more ergonomic `set_palette` and `set_trns` methods, as asking client code to instantiate a `Cow` is not so elegant.

This PR refactors those methods to accept any type that can be converted to a `Cow` byte slice, which allows using both methods like before, receiving an owned `Vec<u8>`, but now they also are generic enough to allow using stack allocated slices, boxed slices, and other types that may be converted to a byte slice with an appropriate lifetime.