### PR TITLE
Bypass BufReader and state machine when decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ include = [
 
 [dependencies]
 bitflags = "1.0"
+byteorder = "1.5.0"
 crc32fast = "1.2.0"
 fdeflate = "0.3.3"
 flate2 = "1.0"
@@ -36,6 +37,10 @@ glium = { version = "0.32", features = ["glutin"], default-features = false }
 glob = "0.3"
 rand = "0.8.4"
 term = "0.7"
+
+
+[profile.release]
+debug = 2
 
 [features]
 unstable = []

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -269,68 +269,6 @@ impl<R: Read> Decoder<R> {
     }
 }
 
-// struct ReadDecoder<R: Read> {
-//     reader: R, //BufReader<R>,
-//     decoder: StreamingDecoder,
-//     at_eof: bool,
-// }
-
-// impl<R: Read> ReadDecoder<R> {
-//     // /// Returns the next decoded chunk. If the chunk is an ImageData chunk, its contents are written
-//     // /// into image_data.
-//     // fn decode_next(&mut self, image_data: &mut Vec<u8>) -> Result<Option<Decoded>, DecodingError> {
-//     //     while !self.at_eof {
-//     //         let (consumed, result) = {
-//     //             let buf = self.reader.fill_buf()?;
-//     //             if buf.is_empty() {
-//     //                 return Err(DecodingError::Format(
-//     //                     FormatErrorInner::UnexpectedEof.into(),
-//     //                 ));
-//     //             }
-//     //             self.decoder.update(buf, image_data)?
-//     //         };
-//     //         self.reader.consume(consumed);
-//     //         match result {
-//     //             Decoded::Nothing => (),
-//     //             Decoded::ImageEnd => self.at_eof = true,
-//     //             result => return Ok(Some(result)),
-//     //         }
-//     //     }
-//     //     Ok(None)
-//     // }
-
-//     fn finish_decoding(&mut self) -> Result<(), DecodingError> {
-//         // while !self.at_eof {
-//         //     let buf = self.reader.fill_buf()?;
-//         //     if buf.is_empty() {
-//         //         return Err(DecodingError::Format(
-//         //             FormatErrorInner::UnexpectedEof.into(),
-//         //         ));
-//         //     }
-//         //     let (consumed, event) = self.decoder.update(buf, &mut vec![])?;
-//         //     self.reader.consume(consumed);
-//         //     match event {
-//         //         Decoded::Nothing => (),
-//         //         Decoded::ImageEnd => self.at_eof = true,
-//         //         // ignore more data
-//         //         Decoded::ChunkComplete(_, _) | Decoded::ChunkBegin(_, _) | Decoded::ImageData => {}
-//         //         Decoded::ImageDataFlushed => return Ok(()),
-//         //         Decoded::PartialChunk(_) => {}
-//         //         new => unreachable!("{:?}", new),
-//         //     }
-//         // }
-
-//         // Err(DecodingError::Format(
-//         //     FormatErrorInner::UnexpectedEof.into(),
-//         // ))
-//         Ok(())
-//     }
-
-//     fn info(&self) -> Option<&Info> {
-//         self.decoder.info.as_ref()
-//     }
-// }
-
 /// PNG reader (mostly high-level interface)
 ///
 /// Provides a high level that iterates over lines or whole images.

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -722,7 +722,7 @@ impl StreamingDecoder {
 
             let initial_length = self.idat_stream.len();
             let read_amount =
-                (self.current_chunk.remaining as usize).min((32 << 10) - self.idat_stream.len());
+                (self.current_chunk.remaining as usize).min((64 << 10) - self.idat_stream.len());
 
             // This reads a fixed amount of data into a Vec without initializing it first.
             self.idat_stream.reserve(read_amount);


### PR DESCRIPTION
This sketches out how we could switch away from our current `BufRead` approach of taking slices of input to drive a state machine. It instead takes a `Read` impl and pull bytes from it as needed.

Leaving this draft state because there's APNG decoding isn't fully working at the moment and because I'm not fully sure we want to go down this path of duplicating the decoding logic between the low-level streaming API and the higher-level decoding API.

Performance is mixed with both significant improvements and regressions. It seems to vary based on the constants driving the minimum and maximum IDAT buffer sizes passed to the zlib decompressor.

```
decode/kodim17.png
                        time:   [-2.7008% -2.6371% -2.5847%] (p = 0.00 < 0.05)

decode/kodim07.png
                        time:   [+0.6333% +1.3371% +2.5938%] (p = 0.00 < 0.05)

decode/kodim02.png
                        time:   [+0.8983% +1.0315% +1.1734%] (p = 0.00 < 0.05)

decode/kodim23.png
                        time:   [+0.1002% +0.1620% +0.2178%] (p = 0.00 < 0.05)

decode/Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png
                        time:   [-1.0207% -0.6634% -0.3293%] (p = 0.00 < 0.05)

decode/Transparency.png time:
                        time:   [+77.678% +78.337% +78.794%] (p = 0.00 < 0.05)

generated-noncompressed-4k-idat/8x8.png
                        time:   [-44.694% -44.589% -44.510%] (p = 0.00 < 0.05)

generated-noncompressed-4k-idat/128x128.png
                        time:   [+28.799% +29.139% +29.482%] (p = 0.00 < 0.05)
...

generated-noncompressed-2g-idat/12288x12288.png
                        time:   [-21.915% -20.856% -19.853%] (p = 0.00 < 0.05)
```

