### PR TITLE
Fix show example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ glob = "0.3"
 rand = "0.7.0"
 
 [dev-dependencies.glium]
-version = "0.24"
+version = "0.31"
 features = ["glutin"]
 default-features = false
 


### PR DESCRIPTION
The show example was not working. It would open and then close immediately with the following panic message:

```console
thread 'main' panicked at 'attempted to leave type `platform::platform::x11::util::input::PointerState` uninitialized, which is invalid', /home/michael/.cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.19.5/src/platform/linux/x11/util/input.rs:94:51
```

This is a known issue that has been fixed in newer versions of the `winit` crate. I had to upgrade the `glium` crate in order to get the newer version of `winit`. There were unfortunately API changes in the newer version, especially around the event loop. I've update the example to use the newer API. There were also changes in the default transformations in the `png` crate that had to be accounted for.