### PR TITLE
Optimize compaction of Reader::data_stream

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -732,7 +732,9 @@ impl<R: Read> Reader<R> {
 
             // Clear the current buffer before appending more data.
             if self.prev_start > 0 {
-                self.data_stream.drain(..self.prev_start).for_each(drop);
+                self.data_stream.copy_within(self.prev_start.., 0);
+                self.data_stream
+                    .truncate(self.data_stream.len() - self.prev_start);
                 self.current_start -= self.prev_start;
                 self.prev_start = 0;
             }


### PR DESCRIPTION
As suggested in https://github.com/image-rs/image-png/pull/422#discussion_r1383779495.

I also tried removing the drain call in _src/decoder/zlib.rs_ but didn't see any performance improvement from that.