### PR TITLE
Refactor `utils::unpack_bits` for palette expanded images

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,40 +1,38 @@
 //! Utility functions
-use std::iter::{repeat, StepBy};
+use std::iter::StepBy;
 use std::ops::Range;
 
 #[inline(always)]
-pub fn unpack_bits<F>(buf: &mut [u8], channels: usize, bit_depth: u8, func: F)
+pub fn unpack_bits<F>(row: &[u8], buf: &mut [u8], channels: usize, bit_depth: u8, func: F)
 where
     F: Fn(u8, &mut [u8]),
 {
-    // Return early if empty. This enables to subtract `channels` later without overflow.
-    if buf.len() < channels {
-        return;
-    }
-
-    let bits = buf.len() / channels * bit_depth as usize;
-    let extra_bits = bits % 8;
-    let entries = bits / 8
-        + match extra_bits {
-            0 => 0,
-            _ => 1,
-        };
-    let skip = match extra_bits {
-        0 => 0,
-        n => (8 - n) / bit_depth as usize,
-    };
     let mask = ((1u16 << bit_depth) - 1) as u8;
-    let i = (0..entries)
-        .rev() // reverse iterator
-        .flat_map(|idx|
-            // this has to be reversed too
-            (0..8).step_by(bit_depth.into())
-            .zip(repeat(idx)))
-        .skip(skip);
-    let j = (0..=buf.len() - channels).rev().step_by(channels);
-    for ((shift, i), j) in i.zip(j) {
-        let pixel = (buf[i] & (mask << shift)) >> shift;
-        func(pixel, &mut buf[j..(j + channels)])
+
+    let mut buf_chunks = buf.chunks_exact_mut(channels);
+
+    // `shift` iterates through these ranges for each bit depth:
+    // 1 => &[7, 6, 5, 4, 3, 2, 1, 0],
+    // 2 => &[6, 4, 2, 0],
+    // 4 => &[4, 0],
+    // 8 => &[0],
+    //
+    // `(0..8).step_by(bit_depth.into()).rev()` doesn't always optimize well so
+    // shifts are calculated instead. (2023-08, Rust 1.71)
+
+    for &curr in row.iter() {
+        let mut shift = 8 - bit_depth as i32;
+
+        while shift >= 0 {
+            if let Some(chunk) = buf_chunks.next() {
+                let pixel = (curr >> shift) & mask;
+                func(pixel, chunk);
+            } else {
+                return;
+            }
+
+            shift -= bit_depth as i32;
+        }
     }
 }
 


### PR DESCRIPTION
Reuse the previous row in `unpack_bits` calculation instead of expanding the palette within the buffer
Use `chunks_exact` and iterate from start to end of the buffer instead of back to front in-place

---

I found this code easier to reason about and might enable someone to optimize this further in the future.
I didn't see a performance difference between the two versions.