### PR TITLE
Bump `bitflags` to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = [
 ]
 
 [dependencies]
-bitflags = "1.0"
+bitflags = "2.0"
 crc32fast = "1.2.0"
 fdeflate = "0.3.0"
 flate2 = "1.0"

--- a/src/common.rs
+++ b/src/common.rs
@@ -725,6 +725,7 @@ bitflags! {
     const SCALE_16            = 0x8000; // read only
     ```
     "]
+    #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
     pub struct Transformations: u32 {
         /// No transformation
         const IDENTITY            = 0x0000; // read and write */


### PR DESCRIPTION
Changelog: https://github.com/bitflags/bitflags/blob/2.0.0/CHANGELOG.md#200.

This is a breaking change. The API that is implemented for `Transformations` by the macro is now different.