### PR TITLE
Optimize adaptive filtering

### DIFF
--- a/examples/corpus-bench.rs
+++ b/examples/corpus-bench.rs
@@ -66,6 +66,7 @@ fn main() {
             encoder.set_depth(bit_depth);
             encoder.set_compression(png::Compression::Fast);
             encoder.set_filter(png::FilterType::Paeth);
+            encoder.set_adaptive_filter(png::AdaptiveFilterType::Adaptive);
             let mut encoder = encoder.write_header().unwrap();
             encoder.write_image_data(&image).unwrap();
             encoder.finish().unwrap();


### PR DESCRIPTION
Optimizations to `sum_buffer` suggested by @okaneco [in this comment](https://github.com/image-rs/image-png/pull/374#issuecomment-1368156984).

On my machine this PR results in a 2.8x end-to-end performance increase when encoding PNGs with adaptive filtering:
```
$ cargo run --example corpus-bench --release qoi_benchmark_suite
existing       83 mps   0.28 GiB/s
this PR       232 mps   0.79 GiB/s
