### PR TITLE
Benchmark varying sizes of IDATs and larger generated images

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ miniz_oxide = { version = "0.7.1", features = ["simd"] }
 [dev-dependencies]
 byteorder = "1.5.0"
 clap = { version = "3.0", features = ["derive"] }
-criterion = "0.5.1"
+criterion = "0.4.0"
 getopts = "0.2.14"
 glium = { version = "0.32", features = ["glutin"], default-features = false }
 glob = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ miniz_oxide = { version = "0.7.1", features = ["simd"] }
 [dev-dependencies]
 byteorder = "1.5.0"
 clap = { version = "3.0", features = ["derive"] }
-criterion = "0.3.1"
+criterion = "0.5.1"
 getopts = "0.2.14"
 glium = { version = "0.32", features = ["glutin"], default-features = false }
 glob = "0.3"

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1716,7 +1716,7 @@ mod tests {
             ..Default::default()
         };
         write_fctl(w, &fctl);
-        write_rgba8_idat_with_width(w, width);
+        write_rgba8_idats(w, width, 0x7fffffff);
 
         fctl.sequence_number += 1;
         write_fctl(w, &fctl);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -27,10 +27,10 @@ use std::io::Write;
 /// discussion](https://github.com/image-rs/image-png/discussions/416#discussioncomment-7436871)
 /// for more details).
 #[allow(dead_code)] // Used from `benches/decoder.rs`
-pub fn write_noncompressed_png(w: &mut impl Write, width: u32) {
+pub fn write_noncompressed_png(w: &mut impl Write, size: u32, idat_bytes: usize) {
     write_png_sig(w);
-    write_rgba8_ihdr_with_width(w, width);
-    write_rgba8_idat_with_width(w, width);
+    write_rgba8_ihdr_with_width(w, size);
+    write_rgba8_idats(w, size, idat_bytes);
     write_iend(w);
 }
 
@@ -105,8 +105,12 @@ pub fn generate_rgba8_with_width(width: u32) -> Vec<u8> {
 }
 
 /// Writes an IDAT chunk.
-pub fn write_rgba8_idat_with_width(w: &mut impl Write, width: u32) {
-    write_chunk(w, b"IDAT", &generate_rgba8_with_width(width));
+pub fn write_rgba8_idats(w: &mut impl Write, size: u32, idat_bytes: usize) {
+    let data = generate_rgba8_with_width(size);
+
+    for chunk in data.chunks(idat_bytes) {
+        write_chunk(w, b"IDAT", chunk);
+    }
 }
 
 /// Writes an IEND chunk.


### PR DESCRIPTION
This PR expands the range of generated noncompressed images for the benchmarks. In particular, it adds larger images that spill into the L3 cache and to RAM respectively, and varies the sizes of IDATs to be capped at 4KB, 64KB, or 2GB.

This also upgrades criterion to the last version.