### PR TITLE
Update `unstable` nightly portable-simd imports

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -9,9 +9,9 @@ use crate::common::BytesPerPixel;
 /// feature of Rust gets stabilized.
 #[cfg(feature = "unstable")]
 mod simd {
-    use std::simd::{
-        u8x4, u8x8, LaneCount, Simd, SimdInt, SimdOrd, SimdPartialEq, SimdUint, SupportedLaneCount,
-    };
+    use std::simd::cmp::{SimdOrd, SimdPartialEq};
+    use std::simd::num::{SimdInt, SimdUint};
+    use std::simd::{u8x4, u8x8, LaneCount, Simd, SupportedLaneCount};
 
     /// This is an equivalent of the `PaethPredictor` function from
     /// [the spec](http://www.libpng.org/pub/png/spec/1.2/PNG-Filters.html#Filter-type-4-Paeth)


### PR DESCRIPTION
Import `SimdOrd`, `SimdPartialEq` from `std::simd::cmp`
Import `SimdInt`, `SimdUint` from `std::simd::num`

The most recent `portable-simd` subtree sync moved some traits out of the top level modules.