### PR TITLE
Reuse some buffers and apply clippy fixes

### DIFF
--- a/benches/decoder.rs
+++ b/benches/decoder.rs
@@ -4,16 +4,14 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use png::Decoder;
 
 fn load_all(c: &mut Criterion) {
-    for file in fs::read_dir("tests/benches/").unwrap() {
-        if let Ok(entry) = file {
-            match entry.path().extension() {
-                Some(st) if st == "png" => {}
-                _ => continue,
-            }
-
-            let data = fs::read(entry.path()).unwrap();
-            bench_file(c, data, entry.file_name().into_string().unwrap());
+    for entry in fs::read_dir("tests/benches/").unwrap().flatten() {
+        match entry.path().extension() {
+            Some(st) if st == "png" => {}
+            _ => continue,
         }
+
+        let data = fs::read(entry.path()).unwrap();
+        bench_file(c, data, entry.file_name().into_string().unwrap());
     }
 }
 

--- a/examples/png-generate.rs
+++ b/examples/png-generate.rs
@@ -1,6 +1,8 @@
 // For reading and opening files
 use png::text_metadata::{ITXtChunk, ZTXtChunk};
-use std::{env, fs::File, io::BufWriter};
+use std::env;
+use std::fs::File;
+use std::io::BufWriter;
 
 fn main() {
     let path = env::args()

--- a/examples/png-generate.rs
+++ b/examples/png-generate.rs
@@ -1,16 +1,13 @@
 // For reading and opening files
-use png;
 use png::text_metadata::{ITXtChunk, ZTXtChunk};
-use std::env;
-use std::fs::File;
-use std::io::BufWriter;
+use std::{env, fs::File, io::BufWriter};
 
 fn main() {
     let path = env::args()
         .nth(1)
         .expect("Expected a filename to output to.");
     let file = File::create(path).unwrap();
-    let ref mut w = BufWriter::new(file);
+    let w = &mut BufWriter::new(file);
 
     let mut encoder = png::Encoder::new(w, 2, 1); // Width is 2 pixels and height is 1.
     encoder.set_color(png::ColorType::Rgba);

--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -4,7 +4,11 @@ extern crate getopts;
 extern crate glob;
 extern crate png;
 
-use std::{env, fs::File, io, io::prelude::*, path::Path};
+use std::env;
+use std::fs::File;
+use std::io;
+use std::io::prelude::*;
+use std::path::Path;
 
 use getopts::{Matches, Options, ParsingStyle};
 use term::{color, Attr};

--- a/examples/show.rs
+++ b/examples/show.rs
@@ -51,7 +51,7 @@ fn load_image(path: &path::PathBuf) -> io::Result<RawImage2d<'static, u8>> {
         data: Cow::Owned(data),
         width: info.width,
         height: info.height,
-        format: format,
+        format,
     })
 }
 
@@ -152,9 +152,6 @@ fn resize_window(display: &Display, image: &RawImage2d<'static, u8>) {
     if width < 50 && height < 50 {
         width *= 10;
         height *= 10;
-    } else if width < 5 && height < 5 {
-        width *= 10;
-        height *= 10;
     }
     display
         .gl_window()
@@ -169,9 +166,9 @@ fn main() {
     } else {
         let mut files = vec![];
         for file in args.iter().skip(1) {
-            match if file.contains("*") {
+            match if file.contains('*') {
                 (|| -> io::Result<_> {
-                    for entry in glob::glob(&file)
+                    for entry in glob::glob(file)
                         .map_err(|err| io::Error::new(io::ErrorKind::Other, err.msg))?
                     {
                         files.push(

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,8 @@
 //! Common types shared between the encoder and decoder
-use crate::text_metadata::{EncodableTextChunk, ITXtChunk, TEXtChunk, ZTXtChunk};
-use crate::{chunk, encoder};
+use crate::{
+    chunk, encoder,
+    text_metadata::{EncodableTextChunk, ITXtChunk, TEXtChunk, ZTXtChunk},
+};
 use io::Write;
 use std::{borrow::Cow, convert::TryFrom, fmt, io};
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,8 +1,6 @@
 //! Common types shared between the encoder and decoder
-use crate::{
-    chunk, encoder,
-    text_metadata::{EncodableTextChunk, ITXtChunk, TEXtChunk, ZTXtChunk},
-};
+use crate::text_metadata::{EncodableTextChunk, ITXtChunk, TEXtChunk, ZTXtChunk};
+use crate::{chunk, encoder};
 use io::Write;
 use std::{borrow::Cow, convert::TryFrom, fmt, io};
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -4,18 +4,16 @@ mod zlib;
 use self::stream::{DecodeConfig, FormatErrorInner, CHUNCK_BUFFER_SIZE};
 pub use self::stream::{Decoded, DecodingError, StreamingDecoder};
 
-use std::{
-    io::{BufRead, BufReader, Read, Write},
-    mem,
-    ops::Range,
-};
+use std::io::{BufRead, BufReader, Read, Write};
+use std::mem;
+use std::ops::Range;
 
-use crate::{
-    chunk,
-    common::{BitDepth, BytesPerPixel, ColorType, Info, ParameterErrorKind, Transformations},
-    filter::{unfilter, FilterType},
-    utils,
+use crate::chunk;
+use crate::common::{
+    BitDepth, BytesPerPixel, ColorType, Info, ParameterErrorKind, Transformations,
 };
+use crate::filter::{unfilter, FilterType};
+use crate::utils;
 
 /*
 pub enum InterlaceHandling {
@@ -428,9 +426,13 @@ impl<R: Read> Reader<R> {
             self.subframe = SubframeInfo::new(info);
         }
         self.allocate_out_buf()?;
+
+        // Instead of allocating a new buffer for prev, we simply clear and
+        // reuse the buffer we used for chunk decoding.
         buf.clear();
         buf.resize(self.subframe.rowlen, 0);
         self.prev = buf;
+
         Ok(self.output_info())
     }
 
@@ -949,10 +951,8 @@ fn expand_gray_u8(buffer: &mut [u8], info: &Info) {
 #[cfg(test)]
 mod tests {
     use super::Decoder;
-    use std::{
-        io::{BufRead, Read, Result},
-        mem::discriminant,
-    };
+    use std::io::{BufRead, Read, Result};
+    use std::mem::discriminant;
 
     /// A reader that reads at most `n` bytes.
     struct SmalBuf<R: BufRead> {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,19 +1,22 @@
 extern crate crc32fast;
 
-use std::{borrow::Cow, cmp::min, convert::From, default::Default, error, fmt, io};
+use std::convert::From;
+use std::default::Default;
+use std::error;
+use std::fmt;
+use std::io;
+use std::{borrow::Cow, cmp::min};
 
 use crc32fast::Hasher as Crc32;
 
 use super::zlib::ZlibStream;
-use crate::{
-    chunk::{self, ChunkType, IDAT, IEND, IHDR},
-    common::{
-        AnimationControl, BitDepth, BlendOp, ColorType, DisposeOp, FrameControl, Info,
-        ParameterError, PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
-    },
-    text_metadata::{ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk},
-    traits::ReadBytesExt,
+use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
+use crate::common::{
+    AnimationControl, BitDepth, BlendOp, ColorType, DisposeOp, FrameControl, Info, ParameterError,
+    PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
 };
+use crate::text_metadata::{ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk};
+use crate::traits::ReadBytesExt;
 
 /// TODO check if these size are reasonable
 pub const CHUNCK_BUFFER_SIZE: usize = 32 * 1024;
@@ -1279,7 +1282,8 @@ impl Default for ChunkState {
 
 #[cfg(test)]
 mod tests {
-    use super::{ScaledFloat, SourceChromaticities};
+    use super::ScaledFloat;
+    use super::SourceChromaticities;
     use std::fs::File;
 
     #[test]

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -6,16 +6,16 @@ use std::{borrow, error, fmt, io, mem, ops, result};
 use crc32fast::Hasher as Crc32;
 use flate2::write::ZlibEncoder;
 
-use crate::{
-    chunk::{self, ChunkType},
-    common::{
-        AnimationControl, BitDepth, BlendOp, BytesPerPixel, ColorType, Compression, DisposeOp,
-        FrameControl, Info, ParameterError, ParameterErrorKind, ScaledFloat,
-    },
-    filter::{filter, AdaptiveFilterType, FilterType},
-    text_metadata::{EncodableTextChunk, ITXtChunk, TEXtChunk, TextEncodingError, ZTXtChunk},
-    traits::WriteBytesExt,
+use crate::chunk::{self, ChunkType};
+use crate::common::{
+    AnimationControl, BitDepth, BlendOp, BytesPerPixel, ColorType, Compression, DisposeOp,
+    FrameControl, Info, ParameterError, ParameterErrorKind, ScaledFloat,
 };
+use crate::filter::{filter, AdaptiveFilterType, FilterType};
+use crate::text_metadata::{
+    EncodableTextChunk, ITXtChunk, TEXtChunk, TextEncodingError, ZTXtChunk,
+};
+use crate::traits::WriteBytesExt;
 
 pub type Result<T> = result::Result<T, EncodingError>;
 
@@ -1671,12 +1671,9 @@ mod tests {
     use crate::Decoder;
 
     use rand::{thread_rng, Rng};
-    use std::{
-        cmp,
-        fs::File,
-        io,
-        io::{Cursor, Write},
-    };
+    use std::fs::File;
+    use std::io::{Cursor, Write};
+    use std::{cmp, io};
 
     #[test]
     fn roundtrip() {

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -2,12 +2,11 @@ extern crate crc32fast;
 extern crate glob;
 extern crate png;
 
-use std::{
-    collections::BTreeMap,
-    fs::File,
-    io::{prelude::*, BufReader},
-    path::{Component, Path, PathBuf},
-};
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::BufReader;
+use std::path::{Component, Path, PathBuf};
 
 use crc32fast::Hasher as Crc32;
 

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -2,19 +2,20 @@ extern crate crc32fast;
 extern crate glob;
 extern crate png;
 
-use std::collections::BTreeMap;
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::BufReader;
-use std::path::{Component, Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{prelude::*, BufReader},
+    path::{Component, Path, PathBuf},
+};
 
 use crc32fast::Hasher as Crc32;
 
-const BASE_PATH: [&'static str; 2] = [".", "tests"];
-const TEST_SUITES: [&'static str; 3] = ["pngsuite", "pngsuite-extra", "bugfixes"];
-const APNG_SUITES: [&'static str; 1] = ["animated"];
+const BASE_PATH: [&str; 2] = [".", "tests"];
+const TEST_SUITES: [&str; 3] = ["pngsuite", "pngsuite-extra", "bugfixes"];
+const APNG_SUITES: [&str; 1] = ["animated"];
 
-fn process_images<F>(results_path: &str, test_suites: &[&'static str], func: F)
+fn process_images<F>(results_path: &str, test_suites: &[&str], func: F)
 where
     F: Fn(PathBuf) -> Result<u32, png::DecodingError>,
 {
@@ -34,7 +35,7 @@ where
                     results.insert(format!("{}", path.display()), format!("{}", crc));
                     println!("{}", crc)
                 }
-                Err(_) if path.file_name().unwrap().to_str().unwrap().starts_with("x") => {
+                Err(_) if path.file_name().unwrap().to_str().unwrap().starts_with('x') => {
                     expected_failures.push(format!("{}", path.display()));
                     println!("Expected failure")
                 }
@@ -42,7 +43,7 @@ where
             }
         }
     }
-    let mut path = base.clone();
+    let mut path = base;
     path.push(results_path);
     let mut ref_results = BTreeMap::new();
     let mut failures = vec![];
@@ -85,10 +86,9 @@ where
     );
     for (path, crc) in results.iter() {
         assert_eq!(
-            ref_results.get(path).expect(&format!(
-                "reference for {} is missing, expected {}",
-                path, crc
-            )),
+            ref_results
+                .get(path)
+                .unwrap_or_else(|| panic!("reference for {} is missing, expected {}", path, crc)),
             crc,
             "{}",
             path
@@ -126,9 +126,9 @@ fn render_images_identity() {
         let mut reader = decoder.read_info()?;
         let mut img_data = vec![0; reader.output_buffer_size()];
         let info = reader.next_frame(&mut img_data)?;
-        let bits = (info.width as usize * info.color_type.samples() * info.bit_depth as usize + 7
-            & !7)
-            * info.height as usize;
+        let bits =
+            ((info.width as usize * info.color_type.samples() * info.bit_depth as usize + 7) & !7)
+                * info.height as usize;
         // First sanity check:
         assert_eq!(
             img_data.len() * 8,


### PR DESCRIPTION
This reuses some buffers that have previously been deallocated in each loop iteration. Additionally clippy has been showing me a bunch of warnings that I haved fixed as well.