### PR TITLE
Add compression level

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -325,6 +325,8 @@ pub enum Compression {
         note = "use one of the other compression levels instead, such as 'fast'"
     )]
     Rle,
+    /// Integer representing the compression level, typically on a scale of 0-9
+    Level(u32),
 }
 
 impl Default for Compression {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1702,6 +1702,7 @@ impl Compression {
             Compression::Default => flate2::Compression::default(),
             Compression::Fast => flate2::Compression::fast(),
             Compression::Best => flate2::Compression::best(),
+            Compression::Level(level) => flate2::Compression::new(level),
             #[allow(deprecated)]
             Compression::Huffman => flate2::Compression::none(),
             #[allow(deprecated)]


### PR DESCRIPTION
This PR adds `Compression::Level(u32)` to allow finer control over compression settings. It maps directly to [`flate2::Compression::new(level)`](https://docs.rs/flate2/1.0.30/src/flate2/lib.rs.html#195-197).


