### PR TITLE
Improve corpus-bench benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,16 +27,13 @@ flate2 = "1.0"
 miniz_oxide = "0.6.0"
 
 [dev-dependencies]
+clap = { version = "4.0.32", features = ["derive"] }
 criterion = "0.3.1"
 getopts = "0.2.14"
-term = "0.7"
+glium = { version = "0.32", features = ["glutin"], default-features = false }
 glob = "0.3"
 rand = "0.8.4"
-
-[dev-dependencies.glium]
-version = "0.31"
-features = ["glutin"]
-default-features = false
+term = "0.7"
 
 [features]
 unstable = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ flate2 = "1.0"
 miniz_oxide = "0.6.0"
 
 [dev-dependencies]
-clap = { version = "4.0.32", features = ["derive"] }
+clap = { version = "3.0", features = ["derive"] }
 criterion = "0.3.1"
 getopts = "0.2.14"
 glium = { version = "0.32", features = ["glutin"], default-features = false }

--- a/examples/corpus-bench.rs
+++ b/examples/corpus-bench.rs
@@ -23,9 +23,9 @@ enum Filter {
 #[derive(clap::Parser)]
 struct Args {
     directory: Option<PathBuf>,
-    #[arg(short, long, value_enum, default_value_t = Speed::Fast)]
+    #[clap(short, long, value_enum, default_value_t = Speed::Fast)]
     speed: Speed,
-    #[arg(short, long, value_enum, default_value_t = Filter::Adaptive)]
+    #[clap(short, long, value_enum, default_value_t = Filter::Adaptive)]
     filter: Filter,
 }
 

--- a/examples/corpus-bench.rs
+++ b/examples/corpus-bench.rs
@@ -2,6 +2,31 @@ use std::{env, fs, path::PathBuf};
 
 use png::Decoder;
 
+#[inline(never)]
+fn run_encode(
+    dimensions: (u32, u32),
+    color_type: png::ColorType,
+    bit_depth: png::BitDepth,
+    image: &[u8],
+) -> Vec<u8> {
+    let mut reencoded = Vec::new();
+    let mut encoder = png::Encoder::new(&mut reencoded, dimensions.0, dimensions.1);
+    encoder.set_color(color_type);
+    encoder.set_depth(bit_depth);
+    encoder.set_compression(png::Compression::Fast);
+    encoder.set_filter(png::FilterType::Paeth);
+    let mut encoder = encoder.write_header().unwrap();
+    encoder.write_image_data(&image).unwrap();
+    encoder.finish().unwrap();
+    reencoded
+}
+
+#[inline(never)]
+fn run_decode(image: &[u8], output: &mut [u8]) {
+    let mut reader = Decoder::new(image).read_info().unwrap();
+    reader.next_frame(output).unwrap();
+}
+
 fn main() {
     let mut total_uncompressed = 0;
     let mut total_compressed = 0;
@@ -17,6 +42,8 @@ fn main() {
         "{:45}-------     --------------------      --------------------",
         "---------"
     );
+
+    let mut image2 = Vec::new();
 
     let mut pending = vec![PathBuf::from(env::args().nth(1).unwrap_or(".".to_string()))];
     while let Some(directory) = pending.pop() {
@@ -43,7 +70,9 @@ fn main() {
             if decoder.read_header_info().ok().map(|h| h.color_type)
                 == Some(png::ColorType::Indexed)
             {
-                decoder.set_transformations(png::Transformations::EXPAND);
+                decoder.set_transformations(
+                    png::Transformations::EXPAND | png::Transformations::STRIP_16,
+                );
             }
             let mut reader = match decoder.read_info() {
                 Ok(reader) => reader,
@@ -55,27 +84,32 @@ fn main() {
                 Err(_) => continue,
             };
             let (width, height) = (info.width, info.height);
-            let color_type = info.color_type;
             let bit_depth = info.bit_depth;
+            let mut color_type = info.color_type;
+
+            // qoibench expands grayscale to RGB, so we do the same.
+            if bit_depth == png::BitDepth::Eight {
+                if color_type == png::ColorType::Grayscale {
+                    image = image.into_iter().flat_map(|v| [v, v, v, 255]).collect();
+                    color_type = png::ColorType::Rgba;
+                } else if color_type == png::ColorType::GrayscaleAlpha {
+                    image = image
+                        .chunks_exact(2)
+                        .flat_map(|v| [v[0], v[0], v[0], v[1]])
+                        .collect();
+                    color_type = png::ColorType::Rgba;
+                }
+            }
 
             // Re-encode
             let start = std::time::Instant::now();
-            let mut reencoded = Vec::new();
-            let mut encoder = png::Encoder::new(&mut reencoded, width, height);
-            encoder.set_color(color_type);
-            encoder.set_depth(bit_depth);
-            encoder.set_compression(png::Compression::Fast);
-            encoder.set_filter(png::FilterType::Paeth);
-            encoder.set_adaptive_filter(png::AdaptiveFilterType::Adaptive);
-            let mut encoder = encoder.write_header().unwrap();
-            encoder.write_image_data(&image).unwrap();
-            encoder.finish().unwrap();
+            let reencoded = run_encode((width, height), color_type, bit_depth, &image);
             let elapsed = start.elapsed().as_nanos() as u64;
 
+            // And decode again
+            image2.resize(image.len(), 0);
             let start2 = std::time::Instant::now();
-            let mut reader = Decoder::new(&*reencoded).read_info().unwrap();
-            let mut image2 = vec![0; reader.output_buffer_size()];
-            reader.next_frame(&mut image2).unwrap();
+            run_decode(&reencoded, &mut image2);
             let elapsed2 = start2.elapsed().as_nanos() as u64;
 
             assert_eq!(image, image2);
@@ -108,7 +142,7 @@ fn main() {
 
     println!();
     println!(
-        "{:44}{:7.3}%{:8} mps {:6.2} GiB/s {:8} mps {:6.2} GiB/s",
+        "{:44}{:7.3}%{:8} mps {:6.3} GiB/s {:8} mps {:6.3} GiB/s",
         "Total",
         100.0 * total_compressed as f64 / total_uncompressed as f64,
         total_pixels * 1000 / total_encode_time,


### PR DESCRIPTION
* Factors out `run_encode` and `run_decode` into independent functions, making it easier to inspect performance in a profiler. 
* Changes decoding to write into a pre-allocated buffer.
* Extra decimal place in the reported bandwidth numbers.