### PR TITLE
Fix test and warnings

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,7 +1,6 @@
 extern crate crc32fast;
 
-use std::convert::{From, TryInto};
-use std::default::Default;
+use std::convert::TryInto;
 use std::error;
 use std::fmt;
 use std::io;
@@ -1765,7 +1764,7 @@ mod tests {
     #[test]
     fn test_png_with_broken_iccp() {
         let decoder = crate::Decoder::new(File::open("tests/iccp/broken_iccp.png").unwrap());
-        assert!(decoder.read_info().is_err());
+        assert!(decoder.read_info().is_ok());
         let mut decoder = crate::Decoder::new(File::open("tests/iccp/broken_iccp.png").unwrap());
         decoder.set_ignore_iccp_chunk(true);
         assert!(decoder.read_info().is_ok());

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1716,9 +1716,9 @@ mod tests {
     use crate::Decoder;
 
     use rand::{thread_rng, Rng};
+    use std::cmp;
     use std::fs::File;
-    use std::io::{Cursor, Write};
-    use std::{cmp, io};
+    use std::io::Cursor;
 
     #[test]
     fn roundtrip() {


### PR DESCRIPTION
Corrupt iCCP chunks are now ignored rather than triggering errors. 