### PR TITLE
Drastically improve encoding performance 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust: ["1.54.0", stable, beta, nightly]
+        rust: ["1.57.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [""]
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 [dependencies]
 bitflags = "1.0"
 crc32fast = "1.2.0"
-fdeflate = "0.1.0"
+fdeflate = "0.2.0"
 flate2 = "1.0"
 miniz_oxide = "0.6.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 [dependencies]
 bitflags = "1.0"
 crc32fast = "1.2.0"
+fdeflate = "0.1.0"
 flate2 = "1.0"
 miniz_oxide = "0.6.0"
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -668,27 +668,55 @@ impl<W: Write> Writer<W> {
 
         let prev = vec![0; in_len];
         let mut prev = prev.as_slice();
-        let mut current = vec![0; in_len];
 
-        let mut zlib = ZlibEncoder::new(Vec::new(), self.info.compression.to_options());
         let bpp = self.info.bpp_in_prediction();
         let filter_method = self.options.filter;
         let adaptive_method = self.options.adaptive_filter;
 
-        for line in data.chunks(in_len) {
-            let filter_type = filter(
-                filter_method,
-                adaptive_method,
-                bpp,
-                prev,
-                &line,
-                &mut current,
-            );
-            zlib.write_all(&[filter_type as u8])?;
-            zlib.write_all(&current)?;
-            prev = line;
-        }
-        let zlib_encoded = zlib.finish()?;
+        let zlib_encoded = match self.info.compression {
+            Compression::Fast => {
+                let mut compressor = fdeflate::Compressor::new(std::io::Cursor::new(Vec::new()));
+                compressor.write_headers()?;
+
+                let mut current = vec![0; in_len + 1];
+                for line in data.chunks(in_len) {
+                    let filter_type = filter(
+                        filter_method,
+                        adaptive_method,
+                        bpp,
+                        prev,
+                        line,
+                        &mut current[1..],
+                    );
+
+                    current[0] = filter_type as u8;
+                    compressor.write_data(&current)?;
+                    prev = line;
+                }
+
+                compressor.finish()?.into_inner()
+            }
+            _ => {
+                let mut current = vec![0; in_len];
+
+                let mut zlib = ZlibEncoder::new(Vec::new(), self.info.compression.to_options());
+                for line in data.chunks(in_len) {
+                    let filter_type = filter(
+                        filter_method,
+                        adaptive_method,
+                        bpp,
+                        prev,
+                        line,
+                        &mut current,
+                    );
+
+                    zlib.write_all(&[filter_type as u8])?;
+                    zlib.write_all(&current)?;
+                    prev = line;
+                }
+                zlib.finish()?
+            }
+        };
 
         match self.info.frame_control {
             None => {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -697,6 +697,13 @@ impl<W: Write> Writer<W> {
                 if compressed.len()
                     > fdeflate::StoredOnlyCompressor::<()>::compressed_size((in_len + 1) * height)
                 {
+                    // Write uncompressed data since the result from fast compression would take
+                    // more space than that.
+                    //
+                    // We always use FilterType::NoFilter here regardless of the filter method
+                    // requested by the user. Doing filtering again would only add performance
+                    // cost for both encoding and subsequent decoding, without improving the
+                    // compression ratio.
                     let mut compressor =
                         fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(Vec::new()))?;
                     for line in data.chunks(in_len) {


### PR DESCRIPTION
The goal of this PR is to achieve faster-than-QOI encoding performance. It adds a custom zlib implementation that leverages assumptions about the patterns in PNG data to get reasonable compression ratios at phenomenal speeds. Takes inspiration from [fpng](https://github.com/richgel999/fpng) and [fpnge](https://github.com/veluca93/fpnge).

Builds on #363 and improves performance by several _times_...
```
Directory                                     Ratio             Encode                    Decode
---------                                    -------     --------------------      --------------------
Total                                        28.282%     294 mps   0.99 GiB/s       53 mps   0.18 GiB/s
```

qoibench on the same machine...
```
# Grand total for qoi_benchmark_suite/images/
        decode ms   encode ms   decode mpps   encode mpps   size kb    rate
libpng:       5.3        69.6         87.49          6.67       398   24.2%
stbi:         4.6        39.7        100.63         11.70       561   34.2%
qoi:          1.5         2.0        308.68        227.88       463   28.2%

```