### PR TITLE
Optimize Sub, Avg, and Paeth decoding with SIMD Within A Register

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -773,13 +773,15 @@ impl<R: Read> Reader<R> {
                     Some(filter) => filter,
                 };
 
-                if let Err(message) =
-                    unfilter(filter, bpp, &self.prev[1..rowlen], &mut row[1..rowlen])
-                {
+                if bpp.into_usize() > (1..rowlen).count() {
                     return Err(DecodingError::Format(
-                        FormatErrorInner::BadFilter(message).into(),
+                        FormatErrorInner::BadFilter(
+                            "Filtering failed: bytes per pixel is greater than length of row",
+                        )
+                        .into(),
                     ));
                 }
+                unfilter(filter, bpp, &self.prev[1..rowlen], &mut row[1..rowlen]);
 
                 self.prev[..rowlen].copy_from_slice(&row[..rowlen]);
                 self.scan_start += rowlen;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -329,21 +329,120 @@ pub(crate) fn unfilter(
             }
         }
         Paeth => {
-            for i in 0..bpp {
-                current[i] = current[i].wrapping_add(filter_paeth_decode(0, previous[i], 0));
-            }
-
             // Paeth filter pixels:
             // C B D
             // A X
-            for (((i, a_index), &b_pixel), &c_pixel) in
-                (bpp..).zip(0..).zip(&previous[bpp..]).zip(previous)
-            {
-                current[i] = current[i].wrapping_add(filter_paeth_decode(
-                    current[a_index],
-                    b_pixel,
-                    c_pixel,
-                ));
+            match tbpp {
+                BytesPerPixel::Three => {
+                    assert!(len > 2);
+                    let mut a_bpp = [0; 3];
+                    let mut c_bpp = [0; 3];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(3).zip(previous.chunks_exact(3))
+                    {
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            chunk[2]
+                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
+                        ];
+                        *TryInto::<&mut [u8; 3]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
+                    }
+                }
+                BytesPerPixel::Four => {
+                    assert!(len > 3);
+                    let mut a_bpp = [0; 4];
+                    let mut c_bpp = [0; 4];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(4).zip(previous.chunks_exact(4))
+                    {
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            chunk[2]
+                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
+                            chunk[3]
+                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
+                        ];
+                        *TryInto::<&mut [u8; 4]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
+                    }
+                }
+                BytesPerPixel::Six => {
+                    assert!(len > 5);
+                    let mut a_bpp = [0; 6];
+                    let mut c_bpp = [0; 6];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
+                    {
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            chunk[2]
+                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
+                            chunk[3]
+                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
+                            chunk[4]
+                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
+                            chunk[5]
+                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
+                        ];
+                        *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
+                    }
+                }
+                BytesPerPixel::Eight => {
+                    assert!(len > 7);
+                    let mut a_bpp = [0; 8];
+                    let mut c_bpp = [0; 8];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(8).zip(previous.chunks_exact(8))
+                    {
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            chunk[2]
+                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
+                            chunk[3]
+                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
+                            chunk[4]
+                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
+                            chunk[5]
+                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
+                            chunk[6]
+                                .wrapping_add(filter_paeth_decode(a_bpp[6], b_bpp[6], c_bpp[6])),
+                            chunk[7]
+                                .wrapping_add(filter_paeth_decode(a_bpp[7], b_bpp[7], c_bpp[7])),
+                        ];
+                        *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
+                    }
+                }
+                _ => {
+                    for i in 0..bpp {
+                        current[i] =
+                            current[i].wrapping_add(filter_paeth_decode(0, previous[i], 0));
+                    }
+
+                    for (((i, a_index), &b_pixel), &c_pixel) in
+                        (bpp..).zip(0..).zip(&previous[bpp..]).zip(previous)
+                    {
+                        current[i] = current[i].wrapping_add(filter_paeth_decode(
+                            current[a_index],
+                            b_pixel,
+                            c_pixel,
+                        ));
+                    }
+                }
             }
         }
     }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -146,6 +146,20 @@ pub(crate) fn unfilter(
         n ^ (x ^ y) & 0x8080808080808080
     }
 
+    // Average of two integers without overflow or casting to a larger bit-width
+    // http://aggregate.org/MAGIC/#Average%20of%20Integers
+    // The base algorithm:
+    //     (x & y) + ((x ^ y) >> 1)
+    fn swar_avg_u32(x: u32, y: u32) -> u32 {
+        // Calculate 4 averages at once masking out the MSB on the right operand
+        // so right-shifted values don't interfere with their neighbors.
+        (x & y) + (((x ^ y) >> 1) & 0x7f7f7f7f)
+    }
+
+    fn swar_avg_u64(x: u64, y: u64) -> u64 {
+        (x & y) + (((x ^ y) >> 1) & 0x7f7f7f7f7f7f7f7f)
+    }
+
     match filter {
         NoFilter => Ok(()),
         Sub => {
@@ -156,6 +170,7 @@ pub(crate) fn unfilter(
 
             match tbpp {
                 BytesPerPixel::Three => {
+                    assert!(len > 2);
                     let mut prev = u32::from_ne_bytes([current[0], current[1], current[2], 0]);
                     for chunk in current[3..].chunks_exact_mut(3) {
                         let cur = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], 0]);
@@ -165,6 +180,7 @@ pub(crate) fn unfilter(
                     }
                 }
                 BytesPerPixel::Four => {
+                    assert!(len > 3);
                     let mut prev =
                         u32::from_ne_bytes([current[0], current[1], current[2], current[3]]);
                     for chunk in current[4..].chunks_exact_mut(4) {
@@ -175,6 +191,7 @@ pub(crate) fn unfilter(
                     }
                 }
                 BytesPerPixel::Six => {
+                    assert!(len > 5);
                     let mut prev = u64::from_ne_bytes([
                         current[0], current[1], current[2], current[3], current[4], current[5], 0,
                         0,
@@ -189,6 +206,7 @@ pub(crate) fn unfilter(
                     }
                 }
                 BytesPerPixel::Eight => {
+                    assert!(len > 7);
                     let mut prev = u64::from_ne_bytes([
                         current[0], current[1], current[2], current[3], current[4], current[5],
                         current[6], current[7],
@@ -260,18 +278,83 @@ pub(crate) fn unfilter(
                 };
             }
 
-            avg_tail!(avg_tail_8, 8);
-            avg_tail!(avg_tail_6, 6);
-            avg_tail!(avg_tail_4, 4);
-            avg_tail!(avg_tail_3, 3);
             avg_tail!(avg_tail_2, 2);
             avg_tail!(avg_tail_1, 1);
 
             match tbpp {
-                BytesPerPixel::Eight => avg_tail_8(current, previous),
-                BytesPerPixel::Six => avg_tail_6(current, previous),
-                BytesPerPixel::Four => avg_tail_4(current, previous),
-                BytesPerPixel::Three => avg_tail_3(current, previous),
+                BytesPerPixel::Eight => {
+                    assert!(len > 7);
+                    let mut lprev = u64::from_ne_bytes([
+                        current[0], current[1], current[2], current[3], current[4], current[5],
+                        current[6], current[7],
+                    ]);
+                    for (chunk, above) in current[8..]
+                        .chunks_exact_mut(8)
+                        .zip(previous[8..].chunks_exact(8))
+                    {
+                        let pprev = u64::from_ne_bytes([
+                            above[0], above[1], above[2], above[3], above[4], above[5], above[6],
+                            above[7],
+                        ]);
+                        let pcurrent = u64::from_ne_bytes([
+                            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], chunk[6],
+                            chunk[7],
+                        ]);
+                        let new_chunk = swar_add_u64(pcurrent, swar_avg_u64(pprev, lprev));
+                        chunk.copy_from_slice(&new_chunk.to_ne_bytes());
+                        lprev = new_chunk;
+                    }
+                }
+                BytesPerPixel::Six => {
+                    assert!(len > 5);
+                    let mut lprev = u64::from_ne_bytes([
+                        current[0], current[1], current[2], current[3], current[4], current[5], 0,
+                        0,
+                    ]);
+                    for (chunk, above) in current[6..]
+                        .chunks_exact_mut(6)
+                        .zip(previous[6..].chunks_exact(6))
+                    {
+                        let pprev = u64::from_ne_bytes([
+                            above[0], above[1], above[2], above[3], above[4], above[5], 0, 0,
+                        ]);
+                        let pcurrent = u64::from_ne_bytes([
+                            chunk[0], chunk[1], chunk[2], chunk[3], chunk[4], chunk[5], 0, 0,
+                        ]);
+                        let new_chunk = swar_add_u64(pcurrent, swar_avg_u64(pprev, lprev));
+                        chunk[..6].copy_from_slice(&new_chunk.to_ne_bytes()[..6]);
+                        lprev = new_chunk;
+                    }
+                }
+                BytesPerPixel::Four => {
+                    assert!(len > 3);
+                    let mut lprev =
+                        u32::from_ne_bytes([current[0], current[1], current[2], current[3]]);
+                    for (chunk, above) in current[4..]
+                        .chunks_exact_mut(4)
+                        .zip(previous[4..].chunks_exact(4))
+                    {
+                        let pprev = u32::from_ne_bytes([above[0], above[1], above[2], above[3]]);
+                        let pcurrent = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                        let new_chunk = swar_add_u32(pcurrent, swar_avg_u32(pprev, lprev));
+                        chunk.copy_from_slice(&new_chunk.to_ne_bytes());
+                        lprev = new_chunk;
+                    }
+                }
+                BytesPerPixel::Three => {
+                    assert!(len > 2);
+                    let mut lprev = u32::from_ne_bytes([current[0], current[1], current[2], 0]);
+                    for (chunk, above) in current[3..]
+                        .chunks_exact_mut(3)
+                        .zip(previous[3..].chunks_exact(3))
+                    {
+                        let pprev = u32::from_ne_bytes([above[0], above[1], above[2], 0]);
+                        let pcurrent = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], 0]);
+                        let new_chunk = swar_add_u32(pcurrent, swar_avg_u32(pprev, lprev));
+                        chunk.copy_from_slice(&new_chunk.to_ne_bytes()[..3]);
+                        lprev = new_chunk;
+                    }
+                }
                 BytesPerPixel::Two => avg_tail_2(current, previous),
                 BytesPerPixel::One => avg_tail_1(current, previous),
             }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -125,9 +125,91 @@ pub(crate) fn unfilter(
 ) {
     use self::FilterType::*;
 
+    // [2023/01 @okaneco] - Notes on optimizing decoding filters
+    //
+    // Links:
+    // [PR]: https://github.com/image-rs/image-png/pull/382
+    // [SWAR]: http://aggregate.org/SWAR/over.html
+    // [AVG]: http://aggregate.org/MAGIC/#Average%20of%20Integers
+    //
+    // #382 heavily refactored and optimized the following filters making the
+    // implementation nonobvious. These comments function as a summary of that
+    // PR with an explanation of the choices made below.
+    //
+    // #382 originally started with trying to optimize using a technique called
+    // SWAR, SIMD Within a Register. SWAR uses regular integer types like `u32`
+    // and `u64` as SIMD registers to perform vertical operations in parallel,
+    // usually involving bit-twiddling. This allowed each `BytesPerPixel` (bpp)
+    // pixel to be decoded in parallel: 3bpp and 4bpp in a `u32`, 6bpp and 8pp
+    // in a `u64`. The `Sub` filter looked like the following code block, `Avg`
+    // was similar but used a bitwise average method from [AVG]:
+    // ```
+    // // See "Unpartitioned Operations With Correction Code" from [SWAR]
+    // fn swar_add_u32(x: u32, y: u32) -> u32 {
+    //     // 7-bit addition so there's no carry over the most significant bit
+    //     let n = (x & 0x7f7f7f7f) + (y & 0x7f7f7f7f); // 0x7F = 0b_0111_1111
+    //     // 1-bit parity/XOR addition to fill in the missing MSB
+    //     n ^ (x ^ y) & 0x80808080                     // 0x80 = 0b_1000_0000
+    // }
+    //
+    // let mut prev =
+    //     u32::from_ne_bytes([current[0], current[1], current[2], current[3]]);
+    // for chunk in current[4..].chunks_exact_mut(4) {
+    //     let cur = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    //     let new_chunk = swar_add_u32(cur, prev);
+    //     chunk.copy_from_slice(&new_chunk.to_ne_bytes());
+    //     prev = new_chunk;
+    // }
+    // ```
+    // While this provided a measurable increase, @fintelia found that this idea
+    // could be taken even further by unrolling the chunks component-wise and
+    // avoiding unnecessary byte-shuffling by using byte arrays instead of
+    // `u32::from|to_ne_bytes`. The bitwise operations were no longer necessary
+    // so they were reverted to their obvious arithmetic equivalent. Lastly,
+    // `TryInto` was used instead of `copy_from_slice`. The `Sub` code now
+    // looked like this (with asserts to remove `0..bpp` bounds checks):
+    // ```
+    // assert!(len > 3);
+    // let mut prev = [current[0], current[1], current[2], current[3]];
+    // for chunk in current[4..].chunks_exact_mut(4) {
+    //     let new_chunk = [
+    //         chunk[0].wrapping_add(prev[0]),
+    //         chunk[1].wrapping_add(prev[1]),
+    //         chunk[2].wrapping_add(prev[2]),
+    //         chunk[3].wrapping_add(prev[3]),
+    //     ];
+    //     *TryInto::<&mut [u8; 4]>::try_into(chunk).unwrap() = new_chunk;
+    //     prev = new_chunk;
+    // }
+    // ```
+    // The compiler was able to optimize the code to be even faster and this
+    // method even sped up Paeth filtering! Assertions were experimentally
+    // added within loop bodies which produced better instructions but no
+    // difference in speed. Finally, the code was refactored to remove manual
+    // slicing and start the previous pixel chunks with arrays of `[0; N]`.
+    // ```
+    // let mut prev = [0; 4];
+    // for chunk in current.chunks_exact_mut(4) {
+    //     let new_chunk = [
+    //         chunk[0].wrapping_add(prev[0]),
+    //         chunk[1].wrapping_add(prev[1]),
+    //         chunk[2].wrapping_add(prev[2]),
+    //         chunk[3].wrapping_add(prev[3]),
+    //     ];
+    //     *TryInto::<&mut [u8; 4]>::try_into(chunk).unwrap() = new_chunk;
+    //     prev = new_chunk;
+    // }
+    // ```
+    // While we're not manually bit-twiddling anymore, a possible takeaway from
+    // this is to "think in SWAR" when dealing with small byte arrays. Unrolling
+    // array operations and performing them component-wise may unlock previously
+    // unavailable optimizations from the compiler, even when using the
+    // `chunks_exact` methods for their potential auto-vectorization benefits.
     match filter {
         NoFilter => {}
         Sub => match tbpp {
+            // These variants regressed instruction count with no performance
+            // benefit when converted to use `chunks`, leave as an obvious loop
             BytesPerPixel::One | BytesPerPixel::Two => {
                 let bpp = tbpp.into_usize();
                 for i in bpp..current.len() {
@@ -193,6 +275,7 @@ pub(crate) fn unfilter(
             }
         },
         Up => {
+            // `chunks_exact[_mut]` won't help here
             for i in 0..current.len() {
                 current[i] = current[i].wrapping_add(previous[i]);
             }
@@ -481,7 +564,10 @@ fn filter_internal(
             {
                 for i in 0..CHUNK_SIZE {
                     // Bitwise average of two integers without overflow and
-                    // without converting to a wider bit-width
+                    // without converting to a wider bit-width. See:
+                    // http://aggregate.org/MAGIC/#Average%20of%20Integers
+                    // If this is unrolled by component, consider reverting to
+                    // `((cur_minus_bpp[i] as u16 + prev[i] as u16) / 2) as u8`
                     out[i] = cur[i].wrapping_sub(
                         (cur_minus_bpp[i] & prev[i]) + ((cur_minus_bpp[i] ^ prev[i]) >> 1),
                     );

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -312,8 +312,10 @@ fn filter_internal(
                 .zip(&mut prev_chunks)
             {
                 for i in 0..CHUNK_SIZE {
+                    // Bitwise average of two integers without overflow and
+                    // without converting to a wider bit-width
                     out[i] = cur[i].wrapping_sub(
-                        ((u16::from(cur_minus_bpp[i]) + u16::from(prev[i])) / 2) as u8,
+                        (cur_minus_bpp[i] & prev[i]) + ((cur_minus_bpp[i] ^ prev[i]) >> 1),
                     );
                 }
             }
@@ -325,7 +327,7 @@ fn filter_internal(
                 .zip(cur_minus_bpp_chunks.remainder())
                 .zip(prev_chunks.remainder())
             {
-                *out = cur.wrapping_sub(((u16::from(cur_minus_bpp) + u16::from(prev)) / 2) as u8);
+                *out = cur.wrapping_sub((cur_minus_bpp & prev) + ((cur_minus_bpp ^ prev) >> 1));
             }
 
             for i in 0..bpp {


### PR DESCRIPTION
_SWAR: SIMD Within A Register
http://aggregate.org/SWAR/over.html
http://aggregate.org/MAGIC/#Average%20of%20Integers_

- Calculate average in `Avg` encoding filter with bitwise operations that don't widen to u16
- Use SWAR for `Sub` and `Avg` filters to filter one pixel at a time for 3, 4, 6, and 8 bpp images

The idea for SWAR is to treat regular integer types like `u32|u64` as a SIMD
register for arbitrary smaller-width bit lanes. We can calculate 3 bytes per
pixel and 4bpp pixels within a `u32`, 6bpp and 8bpp pixels within a `u64`.

It's not an n-times speedup based on the number of lanes because SWAR may
require some overhead of maintaining the lanes depending on the operation
(shifts, for instance). This is evidenced by masking operations during
calculation to correct or prevent lanes from overlapping. For the wrapping
addition operation here, 7-bit arithmetic is calculated to prevent a carry
digit affecting neighboring lanes. After the addition, a correcting XOR addition
is done to repair the most significant bit and arrive at the correct answer for
8-bit wrapping unsigned arithmetic.

Most PNGs seem to be 3 or 4bpp and SWAR seems to improve decoding time over the obvious for-each loop. There's a somewhat unavoidable (to me) level of ugliness and obfuscation in the implementation, but I've tried to leave enough comments and break up the commits.

---

*Edit (2023/01/21):*
This ended up not using bitwise operations for optimizing decoding but did use concepts from the initial commits to improve the `Sub`, `Avg`, and `Paeth` decoding filters.