### PR TITLE
Rework output info usage

### DIFF
--- a/benches/decoder.rs
+++ b/benches/decoder.rs
@@ -25,14 +25,15 @@ fn bench_file(c: &mut Criterion, data: Vec<u8>, name: String) {
     group.sample_size(20);
 
     let decoder = Decoder::new(&*data);
-    let (info, _) = decoder.read_info().unwrap();
-    let mut image = vec![0; info.buffer_size()];
+    let mut reader = decoder.read_info().unwrap();
+    let mut image = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut image).unwrap();
 
     group.throughput(Throughput::Bytes(info.buffer_size() as u64));
     group.bench_with_input(name, &data, |b, data| {
         b.iter(|| {
             let decoder = Decoder::new(data.as_slice());
-            let (_, mut decoder) = decoder.read_info().unwrap();
+            let mut decoder = decoder.read_info().unwrap();
             decoder.next_frame(&mut image).unwrap();
         })
     });

--- a/examples/show.rs
+++ b/examples/show.rs
@@ -17,9 +17,9 @@ use glium::{BlitTarget, Rect, Surface};
 fn load_image(path: &path::PathBuf) -> io::Result<RawImage2d<'static, u8>> {
     use png::ColorType::*;
     let decoder = png::Decoder::new(File::open(path)?);
-    let (info, mut reader) = decoder.read_info()?;
-    let mut img_data = vec![0; info.buffer_size()];
-    reader.next_frame(&mut img_data)?;
+    let mut reader = decoder.read_info()?;
+    let mut img_data = vec![0; reader.output_buffer_size()];
+    let info = reader.next_frame(&mut img_data)?;
 
     let (data, format) = match info.color_type {
         Rgb => (img_data, ClientFormat::U8U8U8),

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -26,7 +26,9 @@ pub enum InterlaceHandling {
 }
 */
 
-/// Output info
+/// Output info.
+///
+/// This describes one particular frame of the image that was written into the output buffer.
 #[derive(Debug, PartialEq, Eq)]
 pub struct OutputInfo {
     pub width: u32,
@@ -159,12 +161,12 @@ impl<R: Read> Decoder<R> {
     }
 
     /// Reads all meta data until the first IDAT chunk
-    pub fn read_info(self) -> Result<(OutputInfo, Reader<R>), DecodingError> {
-        let mut r = Reader::new(self.r, StreamingDecoder::new(), self.transform, self.limits);
-        r.init()?;
+    pub fn read_info(self) -> Result<Reader<R>, DecodingError> {
+        let mut reader = Reader::new(self.r, StreamingDecoder::new(), self.transform, self.limits);
+        reader.init()?;
 
-        let color_type = r.info().color_type;
-        let bit_depth = r.info().bit_depth;
+        let color_type = reader.info().color_type;
+        let bit_depth = reader.info().bit_depth;
         if color_type.is_combination_invalid(bit_depth) {
             return Err(DecodingError::Format(
                 FormatErrorInner::InvalidColorBitDepth {
@@ -176,22 +178,11 @@ impl<R: Read> Decoder<R> {
         }
 
         // Check if the output buffer can be represented at all.
-        if r.checked_output_buffer_size().is_none() {
+        if reader.checked_output_buffer_size().is_none() {
             return Err(DecodingError::LimitsExceeded);
         }
 
-        let (ct, bits) = r.output_color_type();
-        let info = {
-            let info = r.info();
-            OutputInfo {
-                width: info.width,
-                height: info.height,
-                color_type: ct,
-                bit_depth: bits,
-                line_size: r.output_line_size(info.width),
-            }
-        };
-        Ok((info, r))
+        Ok(reader)
     }
 
     /// Set the allowed and performed transformations.
@@ -297,6 +288,7 @@ pub struct Reader<R: Read> {
 /// in a particular IDAT-frame or subframe we are.
 struct SubframeInfo {
     width: u32,
+    height: u32,
     rowlen: usize,
     interlace: InterlaceIter,
     consumed_and_flushed: bool,
@@ -353,9 +345,9 @@ impl<R: Read> Reader<R> {
 
     /// Reads all meta data until the next frame data starts.
     /// Requires IHDR before the IDAT and fcTL before fdAT.
-    fn init(&mut self) -> Result<(), DecodingError> {
+    fn init(&mut self) -> Result<OutputInfo, DecodingError> {
         if self.next_frame == self.subframe_idx() {
-            return Ok(());
+            return Ok(self.output_info());
         } else if self.next_frame == SubframeIdx::End {
             return Err(DecodingError::Parameter(
                 ParameterErrorKind::PolledAfterEndOfImage.into(),
@@ -401,7 +393,22 @@ impl<R: Read> Reader<R> {
         }
         self.allocate_out_buf()?;
         self.prev = vec![0; self.subframe.rowlen];
-        Ok(())
+        Ok(self.output_info())
+    }
+
+    fn output_info(&self) -> OutputInfo {
+        let width = self.subframe.width;
+        let height = self.subframe.height;
+
+        let (color_type, bit_depth) = self.output_color_type();
+
+        OutputInfo {
+            width,
+            height,
+            color_type,
+            bit_depth,
+            line_size: self.output_line_size(width),
+        }
     }
 
     fn reset_current(&mut self) {
@@ -468,9 +475,9 @@ impl<R: Read> Reader<R> {
     ///
     /// Output lines will be written in row-major, packed matrix with width and height of the read
     /// frame (or subframe), all samples are in big endian byte order where this matters.
-    pub fn next_frame(&mut self, buf: &mut [u8]) -> Result<(), DecodingError> {
+    pub fn next_frame(&mut self, buf: &mut [u8]) -> Result<OutputInfo, DecodingError> {
         // Advance until we've read the info / fcTL for this frame.
-        self.init()?;
+        let info = self.init()?;
         // TODO 16 bit
         let (color_type, bit_depth) = self.output_color_type();
         if buf.len() < self.output_buffer_size() {
@@ -511,7 +518,8 @@ impl<R: Read> Reader<R> {
         }
         // Advance our state to expect the next frame.
         self.finished_frame();
-        Ok(())
+
+        Ok(info)
     }
 
     /// Returns the next processed row of the image
@@ -601,11 +609,7 @@ impl<R: Read> Reader<R> {
 
     /// Returns the color type and the number of bits per sample
     /// of the data returned by `Reader::next_row` and Reader::frames`.
-    pub fn output_color_type(&mut self) -> (ColorType, BitDepth) {
-        self.imm_output_color_type()
-    }
-
-    pub(crate) fn imm_output_color_type(&self) -> (ColorType, BitDepth) {
+    pub fn output_color_type(&self) -> (ColorType, BitDepth) {
         use crate::common::ColorType::*;
         let t = self.transform;
         let info = self.info();
@@ -657,7 +661,7 @@ impl<R: Read> Reader<R> {
 
     fn checked_output_buffer_size(&self) -> Option<usize> {
         let (width, height) = self.info().size();
-        let (color, depth) = self.imm_output_color_type();
+        let (color, depth) = self.output_color_type();
         let rowlen = color.checked_raw_row_length(depth, width)? - 1;
         let height: usize = std::convert::TryFrom::try_from(height).ok()?;
         rowlen.checked_mul(height)
@@ -665,7 +669,7 @@ impl<R: Read> Reader<R> {
 
     /// Returns the number of bytes required to hold a deinterlaced row.
     pub fn output_line_size(&self, width: u32) -> usize {
-        let (color, depth) = self.imm_output_color_type();
+        let (color, depth) = self.output_color_type();
         color.raw_row_length_from_width(depth, width) - 1
     }
 
@@ -803,6 +807,7 @@ impl SubframeInfo {
     fn not_yet_init() -> Self {
         SubframeInfo {
             width: 0,
+            height: 0,
             rowlen: 0,
             interlace: InterlaceIter::None(0..0),
             consumed_and_flushed: false,
@@ -826,6 +831,7 @@ impl SubframeInfo {
 
         SubframeInfo {
             width,
+            height,
             rowlen: info.raw_row_length_from_width(width),
             interlace,
             consumed_and_flushed: false,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -31,15 +31,22 @@ pub enum InterlaceHandling {
 /// This describes one particular frame of the image that was written into the output buffer.
 #[derive(Debug, PartialEq, Eq)]
 pub struct OutputInfo {
+    /// The pixel width of this frame.
     pub width: u32,
+    /// The pixel height of this frame.
     pub height: u32,
+    /// The chosen output color type.
     pub color_type: ColorType,
+    /// The chosen output bit depth.
     pub bit_depth: BitDepth,
+    /// The byte count of each scan line in the image.
     pub line_size: usize,
 }
 
 impl OutputInfo {
     /// Returns the size needed to hold a decoded frame
+    /// If the output buffer was larger then bytes after this count should be ignored. They may
+    /// still have been changed.
     pub fn buffer_size(&self) -> usize {
         self.line_size * self.height as usize
     }
@@ -952,15 +959,14 @@ mod tests {
             "/tests/bugfixes/x_issue#214.png"
         ));
 
-        let (info, mut normal) = Decoder::new(IMG).read_info().unwrap();
+        let mut normal = Decoder::new(IMG).read_info().unwrap();
 
-        let mut buffer = vec![0; info.buffer_size()];
+        let mut buffer = vec![0; normal.output_buffer_size()];
         let normal = normal.next_frame(&mut buffer).unwrap_err();
 
         let smal = Decoder::new(SmalBuf::new(IMG, 1))
             .read_info()
             .unwrap()
-            .1
             .next_frame(&mut buffer)
             .unwrap_err();
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1065,7 +1065,7 @@ mod tests {
     fn image_gamma() -> Result<(), ()> {
         fn trial(path: &str, expected: Option<ScaledFloat>) {
             let decoder = crate::Decoder::new(File::open(path).unwrap());
-            let (_, reader) = decoder.read_info().unwrap();
+            let reader = decoder.read_info().unwrap();
             let actual: Option<ScaledFloat> = reader.info().source_gamma;
             assert!(actual == expected);
         }
@@ -1106,7 +1106,7 @@ mod tests {
     fn image_source_chromaticities() -> Result<(), ()> {
         fn trial(path: &str, expected: Option<SourceChromaticities>) {
             let decoder = crate::Decoder::new(File::open(path).unwrap());
-            let (_, reader) = decoder.read_info().unwrap();
+            let reader = decoder.read_info().unwrap();
             let actual: Option<SourceChromaticities> = reader.info().source_chromaticities;
             assert!(actual == expected);
         }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,9 +1,7 @@
 use borrow::Cow;
-use hash::Hasher;
 use io::{Read, Write};
-use mem::swap;
 use ops::{Deref, DerefMut};
-use std::{borrow, error, fmt, hash, io, mem, ops, result};
+use std::{borrow, error, fmt, io, mem, ops, result};
 
 use crc32fast::Hasher as Crc32;
 use deflate::write::ZlibEncoder;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1432,14 +1432,9 @@ mod tests {
                 eprintln!("{}", path.display());
                 // Decode image
                 let decoder = Decoder::new(File::open(path).unwrap());
-                let (info, mut reader) = decoder.read_info().unwrap();
-                if info.line_size != 32 {
-                    // TODO encoding only works with line size 32?
-                    continue;
-                }
-                let mut buf = vec![0; info.buffer_size()];
-                eprintln!("{:?}", info);
-                reader.next_frame(&mut buf).unwrap();
+                let mut reader = decoder.read_info().unwrap();
+                let mut buf = vec![0; reader.output_buffer_size()];
+                let info = reader.next_frame(&mut buf).unwrap();
                 // Encode decoded image
                 let mut out = Vec::new();
                 {
@@ -1448,15 +1443,19 @@ mod tests {
                         w: &mut out,
                     };
 
-                    let mut encoder = Encoder::new(&mut wrapper, info.width, info.height)
-                        .write_header()
-                        .unwrap();
+                    let mut encoder = Encoder::new(&mut wrapper, info.width, info.height);
+                    encoder.set_color(info.color_type);
+                    encoder.set_depth(info.bit_depth);
+                    if let Some(palette) = &reader.info().palette {
+                        encoder.set_palette(palette.clone());
+                    }
+                    let mut encoder = encoder.write_header().unwrap();
                     encoder.write_image_data(&buf).unwrap();
                 }
                 // Decode encoded decoded image
                 let decoder = Decoder::new(&*out);
-                let (info, mut reader) = decoder.read_info().unwrap();
-                let mut buf2 = vec![0; info.buffer_size()];
+                let mut reader = decoder.read_info().unwrap();
+                let mut buf2 = vec![0; reader.output_buffer_size()];
                 reader.next_frame(&mut buf2).unwrap();
                 // check if the encoded image is ok:
                 assert_eq!(buf, buf2);
@@ -1478,13 +1477,9 @@ mod tests {
                 }
                 // Decode image
                 let decoder = Decoder::new(File::open(path).unwrap());
-                let (info, mut reader) = decoder.read_info().unwrap();
-                if info.line_size != 32 {
-                    // TODO encoding only works with line size 32?
-                    continue;
-                }
-                let mut buf = vec![0; info.buffer_size()];
-                reader.next_frame(&mut buf).unwrap();
+                let mut reader = decoder.read_info().unwrap();
+                let mut buf = vec![0; reader.output_buffer_size()];
+                let info = reader.next_frame(&mut buf).unwrap();
                 // Encode decoded image
                 let mut out = Vec::new();
                 {
@@ -1493,9 +1488,13 @@ mod tests {
                         w: &mut out,
                     };
 
-                    let mut encoder = Encoder::new(&mut wrapper, info.width, info.height)
-                        .write_header()
-                        .unwrap();
+                    let mut encoder = Encoder::new(&mut wrapper, info.width, info.height);
+                    encoder.set_color(info.color_type);
+                    encoder.set_depth(info.bit_depth);
+                    if let Some(palette) = &reader.info().palette {
+                        encoder.set_palette(palette.clone());
+                    }
+                    let mut encoder = encoder.write_header().unwrap();
                     let mut stream_writer = encoder.stream_writer().unwrap();
 
                     let mut outer_wrapper = RandomChunkWriter {
@@ -1507,8 +1506,8 @@ mod tests {
                 }
                 // Decode encoded decoded image
                 let decoder = Decoder::new(&*out);
-                let (info, mut reader) = decoder.read_info().unwrap();
-                let mut buf2 = vec![0; info.buffer_size()];
+                let mut reader = decoder.read_info().unwrap();
+                let mut buf2 = vec![0; reader.output_buffer_size()];
                 reader.next_frame(&mut buf2).unwrap();
                 // check if the encoded image is ok:
                 assert_eq!(buf, buf2);
@@ -1522,14 +1521,15 @@ mod tests {
             // Do a reference decoding, choose a fitting palette image from pngsuite
             let path = format!("tests/pngsuite/basn3p0{}.png", bit_depth);
             let decoder = Decoder::new(File::open(&path).unwrap());
-            let (info, mut reader) = decoder.read_info().unwrap();
+            let mut reader = decoder.read_info().unwrap();
 
-            let mut decoded_pixels = vec![0; info.buffer_size()];
+            let mut decoded_pixels = vec![0; reader.output_buffer_size()];
+            let info = reader.info();
             assert_eq!(
                 info.width as usize * info.height as usize * usize::from(bit_depth),
                 decoded_pixels.len() * 8
             );
-            reader.next_frame(&mut decoded_pixels).unwrap();
+            let info = reader.next_frame(&mut decoded_pixels).unwrap();
             let indexed_data = decoded_pixels;
 
             let palette = reader.info().palette.as_ref().unwrap();
@@ -1546,8 +1546,8 @@ mod tests {
 
             // Decode re-encoded image
             let decoder = Decoder::new(&*out);
-            let (info, mut reader) = decoder.read_info().unwrap();
-            let mut redecoded = vec![0; info.buffer_size()];
+            let mut reader = decoder.read_info().unwrap();
+            let mut redecoded = vec![0; reader.output_buffer_size()];
             reader.next_frame(&mut redecoded).unwrap();
             // check if the encoded image is ok:
             assert_eq!(indexed_data, redecoded);
@@ -1754,7 +1754,8 @@ mod tests {
             encoder.write_header()?.write_image_data(&pixel)?;
 
             let decoder = crate::Decoder::new(io::Cursor::new(buffer));
-            let (info, mut reader) = decoder.read_info()?;
+            let mut reader = decoder.read_info()?;
+            let info = reader.info();
             assert_eq!(info.width, 4);
             assert_eq!(info.height, 4);
             let mut dest = vec![0; pixel.len()];
@@ -1789,17 +1790,17 @@ mod tests {
             encoder.write_header()?.write_image_data(&pixel)?;
 
             let decoder = crate::Decoder::new(io::Cursor::new(buffer));
-            let (info, mut reader) = decoder.read_info()?;
+            let mut reader = decoder.read_info()?;
             assert_eq!(
                 reader.info().source_gamma,
                 gamma,
                 "Deviation with gamma {:?}",
                 gamma
             );
+            let mut dest = vec![0; pixel.len()];
+            let info = reader.next_frame(&mut dest)?;
             assert_eq!(info.width, 4);
             assert_eq!(info.height, 4);
-            let mut dest = vec![0; pixel.len()];
-            reader.next_frame(&mut dest)?;
 
             Ok(())
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,26 +1,35 @@
 //! # PNG encoder and decoder
+//!
 //! This crate contains a PNG encoder and decoder. It supports reading of single lines or whole frames.
+//!
 //! ## The decoder
+//!
 //! The most important types for decoding purposes are [`Decoder`](struct.Decoder.html) and
 //! [`Reader`](struct.Reader.html). They both wrap a `std::io::Read`.
 //! `Decoder` serves as a builder for `Reader`. Calling `Decoder::read_info` reads from the `Read` until the
 //! image data is reached.
-//! ### Using the decoder
-//!     use std::fs::File;
 //!
-//!     // The decoder is a build for reader and can be used to set various decoding options
-//!     // via `Transformations`. The default output transformation is `Transformations::EXPAND
-//!     // | Transformations::STRIP_ALPHA`.
-//!     let decoder = png::Decoder::new(File::open("tests/pngsuite/basi0g01.png").unwrap());
-//!     let (info, mut reader) = decoder.read_info().unwrap();
-//!     // Allocate the output buffer.
-//!     let mut buf = vec![0; info.buffer_size()];
-//!     // Read the next frame. An APNG might contain multiple frames.
-//!     reader.next_frame(&mut buf).unwrap();
-//!     // Inspect more details of the last read frame.
-//!     let in_animation = reader.info().frame_control.is_some();
+//! ### Using the decoder
+//! ```
+//! use std::fs::File;
+//! // The decoder is a build for reader and can be used to set various decoding options
+//! // via `Transformations`. The default output transformation is `Transformations::EXPAND
+//! // | Transformations::STRIP_ALPHA`.
+//! let decoder = png::Decoder::new(File::open("tests/pngsuite/basi0g01.png").unwrap());
+//! let mut reader = decoder.read_info().unwrap();
+//! // Allocate the output buffer.
+//! let mut buf = vec![0; reader.output_buffer_size()];
+//! // Read the next frame. An APNG might contain multiple frames.
+//! let info = reader.next_frame(&mut buf).unwrap();
+//! // Grab the bytes of the image.
+//! let bytes = &buf[..info.buffer_size()];
+//! // Inspect more details of the last read frame.
+//! let in_animation = reader.info().frame_control.is_some();
+//! ```
+//!
 //! ## Encoder
 //! ### Using the encoder
+//!
 //! ```no_run
 //! // For reading and opening files
 //! use std::path::Path;
@@ -48,7 +57,6 @@
 //!
 //! let data = [255, 0, 0, 255, 0, 0, 0, 255]; // An array containing a RGBA sequence. First pixel is red and second pixel is black.
 //! writer.write_image_data(&data).unwrap(); // Save
-//! # }
 //! ```
 //!
 

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -101,9 +101,9 @@ fn render_images() {
     process_images("results.txt", &TEST_SUITES, |path| {
         let mut decoder = png::Decoder::new(File::open(path)?);
         decoder.set_transformations(png::Transformations::normalize_to_color8());
-        let (info, mut reader) = decoder.read_info()?;
-        let mut img_data = vec![0; info.buffer_size()];
-        reader.next_frame(&mut img_data)?;
+        let mut reader = decoder.read_info()?;
+        let mut img_data = vec![0; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut img_data)?;
         // First sanity check:
         assert_eq!(
             img_data.len(),
@@ -123,9 +123,9 @@ fn render_images() {
 fn render_images_identity() {
     process_images("results_identity.txt", &TEST_SUITES, |path| {
         let decoder = png::Decoder::new(File::open(&path)?);
-        let (info, mut reader) = decoder.read_info()?;
-        let mut img_data = vec![0; info.buffer_size()];
-        reader.next_frame(&mut img_data)?;
+        let mut reader = decoder.read_info()?;
+        let mut img_data = vec![0; reader.output_buffer_size()];
+        let info = reader.next_frame(&mut img_data)?;
         let bits = (info.width as usize * info.color_type.samples() * info.bit_depth as usize + 7
             & !7)
             * info.height as usize;
@@ -164,8 +164,8 @@ fn apng_images() {
 
         let mut decoder = png::Decoder::new(File::open(&path)?);
         decoder.set_transformations(png::Transformations::normalize_to_color8());
-        let (info, mut reader) = decoder.read_info()?;
-        let mut img_data = vec![0; info.buffer_size()];
+        let mut reader = decoder.read_info()?;
+        let mut img_data = vec![0; reader.output_buffer_size()];
         let real_frames = reader.info().animation_control().unwrap().num_frames;
         // Print out frame info, helps with blessing the result file for new images.
         println!(


### PR DESCRIPTION
Instead of returning it from `read_info`, where it can only contain information on the IHDR that is also contained in `Info`, we will now return it from `next_frame` and it is specific to that frame. This exposes the specific basic frame information that was actually used for that call.