### PR TITLE
Release 0.17.8-rc and call for testing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 ## Unreleased
 
+## 0.17.8
+
+* Increased MSRV to 1.57.0.
+* Substantially optimized encoding and decoding:
+  - Autovectorize filtering and unfiltering.
+  - Make the "fast" compression preset use fdeflate.
+  - Switch decompression to always use fdeflate.
+  - Updated to miniz_oxide 0.7.
+  - Added an option to ignore checksums.
+* Added corpus-bench example which measures the compression ratio and time to
+  re-encode and subsequently decode a corpus of images.
+* More fuzz testing.
+
 ## 0.17.7
 
 * Fixed handling broken tRNS chunk.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.17.7"
+version = "0.17.8-rc"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"


### PR DESCRIPTION
This prepares a preview release to enable broader testing before publishing.

There's been a lot of phenomenal performance improvements to this crate since the last release, including a complete rewrite of the zlib compression/decompression logic and major changes filtering and unfiltering. Further, this was all possible without any semver breaking changes. This introduces risks that we've introduced bugs or regressions which would get immediately picked up by downstream users once released.