### PR TITLE
Cap buffer sizes via `ZlibStream::set_max_total_output`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ include = [
 [dependencies]
 bitflags = "1.0"
 crc32fast = "1.2.0"
-fdeflate = "0.3.1"
+fdeflate = "0.3.3"
 flate2 = "1.0"
 miniz_oxide = { version = "0.7.1", features = ["simd"] }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -73,8 +73,8 @@ pub fn write_rgba8_ihdr_with_width(w: &mut impl Write, width: u32) {
     write_chunk(w, b"IHDR", &data);
 }
 
-/// Generates RGBA8 `width` x `width` image and wraps it in a store-only zlib container.
-pub fn generate_rgba8_with_width(width: u32) -> Vec<u8> {
+/// Generates RGBA8 `width` x `height` image and wraps it in a store-only zlib container.
+pub fn generate_rgba8_with_width_and_height(width: u32, height: u32) -> Vec<u8> {
     // Generate arbitrary test pixels.
     let image_pixels = {
         let mut row = Vec::new();
@@ -88,7 +88,7 @@ pub fn generate_rgba8_with_width(width: u32) -> Vec<u8> {
         row.extend(row_pixels);
 
         std::iter::repeat(row)
-            .take(width as usize)
+            .take(height as usize)
             .flatten()
             .collect::<Vec<_>>()
     };
@@ -104,7 +104,7 @@ pub fn generate_rgba8_with_width(width: u32) -> Vec<u8> {
 
 /// Writes an IDAT chunk.
 pub fn write_rgba8_idats(w: &mut impl Write, size: u32, idat_bytes: usize) {
-    let data = generate_rgba8_with_width(size);
+    let data = generate_rgba8_with_width_and_height(size, size);
 
     for chunk in data.chunks(idat_bytes) {
         write_chunk(w, b"IDAT", chunk);


### PR DESCRIPTION
PTAL?  This results in quite a significant performance improvement for the `noncompressed-8x8.png` benchmark (bigger improvement than https://github.com/image-rs/image-png/pull/427 and https://github.com/image-rs/image-png/pull/428 combined - I am surprised).