### PR TITLE
Simplify Paeth decode filter, fix remaining lib clippy lints

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -365,14 +365,12 @@ impl ScaledFloat {
     /// Slightly inaccurate scaling and quantization.
     /// Clamps the value into the representable range if it is negative or too large.
     pub fn new(value: f32) -> Self {
-        Self {
-            0: Self::forward(value),
-        }
+        Self(Self::forward(value))
     }
 
     /// Fully accurate construction from a value scaled as per specification.
     pub fn from_scaled(val: u32) -> Self {
-        Self { 0: val }
+        Self(val)
     }
 
     /// Get the accurate encoded value.
@@ -382,7 +380,7 @@ impl ScaledFloat {
 
     /// Get the unscaled value as a floating point.
     pub fn into_value(self) -> f32 {
-        Self::reverse(self.0) as f32
+        Self::reverse(self.0)
     }
 
     pub(crate) fn encode_gama<W: Write>(self, w: &mut W) -> encoder::Result<()> {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -605,9 +605,9 @@ impl<R: Read> Reader<R> {
                     let channels = color_type.samples();
                     let trns = get_info!(self).trns.as_ref().unwrap();
                     if bit_depth == 8 {
-                        utils::expand_trns_line(output_buffer, &*trns, channels);
+                        utils::expand_trns_line(output_buffer, trns, channels);
                     } else {
-                        utils::expand_trns_line16(output_buffer, &*trns, channels);
+                        utils::expand_trns_line16(output_buffer, trns, channels);
                     }
                 }
                 _ => (),

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1187,7 +1187,7 @@ impl StreamingDecoder {
         let (keyword_slice, value_slice) = Self::split_keyword(buf)?;
 
         let compression_method = *value_slice
-            .get(0)
+            .first()
             .ok_or_else(|| DecodingError::from(TextDecodingError::InvalidCompressionMethod))?;
 
         let text_slice = &value_slice[1..];
@@ -1206,7 +1206,7 @@ impl StreamingDecoder {
         let (keyword_slice, value_slice) = Self::split_keyword(buf)?;
 
         let compression_flag = *value_slice
-            .get(0)
+            .first()
             .ok_or_else(|| DecodingError::from(TextDecodingError::MissingCompressionFlag))?;
 
         let compression_method = *value_slice

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -149,7 +149,7 @@ impl ZlibStream {
 
             match status {
                 TINFLStatus::Done => {
-                    self.out_buffer.truncate(self.out_pos as usize);
+                    self.out_buffer.truncate(self.out_pos);
                     image_data.append(&mut self.out_buffer);
                     return Ok(());
                 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1100,12 +1100,11 @@ impl<'a, W: Write> ChunkWriter<'a, W> {
         // TODO (maybe): find a way to hold two chunks at a time if `usize`
         //               is 64 bits.
         const CAP: usize = std::u32::MAX as usize >> 1;
-        let curr_chunk;
-        if writer.images_written == 0 {
-            curr_chunk = chunk::IDAT;
+        let curr_chunk = if writer.images_written == 0 {
+            chunk::IDAT
         } else {
-            curr_chunk = chunk::fdAT;
-        }
+            chunk::fdAT
+        };
         ChunkWriter {
             writer,
             buffer: vec![0; CAP.min(buf_len)],

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -56,10 +56,9 @@ impl Default for AdaptiveFilterType {
 
 fn filter_paeth_decode(a: u8, b: u8, c: u8) -> u8 {
     // Decoding seems to optimize better with this algorithm
-    let p = i16::from(a) + i16::from(b) - i16::from(c);
-    let pa = (p - i16::from(a)).abs();
-    let pb = (p - i16::from(b)).abs();
-    let pc = (p - i16::from(c)).abs();
+    let pa = (i16::from(b) - i16::from(c)).abs();
+    let pb = (i16::from(a) - i16::from(c)).abs();
+    let pc = ((i16::from(a) - i16::from(c)) + (i16::from(b) - i16::from(c))).abs();
 
     let mut out = a;
     let mut min = pa;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -292,7 +292,7 @@ fn filter_internal(
 
             for ((out, cur), &prev) in out_chunks
                 .into_remainder()
-                .into_iter()
+                .iter_mut()
                 .zip(cur_chunks.remainder())
                 .zip(prev_chunks.remainder())
             {
@@ -320,7 +320,7 @@ fn filter_internal(
 
             for (((out, cur), &cur_minus_bpp), &prev) in out_chunks
                 .into_remainder()
-                .into_iter()
+                .iter_mut()
                 .zip(cur_chunks.remainder())
                 .zip(cur_minus_bpp_chunks.remainder())
                 .zip(prev_chunks.remainder())
@@ -391,7 +391,7 @@ pub(crate) fn filter(
             let mut filter_choice = FilterType::NoFilter;
             for &filter in [Sub, Up, Avg, Paeth].iter() {
                 filter_internal(filter, bpp, len, previous, current, output);
-                let sum = sum_buffer(&output);
+                let sum = sum_buffer(output);
                 if sum <= min_sum {
                     min_sum = sum;
                     filter_choice = filter;


### PR DESCRIPTION
Using the observations from the optimized filter, the difference expressions can be simplified for a slight decoding speed increase.
Remove clippy warnings in the library crate.

<details>
<summary>Aside on trying to optimize the `filter_paeth` encoding function</summary>

I tried using an `out` parameter for less comparisons (like in the decode filter) and then delaying calculating `pc`, but it wasn't such a clear win that it seemed worth muddying the current code for. It was largely the same speed but with a few mps improvement on some of the QOI benchmark folders.

```rust
pub fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
    let pa = b.max(c) - c.min(b);
    let pb = a.max(c) - c.min(a);

    let mut out = a;
    let mut min = pa;

    if pb < pa {
        out = b;
        min = pb;
    }

    if (a < c) == (c < b) {
		// Pessimizes if you collapse this condition with the above
        if pa.max(pb) - pa.min(pb) < min {
            out = c;
        }
    }

    out
}
```

</details>