### PR TITLE
Add option to ignore Adler32 checksum in ZlibStream, set ignore as default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bitflags = "1.0"
 crc32fast = "1.2.0"
 fdeflate = "0.2.1"
 flate2 = "1.0"
-miniz_oxide = "0.6.0"
+miniz_oxide = { version = "0.7.1", features = ["simd"] }
 
 [dev-dependencies]
 clap = { version = "3.0", features = ["derive"] }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -233,6 +233,15 @@ impl<R: Read> Decoder<R> {
             .decoder
             .set_ignore_text_chunk(ignore_text_chunk);
     }
+
+    /// Set the decoder to ignore and not verify the Adler-32 checksum
+    /// and CRC code.
+    pub fn ignore_checksums(&mut self, ignore_checksums: bool) {
+        self.read_decoder
+            .decoder
+            .set_ignore_adler32(ignore_checksums);
+        self.read_decoder.decoder.set_ignore_crc(ignore_checksums);
+    }
 }
 
 struct ReadDecoder<R: Read> {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -505,13 +505,6 @@ impl StreamingDecoder {
         self.info.as_ref()
     }
 
-    /// Set decode config
-    // FIXME: Remove if there isn't a use for this function
-    #[allow(dead_code)]
-    pub(crate) fn set_decode_config(&mut self, decode_config: DecodeOptions) {
-        self.decode_options = decode_config;
-    }
-
     pub fn set_ignore_text_chunk(&mut self, ignore_text_chunk: bool) {
         self.decode_options.set_ignore_text_chunk(ignore_text_chunk);
     }
@@ -527,7 +520,7 @@ impl StreamingDecoder {
     /// The decoder defaults to `true`.
     ///
     /// This flag cannot be modified after decompression has started until the
-    /// [StreamingDecoder] is reset.
+    /// [`StreamingDecoder`] is reset.
     pub fn set_ignore_adler32(&mut self, ignore_adler32: bool) -> bool {
         self.inflater.set_ignore_adler32(ignore_adler32)
     }

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -125,13 +125,19 @@ impl ZlibStream {
         *self.state = Default::default();
     }
 
-    /// Set the `ignore_adler32` flag. The default is `true`.
+    /// Set the `ignore_adler32` flag and return `true` if the flag was
+    /// successfully set.
+    ///
+    /// The default is `true`.
     ///
     /// This flag cannot be modified after decompression has started until the
     /// [ZlibStream] is reset.
-    pub(crate) fn set_ignore_adler32(&mut self, flag: bool) {
+    pub(crate) fn set_ignore_adler32(&mut self, flag: bool) -> bool {
         if !self.started {
             self.ignore_adler32 = flag;
+            true
+        } else {
+            false
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,9 @@ pub mod text_metadata;
 mod traits;
 mod utils;
 
-pub use crate::{
-    common::*,
-    decoder::{Decoded, Decoder, DecodingError, Limits, OutputInfo, Reader, StreamingDecoder},
-    encoder::{Encoder, EncodingError, StreamWriter, Writer},
-    filter::{AdaptiveFilterType, FilterType},
+pub use crate::common::*;
+pub use crate::decoder::{
+    DecodeOptions, Decoded, Decoder, DecodingError, Limits, OutputInfo, Reader, StreamingDecoder,
 };
+pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
+pub use crate::filter::{AdaptiveFilterType, FilterType};


### PR DESCRIPTION
Add `ignore_adler32` flag to `ZlibStream`
Disable computing and checking the Adler-32 checksum by default
Reset `ZlibStream` where possible instead of instantiating new structs
Add `ignore_crc` flag to DecodeOptions

I'm not sure what to do about the user interface for this. I added options to the `StreamingDecoder`. The coupling of setting the option is clunky to sync with the multiple levels of structs from `ZlibStream` upwards.

I see a 3.5%-8% improvement on the benchmarks.

Closes #254 and closes #347 