### PR TITLE
Improve unfilter() performance

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -208,12 +208,15 @@ pub(crate) fn unfilter(
     match filter {
         NoFilter => {}
         Sub => match tbpp {
-            // These variants regressed instruction count with no performance
-            // benefit when converted to use `chunks`, leave as an obvious loop
-            BytesPerPixel::One | BytesPerPixel::Two => {
-                let bpp = tbpp.into_usize();
-                for i in bpp..current.len() {
-                    current[i] = current[i].wrapping_add(current[i - bpp]);
+            BytesPerPixel::One => {
+                current.iter_mut().reduce(|&mut prev, curr| {
+                    *curr = curr.wrapping_add(prev);
+                    curr
+                });
+            }
+            BytesPerPixel::Two => {
+                for i in 2..current.len() {
+                    current[i] = current[i].wrapping_add(current[i - 2]);
                 }
             }
             BytesPerPixel::Three => {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -284,9 +284,8 @@ pub(crate) fn unfilter(
             }
         },
         Up => {
-            // `chunks_exact[_mut]` won't help here
-            for i in 0..current.len() {
-                current[i] = current[i].wrapping_add(previous[i]);
+            for (curr, &above) in current.iter_mut().zip(previous) {
+                *curr = curr.wrapping_add(above);
             }
         }
         Avg => match tbpp {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -215,8 +215,14 @@ pub(crate) fn unfilter(
                 });
             }
             BytesPerPixel::Two => {
-                for i in 2..current.len() {
-                    current[i] = current[i].wrapping_add(current[i - 2]);
+                let mut prev = [0; 2];
+                for chunk in current.chunks_exact_mut(2) {
+                    let new_chunk = [
+                        chunk[0].wrapping_add(prev[0]),
+                        chunk[1].wrapping_add(prev[1]),
+                    ];
+                    *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                    prev = new_chunk;
                 }
             }
             BytesPerPixel::Three => {


### PR DESCRIPTION
The short summary of this is that loops using a counter don't seem to vectorize nearly as well as iterator-based ones. In the case of the `Up` filter method, there's also slice index into `previous` with no bounds-checking on `previous`, likely resulting in missed optimizations.

In practice, some of these might have no or negligible impact, since `unfilter` is private to the crate and the compiler can attempt other things like inlining or gaining context from the single call-site. However, in isolated benchmarks, these changes make for notable performance improvements.

## Benchmarking

I created a [bench-unfilter](https://github.com/zlstringham/image-png/tree/bench-unfilter) branch which adds benchmarks for each `FilterType` and `BytesPerPixel` combination, passing in randomized `(1000*bpp)`-length rows for the `previous` and `current` rows. This benchmark isn't included as part of the PR as it affects the public visiblity of some types and, of course, the `unfilter` method.

The (Windows) command I used for the following section was this:
```bash
git checkout master ; git cherry-pick 7d43272 ; cargo bench unfilter ; git reset --hard HEAD^ ; git checkout improve-unfilter ; git cherry-pick 7d43272 ; cargo bench unfilter ; git reset --hard HEAD^
```

## Results
All of the untouched filter types are "within noise threshold." For the modified ones, the results look like this:

### Sub

`master`:
```
unfilter/Sub-1bpp       time:   [1.3295 µs 1.3312 µs 1.3326 µs]
                        thrpt:  [715.64 MiB/s 716.41 MiB/s 717.32 MiB/s]
Found 31 outliers among 500 measurements (6.20%)
  8 (1.60%) low severe
  2 (0.40%) low mild
  11 (2.20%) high mild
  10 (2.00%) high severe
unfilter/Sub-2bpp       time:   [1.3267 µs 1.3287 µs 1.3309 µs]
                        thrpt:  [1.3995 GiB/s 1.4018 GiB/s 1.4040 GiB/s]
Found 22 outliers among 500 measurements (4.40%)
  1 (0.20%) low mild
  17 (3.40%) high mild
  4 (0.80%) high severe
```

PR:
```
unfilter/Sub-1bpp       time:   [185.98 ns 186.16 ns 186.36 ns]
                        thrpt:  [4.9975 GiB/s 5.0027 GiB/s 5.0078 GiB/s]
                 change:
                        time:   [-86.020% -85.983% -85.944%] (p = 0.00 < 0.05)
                        thrpt:  [+611.44% +613.43% +615.32%]
                        Performance has improved.
Found 23 outliers among 500 measurements (4.60%)
  12 (2.40%) high mild
  11 (2.20%) high severe
unfilter/Sub-2bpp       time:   [215.30 ns 215.53 ns 215.78 ns]
                        thrpt:  [8.6323 GiB/s 8.6420 GiB/s 8.6515 GiB/s]
                 change:
                        time:   [-83.823% -83.783% -83.745%] (p = 0.00 < 0.05)
                        thrpt:  [+515.19% +516.63% +518.16%]
                        Performance has improved.
Found 41 outliers among 500 measurements (8.20%)
  25 (5.00%) low mild
  14 (2.80%) high mild
  2 (0.40%) high severe
```

### Up

`master`:
```
unfilter/Up-1bpp        time:   [20.917 ns 21.071 ns 21.226 ns]
                        thrpt:  [43.877 GiB/s 44.200 GiB/s 44.525 GiB/s]
Found 3 outliers among 500 measurements (0.60%)
  1 (0.20%) high mild
  2 (0.40%) high severe
unfilter/Up-2bpp        time:   [34.652 ns 34.874 ns 35.104 ns]
                        thrpt:  [53.061 GiB/s 53.410 GiB/s 53.752 GiB/s]
Found 17 outliers among 500 measurements (3.40%)
  12 (2.40%) high mild
  5 (1.00%) high severe
unfilter/Up-3bpp        time:   [45.830 ns 46.144 ns 46.471 ns]
                        thrpt:  [60.123 GiB/s 60.548 GiB/s 60.964 GiB/s]
Found 22 outliers among 500 measurements (4.40%)
  15 (3.00%) high mild
  7 (1.40%) high severe
unfilter/Up-4bpp        time:   [64.493 ns 64.957 ns 65.451 ns]
                        thrpt:  [56.918 GiB/s 57.350 GiB/s 57.763 GiB/s]
Found 30 outliers among 500 measurements (6.00%)
  21 (4.20%) high mild
  9 (1.80%) high severe
unfilter/Up-6bpp        time:   [90.296 ns 91.002 ns 91.731 ns]
                        thrpt:  [60.917 GiB/s 61.405 GiB/s 61.885 GiB/s]
Found 31 outliers among 500 measurements (6.20%)
  22 (4.40%) high mild
  9 (1.80%) high severe
unfilter/Up-8bpp        time:   [115.87 ns 116.83 ns 117.83 ns]
                        thrpt:  [63.234 GiB/s 63.773 GiB/s 64.300 GiB/s]
Found 31 outliers among 500 measurements (6.20%)
  20 (4.00%) high mild
  11 (2.20%) high severe
```

PR:
```
unfilter/Up-1bpp        time:   [11.553 ns 11.565 ns 11.578 ns]
                        thrpt:  [80.437 GiB/s 80.527 GiB/s 80.614 GiB/s]
                 change:
                        time:   [-45.470% -45.014% -44.574%] (p = 0.00 < 0.05)
                        thrpt:  [+80.422% +81.863% +83.387%]
                        Performance has improved.
Found 20 outliers among 500 measurements (4.00%)
  2 (0.40%) low mild
  11 (2.20%) high mild
  7 (1.40%) high severe
unfilter/Up-2bpp        time:   [20.608 ns 20.873 ns 21.400 ns]
                        thrpt:  [87.038 GiB/s 89.236 GiB/s 90.386 GiB/s]
                 change:
                        time:   [-41.039% -40.433% -39.663%] (p = 0.00 < 0.05)
                        thrpt:  [+65.737% +67.878% +69.604%]
                        Performance has improved.
Found 26 outliers among 500 measurements (5.20%)
  1 (0.20%) low mild
  12 (2.40%) high mild
  13 (2.60%) high severe
unfilter/Up-3bpp        time:   [29.445 ns 29.479 ns 29.518 ns]
                        thrpt:  [94.654 GiB/s 94.778 GiB/s 94.889 GiB/s]
                 change:
                        time:   [-37.230% -36.627% -36.027%] (p = 0.00 < 0.05)
                        thrpt:  [+56.317% +57.795% +59.311%]
                        Performance has improved.
Found 30 outliers among 500 measurements (6.00%)
  4 (0.80%) low mild
  10 (2.00%) high mild
  16 (3.20%) high severe
unfilter/Up-4bpp        time:   [37.767 ns 37.808 ns 37.849 ns]
                        thrpt:  [98.425 GiB/s 98.532 GiB/s 98.638 GiB/s]
                 change:
                        time:   [-42.520% -42.051% -41.595%] (p = 0.00 < 0.05)
                        thrpt:  [+71.219% +72.567% +73.972%]
                        Performance has improved.
Found 16 outliers among 500 measurements (3.20%)
  7 (1.40%) high mild
  9 (1.80%) high severe
unfilter/Up-6bpp        time:   [55.533 ns 55.587 ns 55.642 ns]
                        thrpt:  [100.43 GiB/s 100.53 GiB/s 100.62 GiB/s]
                 change:
                        time:   [-40.221% -39.559% -38.929%] (p = 0.00 < 0.05)
                        thrpt:  [+63.743% +65.450% +67.284%]
                        Performance has improved.
Found 27 outliers among 500 measurements (5.40%)
  12 (2.40%) high mild
  15 (3.00%) high severe
unfilter/Up-8bpp        time:   [72.685 ns 72.752 ns 72.821 ns]
                        thrpt:  [102.31 GiB/s 102.41 GiB/s 102.51 GiB/s]
                 change:
                        time:   [-39.020% -38.322% -37.649%] (p = 0.00 < 0.05)
                        thrpt:  [+60.383% +62.132% +63.989%]
                        Performance has improved.
Found 19 outliers among 500 measurements (3.80%)
  10 (2.00%) high mild
  9 (1.80%) high severe
```