### PR TITLE
Move color/bit depths combination check

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -172,18 +172,6 @@ impl<R: Read> Decoder<R> {
         let mut reader = Reader::new(self.r, StreamingDecoder::new(), self.transform, self.limits);
         reader.init()?;
 
-        let color_type = reader.info().color_type;
-        let bit_depth = reader.info().bit_depth;
-        if color_type.is_combination_invalid(bit_depth) {
-            return Err(DecodingError::Format(
-                FormatErrorInner::InvalidColorBitDepth {
-                    color: color_type,
-                    depth: bit_depth,
-                }
-                .into(),
-            ));
-        }
-
         // Check if the output buffer can be represented at all.
         if reader.checked_output_buffer_size().is_none() {
             return Err(DecodingError::LimitsExceeded);
@@ -852,8 +840,8 @@ fn expand_paletted(buffer: &mut [u8], info: &Info) -> Result<(), DecodingError> 
             // This should have been caught earlier but let's check again. Can't hurt.
             Err(DecodingError::Format(
                 FormatErrorInner::InvalidColorBitDepth {
-                    color: ColorType::Indexed,
-                    depth: BitDepth::Sixteen,
+                    color_type: ColorType::Indexed,
+                    bit_depth: BitDepth::Sixteen,
                 }
                 .into(),
             ))

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -179,8 +179,8 @@ pub(crate) enum FormatErrorInner {
     PaletteRequired,
     /// The color-depth combination is not valid according to Table 11.1.
     InvalidColorBitDepth {
-        color: ColorType,
-        depth: BitDepth,
+        color_type: ColorType,
+        bit_depth: BitDepth,
     },
     ColorWithBadTrns(ColorType),
     InvalidBitDepth(u8),
@@ -265,10 +265,13 @@ impl fmt::Display for FormatError {
                 expected, len
             ),
             PaletteRequired => write!(fmt, "Missing palette of indexed image."),
-            InvalidColorBitDepth { color, depth } => write!(
+            InvalidColorBitDepth {
+                color_type,
+                bit_depth,
+            } => write!(
                 fmt,
                 "Invalid color/depth combination in header: {:?}/{:?}",
-                color, depth,
+                color_type, bit_depth,
             ),
             ColorWithBadTrns(color_type) => write!(
                 fmt,
@@ -1022,7 +1025,6 @@ impl StreamingDecoder {
     }
 
     fn parse_ihdr(&mut self) -> Result<Decoded, DecodingError> {
-        // TODO: check if color/bit depths combination is valid
         let mut buf = &self.current_chunk.raw_bytes[..];
         let width = buf.read_be()?;
         let height = buf.read_be()?;
@@ -1037,7 +1039,19 @@ impl StreamingDecoder {
         };
         let color_type = buf.read_be()?;
         let color_type = match ColorType::from_u8(color_type) {
-            Some(color_type) => color_type,
+            Some(color_type) => {
+                if color_type.is_combination_invalid(bit_depth) {
+                    return Err(DecodingError::Format(
+                        FormatErrorInner::InvalidColorBitDepth {
+                            color_type,
+                            bit_depth,
+                        }
+                        .into(),
+                    ));
+                } else {
+                    color_type
+                }
+            }
             None => {
                 return Err(DecodingError::Format(
                     FormatErrorInner::InvalidColorType(color_type).into(),


### PR DESCRIPTION
There was a TODO comment in the `parse_ihdr` method to check if the color/bit depths combination is valid. It turned out there was already a check for this in the `read_info` method. It makes more sense for all of the checks to be in one place, so I moved the check into the `parse_ihdr` method.

I also renamed the fields of the `InvalidColorBitDepth` error enum value to match their names in the rest of the code. That way the field names do not need to be named when constructing the `InvalidColorBitDepth` value. The type in not exposed publicly so it is not an API breaking change.