### PR TITLE
StoredOnlyCompressor feature is here, and we can now access it.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -315,6 +315,8 @@ pub enum Compression {
     /// the encoder can do, but is meant to emulate the `Best` setting in the `Flate2`
     /// library.
     Best,
+    /// Do no compression
+    None,
     #[deprecated(
         since = "0.17.6",
         note = "use one of the other compression levels instead, such as 'fast'"

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -694,7 +694,7 @@ impl<W: Write> Writer<W> {
         let adaptive_method = self.options.adaptive_filter;
 
         let zlib_encoded = match self.info.compression {
-            Compression::None => self.stored_only_compressor(data, in_len)?,
+            Compression::None => Self::stored_only_compressor(data, in_len)?,
             Compression::Fast => {
                 let mut compressor = fdeflate::Compressor::new(std::io::Cursor::new(Vec::new()))?;
 
@@ -725,7 +725,7 @@ impl<W: Write> Writer<W> {
                     // requested by the user. Doing filtering again would only add performance
                     // cost for both encoding and subsequent decoding, without improving the
                     // compression ratio.
-                    self.stored_only_compressor(data, in_len)?
+                    Self::stored_only_compressor(data, in_len)?
                 } else {
                     compressed
                 }
@@ -812,7 +812,7 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn stored_only_compressor(&self, data: &[u8], in_len: usize) -> Result<Vec<u8>> {
+    fn stored_only_compressor(data: &[u8], in_len: usize) -> Result<Vec<u8>> {
         let mut compressor = fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(Vec::new()))?;
         for line in data.chunks(in_len) {
             compressor.write_data(&[0])?;


### PR DESCRIPTION
StoredOnlyCompressor feature is here, and we can now access it:

> Why

Creating a png with `Compression::None` makes file creation much faster than `Compression::Fast`.

For hard to compress images, file size between `Compression::None` and `Compression::Fast` is is similar.