### PR TITLE
Use chunk type in `CrcMismatch` error

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -125,6 +125,7 @@ pub(crate) enum FormatErrorInner {
         crc_val: u32,
         /// Calculated CRC32 sum
         crc_sum: u32,
+        /// The chunk type that has the CRC mismatch.
         chunk: ChunkType,
     },
     /// Not a PNG, the magic signature is missing.
@@ -236,11 +237,14 @@ impl fmt::Display for FormatError {
         use FormatErrorInner::*;
         match &self.inner {
             CrcMismatch {
-                crc_val, crc_sum, ..
+                crc_val,
+                crc_sum,
+                chunk,
+                ..
             } => write!(
                 fmt,
-                "CRC error: expected 0x{:x} have 0x{:x}",
-                crc_val, crc_sum
+                "CRC error: expected 0x{:x} have 0x{:x} while decoding {:?} chunk.",
+                crc_val, crc_sum, chunk
             ),
             MissingIhdr => write!(fmt, "IHDR chunk missing"),
             MissingFctl => write!(fmt, "fcTL chunk missing before fdAT chunk."),


### PR DESCRIPTION
If there is a CRC mismatch, then it would be nice to know which chunk was corrupted. If, for example, the CRC mismatch is in a text chunk, then it would not be a great loss to the user and the image would most likely still be viewable. If, on the other hand, the CRC mismatch is in the image data chunk, then the image on the screen will be garbled to some degree. The user might in that case want to re-request the image from where they got it from.

Using the chunk type also fixes an unused field warning.