### PR TITLE
Using `std::simd` to speed-up `unfilter` for `Paeth` for bpp=3 and bpp=6

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
     - run: rustup default stable
     - name: test
       run: >
-        cargo test -v --all-targets --all-features
+        cargo test -v --all-targets
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/benches/unfilter.rs
+++ b/benches/unfilter.rs
@@ -2,9 +2,9 @@
 //!
 //! ```
 //! $ alias bench="rustup run nightly cargo bench"
-//! $ bench --bench=unfilter --features=benchmarks -- --save-baseline my_baseline
+//! $ bench --bench=unfilter --features=benchmarks,unstable -- --save-baseline my_baseline
 //! ... tweak something, say the Sub filter ...
-//! $ bench --bench=unfilter --features=benchmarks -- filter=Sub --baseline my_baseline
+//! $ bench --bench=unfilter --features=benchmarks,unstable -- filter=Sub --baseline my_baseline
 //! ```
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 //! ```
 //!
 
+#![cfg_attr(feature = "unstable", feature(portable_simd))]
 #![forbid(unsafe_code)]
 
 #[macro_use]


### PR DESCRIPTION
PTAL?

I hope that we can land this series of 4 commits please.  I understand that relying on unstable language/standard-library features means additional maintenance burden, but:
- There is a precedent for using the `unstable` feature of the `png` crate in the past: 6c0b8fa2a041ddf32e7acfdb5d5877187863ea29 (i.e. this PR doesn't introduce the `unstable` feature)
- The risk of having to deal with breaking changes (which an unstable feature can introduce at any time) only affects library clients that explicitly opt into using the `unstable` feature.

Do you think it might be desirable to cover the nightly + `unstable`-feature-enabled configuration on CI of the `png` crate?  FWIW Chromium uses the nightly compiler (rolled into Chromium toolchain every 1-2 weeks) and can also serve as a canary for detecting breakages (if/once we start depending on the `png` crate - this is still a work-in-progress and we are still evaluating Rust performance against the C/C++ implementation).

Note that I have tried to extend the `std::simd` approach to other bpp cases, but it failed to produce measurable improvements - see: https://github.com/image-rs/image-png/commit/36b541b6b4cf4eec5e1f8f21e544a324c7442bbd

Can you please provide your feedback on whether I should also try to make additional changes to simplify existing `unfilter` code?  (@marshallpierce has pointed out that two versions of the code at https://godbolt.org/z/5MvssMncb compile to the same auto-vectorized code.)  On one hand, simpler code seems nice (easier to read, less wrapping to fit 100 columns).  OTOH, the simplification can be seen as an unnecessary change (and therefore unnecessary risk as auto-vectorization is a bit magical and difficult to test).