### PR TITLE
Bump MSRV to 1.46 and release version 0.17.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust: ["1.34.2", stable, beta, nightly]
+        rust: ["1.46.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [""]
     runs-on: ${{ matrix.os }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+## 0.17.0
+
+* Increased MSRV to 1.46.0
+* Rework output info usage
+* Implement APNG encoding 
+* Improve ergonomics of encoder set_palette and set_trns methods
+* Make Info struct non-exhaustive 
+* Make encoder a core feature
+* Default Transformations to Identity
+* Add Adaptive filtering method for encoding 
+* Fix SCREAM_CASE on ColorType variants 
+* Forbid unsafe code
+
 ## 0.16.7
 
 * Added `Encoder::set_trns` to register a transparency table to be written.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.16.7"
+version = "0.17.0"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"


### PR DESCRIPTION
Our bitflags dependency [decided to bump their minimum supported Rust version](https://github.com/bitflags/bitflags/issues/255), so we must do the same.

Fixes #272 (which is long, long overdue)