### PR TITLE
Adds `Reader::finish` to read all the auxillary chunks that comes after the image

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -609,9 +609,8 @@ impl<R: Read> Reader<R> {
             let mut buf = Vec::new();
             let state = self.decoder.decode_next(&mut buf)?;
 
-            match state {
-                None => break,
-                _ => {}
+            if state.is_none() {
+                break;
             }
         }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -609,12 +609,7 @@ impl<R: Read> Reader<R> {
             let state = self.decoder.decode_next(&mut buf)?;
 
             match state {
-                Some(Decoded::ImageEnd) => break,
-                None => {
-                    return Err(DecodingError::Format(
-                        FormatErrorInner::MissingImageData.into(),
-                    ))
-                }
+                None => break,
                 _ => {}
             }
         }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -598,7 +598,8 @@ impl<R: Read> Reader<R> {
         }))
     }
 
-    /// Read the rest of the image and chunks and finish up, including text chunks or others, will discard the rest of the image data
+    /// Read the rest of the image and chunks and finish up, including text chunks or others
+    /// This will discard the rest of the image if the image is not read already with [`Reader::next_frame`], [`Reader::next_row`] or [`Reader::next_interlaced_row`]
     pub fn finish(&mut self) -> Result<(), DecodingError> {
         self.next_frame = SubframeIdx::End;
         self.data_stream.clear();


### PR DESCRIPTION
Closes #343 