### PR TITLE
Warn instead of crashing on duplicate iCCP chunk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bitflags = "1.0"
 crc32fast = "1.2.0"
 flate2 = "1.0"
 miniz_oxide = "0.6.0"
+log = "0.4.17"
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1031,11 +1031,11 @@ impl StreamingDecoder {
             Err(DecodingError::Format(
                 FormatErrorInner::AfterIdat { kind: chunk::iCCP }.into(),
             ))
-        } else if info.icc_profile.is_some() {
-            return Err(DecodingError::Format(
-                FormatErrorInner::DuplicateChunk { kind: chunk::iCCP }.into(),
-            ));
         } else {
+            if info.icc_profile.is_some() {
+                log::warn!("iCCP chunks must appear at most once");
+            }
+
             let mut buf = &self.current_chunk.raw_bytes[..];
 
             // read profile name


### PR DESCRIPTION
Fixes https://github.com/image-rs/image/issues/1825

Before:
```rust
     Running `target/debug/test_rust`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Format(FormatError { inner: DuplicateChunk { kind: ChunkType { type: iCCP, critical: false, private: false, reserved: false, safecopy: false } } })', src/main.rs:6966:42
```

After (using env_logger):
```rust
     Running `target/debug/test_rust`
[2022-11-21T12:00:04Z WARN  png::decoder::stream] iCCP chunks must appear at most once
```

Should other kinds of duplicate chunks be converted into warnings too?