### PR TITLE
Fix decoder default transformations documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,7 @@
 //! ```
 //! use std::fs::File;
 //! // The decoder is a build for reader and can be used to set various decoding options
-//! // via `Transformations`. The default output transformation is `Transformations::EXPAND
-//! // | Transformations::STRIP_ALPHA`.
+//! // via `Transformations`. The default output transformation is `Transformations::IDENTITY`.
 //! let decoder = png::Decoder::new(File::open("tests/pngsuite/basi0g01.png").unwrap());
 //! let mut reader = decoder.read_info().unwrap();
 //! // Allocate the output buffer.


### PR DESCRIPTION
The default transformation was changed to `IDENTITY` in version 0.17 but this part of the documentation was not updated.

The changelog and the documentation for `normalize_to_color8` both correctly state that the default value changed from version 0.16 to version 0.17.