### PR TITLE
Faster decompression of non-fdeflate encoded PNGs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 [dependencies]
 bitflags = "1.0"
 crc32fast = "1.2.0"
-fdeflate = "0.2.1"
+fdeflate = "0.3.0"
 flate2 = "1.0"
 miniz_oxide = { version = "0.7.1", features = ["simd"] }
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -196,7 +196,7 @@ pub(crate) enum FormatErrorInner {
     // Errors specific to the IDAT/fDAT chunks.
     /// The compression of the data stream was faulty.
     CorruptFlateStream {
-        err: miniz_oxide::inflate::TINFLStatus,
+        err: fdeflate::DecompressionError,
     },
     /// The image data chunk was too short for the expected pixel count.
     NoMoreImageData,
@@ -291,22 +291,7 @@ impl fmt::Display for FormatError {
             NoMoreImageData => write!(fmt, "IDAT or fDAT chunk is has not enough data for image."),
             CorruptFlateStream { err } => {
                 write!(fmt, "Corrupt deflate stream. ")?;
-                use miniz_oxide::inflate::TINFLStatus;
-                match err {
-                    TINFLStatus::Adler32Mismatch => write!(fmt, "Adler32 checksum failed."),
-                    TINFLStatus::BadParam => write!(fmt, "Invalid input parameters."),
-                    // The Done status should already have been handled.
-                    TINFLStatus::Done => write!(fmt, "Unexpected done status."),
-                    TINFLStatus::FailedCannotMakeProgress => {
-                        write!(fmt, "Unexpected end of data.")
-                    }
-                    // The HasMoreOutput status should already have been handled.
-                    TINFLStatus::HasMoreOutput => write!(fmt, "Has more output."),
-                    // The HasMoreInput status should already have been handled.
-                    TINFLStatus::NeedsMoreInput => write!(fmt, "Needs more input."),
-                    // Write out the error number in case a new has been added.
-                    _ => write!(fmt, "Error number {:?}.", err),
-                }
+                write!(fmt, "{:?}", err)
             }
             // TODO: Wrap more info in the enum variant
             BadTextEncoding(tde) => {


### PR DESCRIPTION
This PR brings image-png decoding performance to around 90-95% of what zune-png can do. It uses a work-in-progress branch of fdeflate which adds support for arbitrary zlib streams and incorporates some of the optimizations from zune-inflate. 
```
$ cargo run --release --example corpus-bench -- qoi_benchmark_suite/

Directory                                     Ratio             zune-png                  image-png
---------                                    -------     --------------------      --------------------
qoi_benchmark_suite/images/pngimg              0.00%     191 mps   0.71 GiB/s      176 mps   0.65 GiB/s
qoi_benchmark_suite/images/icon_512            0.00%     447 mps   1.67 GiB/s      336 mps   1.25 GiB/s
qoi_benchmark_suite/images/textures_photo      0.00%     116 mps   0.32 GiB/s      101 mps   0.28 GiB/s
qoi_benchmark_suite/images/photo_kodak         0.00%     128 mps   0.36 GiB/s      112 mps   0.31 GiB/s
qoi_benchmark_suite/images/screenshot_game     0.00%     214 mps   0.69 GiB/s      172 mps   0.55 GiB/s
qoi_benchmark_suite/images/icon_64             0.00%     154 mps   0.58 GiB/s       87 mps   0.33 GiB/s
qoi_benchmark_suite/images/photo_tecnick       0.00%     117 mps   0.33 GiB/s      164 mps   0.46 GiB/s
qoi_benchmark_suite/images/textures_pk         0.00%      86 mps   0.32 GiB/s       82 mps   0.31 GiB/s
qoi_benchmark_suite/images/photo_wikipedia     0.00%     112 mps   0.32 GiB/s      123 mps   0.34 GiB/s
qoi_benchmark_suite/images/textures_pk01       0.00%     145 mps   0.54 GiB/s      122 mps   0.45 GiB/s
qoi_benchmark_suite/images/textures_plants     0.00%     201 mps   0.75 GiB/s      168 mps   0.63 GiB/s
qoi_benchmark_suite/images/textures_pk02       0.00%     131 mps   0.49 GiB/s      113 mps   0.42 GiB/s
qoi_benchmark_suite/images/screenshot_web      0.00%     313 mps   1.17 GiB/s      312 mps   1.16 GiB/s

Total                                         0.000%     181 mps  0.616 GiB/s      170 mps  0.579 GiB/s
```