### PR TITLE
Remove setting trns on rgba image in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,6 @@
 //! let mut encoder = png::Encoder::new(w, 2, 1); // Width is 2 pixels and height is 1.
 //! encoder.set_color(png::ColorType::Rgba);
 //! encoder.set_depth(png::BitDepth::Eight);
-//! encoder.set_trns(vec!(0xFFu8, 0xFFu8, 0xFFu8, 0xFFu8));
 //! encoder.set_source_gamma(png::ScaledFloat::from_scaled(45455)); // 1.0 / 2.2, scaled by 100000
 //! encoder.set_source_gamma(png::ScaledFloat::new(1.0 / 2.2));     // 1.0 / 2.2, unscaled, but rounded
 //! let source_chromaticities = png::SourceChromaticities::new(     // Using unscaled instantiation here


### PR DESCRIPTION
The documentation sets trns for an rgba image, which then fails when trying to decode with 
`FormatError { inner: ColorWithBadTrns(Rgba) }`
from:
https://github.com/image-rs/image-png/blob/master/src/decoder/stream.rs#L893