### PR TITLE
Test failing image for skip_ancillary_crc disabled

### DIFF
--- a/tests/bugfixes.rs
+++ b/tests/bugfixes.rs
@@ -1,0 +1,18 @@
+use std::fs::File;
+
+use png::{DecodeOptions, Decoder, DecodingError};
+
+#[test]
+fn issue_430() {
+    let file = File::open("tests/bugfixes/issue#430.png").unwrap();
+
+    let mut decode_options = DecodeOptions::default();
+    decode_options.set_skip_ancillary_crc_failures(false);
+
+    let decoder = Decoder::new_with_options(file, decode_options).read_info();
+
+    assert!(
+        matches!(decoder, Err(DecodingError::Format(_))),
+        "Decoding of iCCP chunk with invalid CRC should have failed with 'skip_ancillary_crc' disabled."
+    );
+}


### PR DESCRIPTION
Complements 7f70ffa26c77956e47670eb959b3aea27aafdced

cc @anforowicz 