### PR TITLE
Assign instead of `replace`

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -562,7 +562,7 @@ impl<R: Read> Reader<R> {
             (false, InterlaceInfo::Null)
         };
         // swap back
-        let _ = mem::replace(&mut self.processed, buffer);
+        self.processed = buffer;
 
         if !got_next {
             return Ok(None);


### PR DESCRIPTION
Use `swap` to swap the buffers instead of `replace`. It makes more sense and there is no return value that needs to be ignored.