### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -460,6 +460,7 @@ impl SrgbRenderingIntent {
 
 /// PNG info struct
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Info<'a> {
     pub width: u32,
     pub height: u32,
@@ -491,8 +492,6 @@ pub struct Info<'a> {
     pub compressed_latin1_text: Vec<ZTXtChunk>,
     /// iTXt field
     pub utf8_text: Vec<ITXtChunk>,
-    /// Private field to mark the struct as non-exhaustive.
-    _extensible: (),
 }
 
 impl Default for Info<'_> {
@@ -518,7 +517,6 @@ impl Default for Info<'_> {
             uncompressed_latin1_text: Vec::new(),
             compressed_latin1_text: Vec::new(),
             utf8_text: Vec::new(),
-            _extensible: (),
         }
     }
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -554,7 +554,7 @@ impl<R: Read> Reader<R> {
         }
 
         // swap buffer to circumvent borrow issues
-        let mut buffer = mem::replace(&mut self.processed, Vec::new());
+        let mut buffer = mem::take(&mut self.processed);
         let (got_next, adam7) = if let Some(row) = self.next_raw_interlaced_row()? {
             (&mut buffer[..]).write_all(row.data)?;
             (true, row.interlace)

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1071,14 +1071,16 @@ impl StreamingDecoder {
                 ))
             }
         };
-        let mut info = Info::default();
 
-        info.width = width;
-        info.height = height;
-        info.bit_depth = bit_depth;
-        info.color_type = color_type;
-        info.interlaced = interlaced;
-        self.info = Some(info);
+        self.info = Some(Info {
+            width,
+            height,
+            bit_depth,
+            color_type,
+            interlaced,
+            ..Default::default()
+        });
+
         Ok(Decoded::Header(
             width, height, bit_depth, color_type, interlaced,
         ))
@@ -1088,7 +1090,7 @@ impl StreamingDecoder {
         let null_byte_index = buf
             .iter()
             .position(|&b| b == 0)
-            .ok_or(DecodingError::from(TextDecodingError::MissingNullSeparator))?;
+            .ok_or_else(|| DecodingError::from(TextDecodingError::MissingNullSeparator))?;
 
         if null_byte_index == 0 || null_byte_index > 79 {
             return Err(DecodingError::from(TextDecodingError::InvalidKeywordSize));
@@ -1102,9 +1104,11 @@ impl StreamingDecoder {
 
         let (keyword_slice, value_slice) = Self::split_keyword(buf)?;
 
-        self.info.as_mut().unwrap().uncompressed_latin1_text.push(
-            TEXtChunk::decode(keyword_slice, value_slice).map_err(|e| DecodingError::from(e))?,
-        );
+        self.info
+            .as_mut()
+            .unwrap()
+            .uncompressed_latin1_text
+            .push(TEXtChunk::decode(keyword_slice, value_slice).map_err(DecodingError::from)?);
 
         Ok(Decoded::Nothing)
     }
@@ -1114,15 +1118,15 @@ impl StreamingDecoder {
 
         let (keyword_slice, value_slice) = Self::split_keyword(buf)?;
 
-        let compression_method = *value_slice.get(0).ok_or(DecodingError::from(
-            TextDecodingError::InvalidCompressionMethod,
-        ))?;
+        let compression_method = *value_slice
+            .get(0)
+            .ok_or_else(|| DecodingError::from(TextDecodingError::InvalidCompressionMethod))?;
 
         let text_slice = &value_slice[1..];
 
         self.info.as_mut().unwrap().compressed_latin1_text.push(
             ZTXtChunk::decode(keyword_slice, compression_method, text_slice)
-                .map_err(|e| DecodingError::from(e))?,
+                .map_err(DecodingError::from)?,
         );
 
         Ok(Decoded::Nothing)
@@ -1195,18 +1199,18 @@ impl StreamingDecoder {
 
         let (keyword_slice, value_slice) = Self::split_keyword(buf)?;
 
-        let compression_flag = *value_slice.get(0).ok_or(DecodingError::from(
-            TextDecodingError::MissingCompressionFlag,
-        ))?;
+        let compression_flag = *value_slice
+            .get(0)
+            .ok_or_else(|| DecodingError::from(TextDecodingError::MissingCompressionFlag))?;
 
-        let compression_method = *value_slice.get(1).ok_or(DecodingError::from(
-            TextDecodingError::InvalidCompressionMethod,
-        ))?;
+        let compression_method = *value_slice
+            .get(1)
+            .ok_or_else(|| DecodingError::from(TextDecodingError::InvalidCompressionMethod))?;
 
         let second_null_byte_index = value_slice[2..]
             .iter()
             .position(|&b| b == 0)
-            .ok_or(DecodingError::from(TextDecodingError::MissingNullSeparator))?
+            .ok_or_else(|| DecodingError::from(TextDecodingError::MissingNullSeparator))?
             + 2;
 
         let language_tag_slice = &value_slice[2..second_null_byte_index];
@@ -1214,7 +1218,7 @@ impl StreamingDecoder {
         let third_null_byte_index = value_slice[second_null_byte_index + 1..]
             .iter()
             .position(|&b| b == 0)
-            .ok_or(DecodingError::from(TextDecodingError::MissingNullSeparator))?
+            .ok_or_else(|| DecodingError::from(TextDecodingError::MissingNullSeparator))?
             + (second_null_byte_index + 1);
 
         let translated_keyword_slice =
@@ -1231,7 +1235,7 @@ impl StreamingDecoder {
                 translated_keyword_slice,
                 text_slice,
             )
-            .map_err(|e| DecodingError::from(e))?,
+            .map_err(DecodingError::from)?,
         );
 
         Ok(Decoded::Nothing)

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -74,7 +74,7 @@ impl ZlibStream {
             decompress(
                 &mut self.state,
                 in_data,
-                &mut self.out_buffer.as_mut_slice(),
+                self.out_buffer.as_mut_slice(),
                 self.out_pos,
                 BASE_FLAGS,
             )
@@ -138,7 +138,7 @@ impl ZlibStream {
                 decompress(
                     &mut self.state,
                     &tail[start..],
-                    &mut self.out_buffer.as_mut_slice(),
+                    self.out_buffer.as_mut_slice(),
                     self.out_pos,
                     BASE_FLAGS,
                 )

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -274,7 +274,7 @@ pub(crate) fn filter(
             // values of each filtered buffer treating the bytes as signed
             // integers. Choose the filter with the smallest sum.
             let mut filtered_buffer = vec![0; len];
-            filtered_buffer.copy_from_slice(&current);
+            filtered_buffer.copy_from_slice(current);
             let mut scratch = vec![0; len];
 
             // Initialize min_sum with the NoFilter buffer sum
@@ -282,7 +282,7 @@ pub(crate) fn filter(
             let mut filter_choice = FilterType::NoFilter;
 
             for &filter in [Sub, Up, Avg, Paeth].iter() {
-                scratch.copy_from_slice(&current);
+                scratch.copy_from_slice(current);
                 filter_internal(filter, bpp, len, previous, &mut scratch);
                 let sum = sum_buffer(&scratch);
                 if sum < min_sum {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,7 +166,7 @@ impl Iterator for Adam7Iterator {
     }
 }
 
-fn subbyte_pixels<'a>(scanline: &'a [u8], bits_pp: usize) -> impl Iterator<Item = u8> + 'a {
+fn subbyte_pixels(scanline: &[u8], bits_pp: usize) -> impl Iterator<Item = u8> + '_ {
     (0..scanline.len() * 8)
         .step_by(bits_pp)
         .map(move |bit_idx| {


### PR DESCRIPTION
There were 27 clippy warnings that were pretty self-explanatory. You can run `cargo clippy` if you want the details of each change.

I'm happy to break it up into multiple pull request with each category of warnings by themselves if needed.