### PR TITLE
Support ignore text chunk while decode

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,8 +1,8 @@
 mod stream;
 mod zlib;
 
-pub use self::stream::{Decoded, DecodingError, StreamingDecoder};
 use self::stream::{DecodeConfig, FormatErrorInner, CHUNCK_BUFFER_SIZE};
+pub use self::stream::{Decoded, DecodingError, StreamingDecoder};
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::mem;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -2,7 +2,7 @@ mod stream;
 mod zlib;
 
 pub use self::stream::{Decoded, DecodingError, StreamingDecoder};
-use self::stream::{FormatErrorInner, CHUNCK_BUFFER_SIZE};
+use self::stream::{DecodeConfig, FormatErrorInner, CHUNCK_BUFFER_SIZE};
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::mem;
@@ -75,8 +75,7 @@ pub struct Decoder<R: Read> {
     transform: Transformations,
     /// Limits on resources the Decoder is allowed to use
     limits: Limits,
-    /// Ignore text chunk when decode
-    ignore_text_chunk: bool,
+    decode_config: DecodeConfig,
 }
 
 /// A row of data with interlace information attached.
@@ -139,7 +138,7 @@ impl<R: Read> Decoder<R> {
             r,
             transform: Transformations::IDENTITY,
             limits,
-            ignore_text_chunk: false,
+            decode_config: DecodeConfig::default(),
         }
     }
 
@@ -170,18 +169,12 @@ impl<R: Read> Decoder<R> {
         self.limits = limits;
     }
 
-    /// Ignore parse text(text/ztxt/itxt) chunk while read meta data
-    pub fn ignore_text_chunk(&mut self) {
-        self.ignore_text_chunk = true;
-    }
-
     /// Reads all meta data until the first IDAT chunk
     pub fn read_info(self) -> Result<Reader<R>, DecodingError> {
-        let mut decoder = StreamingDecoder::new();
-        if self.ignore_text_chunk {
-            decoder.ignore_text_chunk();
-        }
-        let mut reader = Reader::new(self.r, decoder, self.transform, self.limits);
+        let mut streaming_decoder = StreamingDecoder::new();
+        streaming_decoder.set_decode_config(self.decode_config);
+
+        let mut reader = Reader::new(self.r, streaming_decoder, self.transform, self.limits);
         reader.init()?;
 
         // Check if the output buffer can be represented at all.
@@ -198,6 +191,20 @@ impl<R: Read> Decoder<R> {
     /// Many options have an impact on memory or CPU usage during decoding.
     pub fn set_transformations(&mut self, transform: Transformations) {
         self.transform = transform;
+    }
+
+    /// Set the decoder to ignore all text chunks while parsing.
+    ///
+    /// eg.
+    /// ```
+    /// use std::fs::File;
+    /// use png::Decoder;
+    /// let mut decoder = Decoder::new(File::open("tests/pngsuite/basi0g01.png").unwrap());
+    /// decoder.set_ignore_text_chunk(true);
+    /// assert!(decoder.read_info().is_ok());
+    /// ```
+    pub fn set_ignore_text_chunk(&mut self, ignore_text_chunk: bool) {
+        self.decode_config.set_ignore_text_chunk(ignore_text_chunk);
     }
 }
 


### PR DESCRIPTION
I find some png convert from jpeg may keep "EXIF" info into text chunk, but use the wrong way. This will make the whole parsing fail.

Most of the time, I don't use text chunks, so I add a ignore text chunk config, but not sure it is a common need.