### PR TITLE
Implement `Default` trait for `Compression`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -327,6 +327,12 @@ pub enum Compression {
     Rle,
 }
 
+impl Default for Compression {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 /// An unsigned integer scaled version of a floating point value,
 /// equivalent to an integer quotient with fixed denominator (100_000)).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Implements the Default trait for `common::Compression`, which just returns `Compression::Default`. 

I chose to stick with not using the new `#[default]` since that is a relatively new feature and would likely increase the MSRV