### PR TITLE
Autovectorize paeth unfiltering

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -95,7 +95,7 @@ pub enum BitDepth {
 /// This is used for filtering which never uses sub-byte units. This essentially reduces the number
 /// of possible byte chunk lengths to a very small set of values appropriate to be defined as an
 /// enum.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub(crate) enum BytesPerPixel {
     One = 1,


### PR DESCRIPTION
Unfiltering paeth image data is particularly tricky because each pixel depends on both the pixel above and to the right. This PR adds a `unfilter_paeth_strip` method which processes 8 consecutive paeth filtered rows at a time, along with a bunch of rather messy bookkeeping to properly call it.

```
$ cargo run --example corpus-bench --release qoi_benchmark_suite

main   55 mps   0.19 GiB/s
PR     92 mps   0.31 GiB/s
```

The trick is that it processes pixels along a diagonal swatch of the strip. (I'll include some diagram/explanation like this in the final PR)
```
P = previous row passed as input
X = computed serially at start
. = first swatch processed with SIMD
0 = computed serially at end 

prev [PPPPPPPPPPPPPPPPPPPPPPPP]
row0 [XXXXXXXX.               ]
row1 [XXXXXXX.               0]
row2 [XXXXXX.               00]
row3 [XXXXX.               000]
row4 [XXXX.               0000]
row5 [XXX.               00000]
row6 [XX.               000000]
row7 [X.               0000000]
```

