### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["The image-rs Developers"]
 repository = "https://github.com/image-rs/image-png.git"
 
 edition = "2018"
+rust-version = "1.57"
 include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",


### PR DESCRIPTION
Maintaining this field will be useful for when msrv-aware resolvers land in Cargo.