### PR TITLE
Validate provided info in Encoder::with_info

### DIFF
--- a/examples/change-png-info.rs
+++ b/examples/change-png-info.rs
@@ -29,7 +29,7 @@ fn main() -> BoxResult<()> {
 
     // Edit previous info
     info_out.interlaced = info_default.interlaced;
-    let mut encoder = png::Encoder::with_info(w, info_out);
+    let mut encoder = png::Encoder::with_info(w, info_out)?;
     encoder.set_depth(png_info.bit_depth);
 
     // Edit some attribute

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -169,12 +169,22 @@ impl<'a, W: Write> Encoder<'a, W> {
         }
     }
 
-    pub fn with_info(w: W, info: Info<'a>) -> Encoder<'a, W> {
-        Encoder {
+    pub fn with_info(w: W, info: Info<'a>) -> Result<Encoder<'a, W>> {
+        if info.animation_control.is_some() != info.frame_control.is_some() {
+            return Err(EncodingError::Format(FormatErrorKind::NotAnimated.into()));
+        }
+
+        if let Some(actl) = info.animation_control {
+            if actl.num_frames == 0 {
+                return Err(EncodingError::Format(FormatErrorKind::ZeroFrames.into()));
+            }
+        }
+
+        Ok(Encoder {
             w,
             info,
             options: Options::default(),
-        }
+        })
     }
 
     /// Specify that the image is animated.


### PR DESCRIPTION
This would normally be a breaking change, but the Encoder::with_info API hasn't yet been included in a release.