### PR TITLE
Scaffolding for direct benchmarking of `crate::filter::unfilter`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,9 @@ benchmarks = []
 path = "benches/decoder.rs"
 name = "decoder"
 harness = false
+
+[[bench]]
+path = "benches/unfilter.rs"
+name = "unfilter"
+harness = false
+required-features = ["benchmarks"]

--- a/benches/unfilter.rs
+++ b/benches/unfilter.rs
@@ -1,0 +1,56 @@
+//! Usage example:
+//!
+//! ```
+//! $ alias bench="rustup run nightly cargo bench"
+//! $ bench --bench=unfilter --features=benchmarks -- --save-baseline my_baseline
+//! ... tweak something, say the Sub filter ...
+//! $ bench --bench=unfilter --features=benchmarks -- filter=Sub --baseline my_baseline
+//! ```
+
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use png::benchable_apis::unfilter;
+use png::FilterType;
+use rand::Rng;
+
+fn unfilter_all(c: &mut Criterion) {
+    let bpps = [1, 2, 3, 4, 6, 8];
+    let filters = [
+        FilterType::Sub,
+        FilterType::Up,
+        FilterType::Avg,
+        FilterType::Paeth,
+    ];
+    for &filter in filters.iter() {
+        for &bpp in bpps.iter() {
+            bench_unfilter(c, filter, bpp);
+        }
+    }
+}
+
+criterion_group!(benches, unfilter_all);
+criterion_main!(benches);
+
+fn bench_unfilter(c: &mut Criterion, filter: FilterType, bpp: u8) {
+    let mut group = c.benchmark_group("unfilter");
+
+    fn get_random_bytes<R: Rng>(rng: &mut R, n: usize) -> Vec<u8> {
+        use rand::Fill;
+        let mut result = vec![0u8; n];
+        result.as_mut_slice().try_fill(rng).unwrap();
+        result
+    }
+    let mut rng = rand::thread_rng();
+    let row_size = 4096 * (bpp as usize);
+    let two_rows = get_random_bytes(&mut rng, row_size * 2);
+
+    group.throughput(Throughput::Bytes(row_size as u64));
+    group.bench_with_input(
+        format!("filter={filter:?}/bpp={bpp}"),
+        &two_rows,
+        |b, two_rows| {
+            let (prev_row, curr_row) = two_rows.split_at(row_size);
+            let mut curr_row = curr_row.to_vec();
+            b.iter(|| unfilter(filter, bpp, prev_row, curr_row.as_mut_slice()));
+        },
+    );
+}

--- a/src/benchable_apis.rs
+++ b/src/benchable_apis.rs
@@ -6,12 +6,7 @@ use crate::filter::FilterType;
 
 /// Re-exporting `unfilter` to make it easier to benchmark, despite some items being only
 /// `pub(crate)`: `fn unfilter`, `enum BytesPerPixel`.
-pub fn unfilter(
-    filter: FilterType,
-    tbpp: u8,
-    previous: &[u8],
-    current: &mut [u8],
-) {
+pub fn unfilter(filter: FilterType, tbpp: u8, previous: &[u8], current: &mut [u8]) {
     let tbpp = BytesPerPixel::for_prediction(tbpp as usize);
     crate::filter::unfilter(filter, tbpp, previous, current)
 }

--- a/src/benchable_apis.rs
+++ b/src/benchable_apis.rs
@@ -1,0 +1,17 @@
+//! Development-time-only helper module for exporting private APIs so that they can be benchmarked.
+//! This module is gated behind the "benchmarks" feature.
+
+use crate::common::BytesPerPixel;
+use crate::filter::FilterType;
+
+/// Re-exporting `unfilter` to make it easier to benchmark, despite some items being only
+/// `pub(crate)`: `fn unfilter`, `enum BytesPerPixel`.
+pub fn unfilter(
+    filter: FilterType,
+    tbpp: u8,
+    previous: &[u8],
+    current: &mut [u8],
+) {
+    let tbpp = BytesPerPixel::for_prediction(tbpp as usize);
+    crate::filter::unfilter(filter, tbpp, previous, current)
+}

--- a/src/benchable_apis.rs
+++ b/src/benchable_apis.rs
@@ -7,6 +7,6 @@ use crate::filter::FilterType;
 /// Re-exporting `unfilter` to make it easier to benchmark, despite some items being only
 /// `pub(crate)`: `fn unfilter`, `enum BytesPerPixel`.
 pub fn unfilter(filter: FilterType, tbpp: u8, previous: &[u8], current: &mut [u8]) {
-    let tbpp = BytesPerPixel::for_prediction(tbpp as usize);
+    let tbpp = BytesPerPixel::from_usize(tbpp as usize);
     crate::filter::unfilter(filter, tbpp, previous, current)
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -594,15 +594,7 @@ impl Info<'_> {
     /// has the consequence that the number of possible values is rather small. To make this fact
     /// more obvious in the type system and the optimizer we use an explicit enum here.
     pub(crate) fn bpp_in_prediction(&self) -> BytesPerPixel {
-        match self.bytes_per_pixel() {
-            1 => BytesPerPixel::One,
-            2 => BytesPerPixel::Two,
-            3 => BytesPerPixel::Three,
-            4 => BytesPerPixel::Four,
-            6 => BytesPerPixel::Six,   // Only rgb×16bit
-            8 => BytesPerPixel::Eight, // Only rgba×16bit
-            _ => unreachable!("Not a possible byte rounded pixel width"),
-        }
+        BytesPerPixel::for_prediction(self.bytes_per_pixel())
     }
 
     /// Returns the number of bytes needed for one deinterlaced image.
@@ -695,6 +687,18 @@ impl Info<'_> {
 }
 
 impl BytesPerPixel {
+    pub(crate) fn for_prediction(bpp: usize) -> Self {
+        match bpp {
+            1 => BytesPerPixel::One,
+            2 => BytesPerPixel::Two,
+            3 => BytesPerPixel::Three,
+            4 => BytesPerPixel::Four,
+            6 => BytesPerPixel::Six,   // Only rgb×16bit
+            8 => BytesPerPixel::Eight, // Only rgba×16bit
+            _ => unreachable!("Not a possible byte rounded pixel width"),
+        }
+    }
+
     pub(crate) fn into_usize(self) -> usize {
         self as usize
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -594,7 +594,7 @@ impl Info<'_> {
     /// has the consequence that the number of possible values is rather small. To make this fact
     /// more obvious in the type system and the optimizer we use an explicit enum here.
     pub(crate) fn bpp_in_prediction(&self) -> BytesPerPixel {
-        BytesPerPixel::for_prediction(self.bytes_per_pixel())
+        BytesPerPixel::from_usize(self.bytes_per_pixel())
     }
 
     /// Returns the number of bytes needed for one deinterlaced image.
@@ -687,7 +687,7 @@ impl Info<'_> {
 }
 
 impl BytesPerPixel {
-    pub(crate) fn for_prediction(bpp: usize) -> Self {
+    pub(crate) fn from_usize(bpp: usize) -> Self {
         match bpp {
             1 => BytesPerPixel::One,
             2 => BytesPerPixel::Two,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,6 @@ pub use crate::decoder::{
 };
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
 pub use crate::filter::{AdaptiveFilterType, FilterType};
+
+#[cfg(feature = "benchmarks")]
+pub mod benchable_apis;


### PR DESCRIPTION
Can you PTAL?  The new benchmarks from this PR should help with work on performance improvements of `fn unfilter`.

The real motivation for this PR is that it is a prelude to a series of commits at https://github.com/image-rs/image-png/compare/bf2c26b5d9d99973d98a850084ea62af32b403e4...1c78a3fa50912240dd05cbcfd192793c23687cde that results in a significant decoding speed-up (measured on Intel).  Special thanks to @veluca93 for help with various SIMD questions that I had.  Results that I got from running the benchmarks:
- `decode/kodim02.png`: -26.6% time
- `decode/kodim17.png`: -25.7% time
- `decode/kodim07.png`: -27.1% time
- `decode/kodim23.png`: -21.8% time
- `unfilter/filter=Sub/bpp=3`: -71.5% time
- `unfilter/filter=Sub/bpp=6`: -86.1% time
- `unfilter/filter=Avg/bpp=3`: -71.8% time
- `unfilter/filter=Avg/bpp=6`: -70.6% time
- `unfilter/filter=Paeth/bpp=3`: -51.4% time
- `unfilter/filter=Paeth/bpp=6`: -62.9% time
- AFAICT other `decode/...` and `unfilter/...` benchmarks are unchanged

I note that the speed-up above depends on `std::simd` which hasn't yet been stabilized, so I thought that it would be best to have a separate PR for just the benchmarks.  (i.e. the new benchmarks seem desirable on their own, even if we decide not to pursue the `std::simd`-based improvements)

/cc @calebzulawski as FYI, since the improvements are possible thanks to `std::simd` and https://github.com/rust-lang/rust/issues/86656.  