### PR TITLE
New PNG inputs for benchmarking non-compressed, non-filtered data.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ flate2 = "1.0"
 miniz_oxide = { version = "0.7.1", features = ["simd"] }
 
 [dev-dependencies]
+byteorder = "1.5.0"
 clap = { version = "3.0", features = ["derive"] }
 criterion = "0.3.1"
 getopts = "0.2.14"

--- a/benches/png_generator.rs
+++ b/benches/png_generator.rs
@@ -1,0 +1,93 @@
+use byteorder::WriteBytesExt;
+use std::io::Write;
+
+/// Generates a store-only, non-compressed image:
+///
+/// * `00` compression mode (i.e.`BTYPE` = `00` = no compression) is used
+/// * No filter is applied to the image rows
+///
+/// Currently the image always has the following properties:
+///
+/// * Single `IDAT` chunk
+/// * Zlib chunks of maximum possible size
+/// * 8-bit RGBA
+///
+/// These images are somewhat artificial, but may be useful for benchmarking performance of parts
+/// outside of `fdeflate` crate and/or the `unfilter` function (e.g. these images were originally
+/// used to evaluate changes to minimize copying of image pixels between various buffers - see
+/// [this
+/// discussion](https://github.com/image-rs/image-png/discussions/416#discussioncomment-7436871)
+/// for more details).
+pub fn write_noncompressed_png(w: &mut impl Write, width: u32) {
+    write_png_sig(w);
+    write_ihdr(w, width);
+    write_noncompressed_idat(w, width);
+    write_iend(w);
+}
+
+fn write_png_sig(w: &mut impl Write) {
+    const SIG: [u8; 8] = [137, 80, 78, 71, 13, 10, 26, 10];
+    w.write_all(&SIG).unwrap();
+}
+
+fn write_chunk(w: &mut impl Write, chunk_type: &[u8], data: &[u8]) {
+    let crc = {
+        let input = chunk_type
+            .iter()
+            .copied()
+            .chain(data.iter().copied())
+            .collect::<Vec<_>>();
+        crc32fast::hash(input.as_slice())
+    };
+    w.write_u32::<byteorder::BigEndian>(data.len() as u32)
+        .unwrap();
+    w.write_all(chunk_type).unwrap();
+    w.write_all(data).unwrap();
+    w.write_u32::<byteorder::BigEndian>(crc).unwrap();
+}
+
+fn write_ihdr(w: &mut impl Write, width: u32) {
+    let mut data = Vec::new();
+    data.write_u32::<byteorder::BigEndian>(width).unwrap();
+    data.write_u32::<byteorder::BigEndian>(width).unwrap(); // height
+    data.write_u8(8).unwrap(); // bit depth = always 8-bits per channel
+    data.write_u8(6).unwrap(); // color type = color + alpha
+    data.write_u8(0).unwrap(); // compression method (0 is the only allowed value)
+    data.write_u8(0).unwrap(); // filter method (0 is the only allowed value)
+    data.write_u8(0).unwrap(); // interlace method = no interlacing
+    write_chunk(w, b"IHDR", &data);
+}
+
+fn write_noncompressed_idat(w: &mut impl Write, width: u32) {
+    // Generate arbitrary test pixels.
+    let image_pixels = {
+        let mut row = Vec::new();
+        row.write_u8(0).unwrap(); // filter = no filter
+
+        let row_pixels = (0..width)
+            .map(|i| {
+                let color: u8 = (i * 255 / width) as u8;
+                let alpha: u8 = 0xff;
+                [color, 255 - color, color / 2, alpha]
+            })
+            .flatten();
+        row.extend(row_pixels);
+
+        std::iter::repeat(row)
+            .take(width as usize)
+            .flatten()
+            .collect::<Vec<_>>()
+    };
+
+    let mut zlib_data = Vec::new();
+    let mut store_only_compressor =
+        fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(&mut zlib_data)).unwrap();
+    store_only_compressor.write_data(&image_pixels).unwrap();
+    store_only_compressor.finish().unwrap();
+
+    write_chunk(w, b"IDAT", &zlib_data);
+}
+
+fn write_iend(w: &mut impl Write) {
+    write_chunk(w, b"IEND", &[]);
+}

--- a/tests/benches/README.md
+++ b/tests/benches/README.md
@@ -1,12 +1,13 @@
 Copyrights:
 
-Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png: Public Domain, according to Wikimedia
-kodim*.png: Eastman Kodak Company, released for unrestricted use
-Transparency.png: Public Domain, according to Wikimedia
+* `Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png`: Public Domain, according to Wikimedia
+* `kodim*.png`: Eastman Kodak Company, released for unrestricted use
+* `Transparency.png`: Public Domain, according to Wikimedia
 
 The images use different filtering:
-Lohengrin: no filtering
-kodim02: mixed
-kodim07: mainly paeth
-kodim17: mainly sub
-kodim23: mixed
+
+* Lohengrin: no filtering
+* kodim02: mixed
+* kodim07: mainly paeth
+* kodim17: mainly sub
+* kodim23: mixed


### PR DESCRIPTION
PTAL?

The new test images are somewhat artificial, but they help to see the performance of the bulk of the PNG decoding code.  Runtime overhead of this code is relatively small when compared to the overhead of decompression (mostly in the `fdeflate` crate) and unfiltering (in `src/filter.rs`), but performance of this code is still important (e.g. as discussed in [another discussion thread](https://github.com/image-rs/image-png/discussions/416#discussioncomment-7436871), optimizing this code can yield 10+% of gains for a more realistic test corpus).  And I think that these new test images will be a useful tool for evaluating performance of this code (which may be more difficult to confidently measure using other test inputs).

I am adding 2 separate images, because I think that:

* The 128x128 image will be useful for evaluating performance of copying the image data out of a PNG file
* The 8x8 image will be useful for evaluating constant costs (e.g. when trying to optimize handling of small images - favicons, emojis, etc.)