### PR TITLE
Add `Reader.read_row` for decoding into caller-provided buffer.

### DIFF
--- a/benches/decoder.rs
+++ b/benches/decoder.rs
@@ -41,6 +41,13 @@ fn load_all(c: &mut Criterion) {
     bench_noncompressed_png(&mut g, 2048, 0x7fffffff); // 16 MB
     bench_noncompressed_png(&mut g, 12288, 0x7fffffff); // 576 MB
     g.finish();
+
+    // Incremental decoding via `next_row`
+    let mut g = c.benchmark_group("row-by-row");
+    let mut data = Vec::new();
+    test_utils::write_noncompressed_png(&mut data, 128, 4096);
+    bench_next_row(&mut g, data, "128x128-4k-idat");
+    g.finish();
 }
 
 criterion_group! {benches, load_all}
@@ -52,19 +59,10 @@ fn bench_noncompressed_png(g: &mut BenchmarkGroup<WallTime>, size: u32, idat_byt
     bench_file(g, data, format!("{size}x{size}.png"));
 }
 
+/// This benchmarks decoding via a call to `Reader::next_frame`.
 fn bench_file(g: &mut BenchmarkGroup<WallTime>, data: Vec<u8>, name: String) {
     if data.len() > 1_000_000 {
         g.sample_size(10);
-    }
-
-    fn create_reader(data: &[u8]) -> Reader<&[u8]> {
-        let mut decoder = Decoder::new(data);
-
-        // Cover default transformations used by the `image` crate when constructing
-        // `image::codecs::png::PngDecoder`.
-        decoder.set_transformations(Transformations::EXPAND);
-
-        decoder.read_info().unwrap()
     }
 
     let mut reader = create_reader(data.as_slice());
@@ -78,4 +76,32 @@ fn bench_file(g: &mut BenchmarkGroup<WallTime>, data: Vec<u8>, name: String) {
             reader.next_frame(&mut image).unwrap();
         })
     });
+}
+
+/// This benchmarks decoding via a sequence of `Reader::next_row` calls.
+fn bench_next_row(g: &mut BenchmarkGroup<WallTime>, data: Vec<u8>, name: &str) {
+    let reader = create_reader(data.as_slice());
+    let mut image = vec![0; reader.output_buffer_size()];
+    let bytes_per_row = reader.output_line_size(reader.info().width);
+    g.throughput(Throughput::Bytes(image.len() as u64));
+    g.bench_with_input(name, &data, |b, data| {
+        b.iter(|| {
+            let mut reader = create_reader(data.as_slice());
+
+            for output_row in image.chunks_exact_mut(bytes_per_row) {
+                let decoded_row = reader.next_row().unwrap().unwrap();
+                output_row.copy_from_slice(decoded_row.data());
+            }
+        })
+    });
+}
+
+fn create_reader(data: &[u8]) -> Reader<&[u8]> {
+    let mut decoder = Decoder::new(data);
+
+    // Cover default transformations used by the `image` crate when constructing
+    // `image::codecs::png::PngDecoder`.
+    decoder.set_transformations(Transformations::EXPAND);
+
+    decoder.read_info().unwrap()
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -23,6 +23,7 @@ pub const CHUNK_BUFFER_SIZE: usize = 32 * 1024;
 ///
 /// This is used only in fuzzing. `afl` automatically adds `--cfg fuzzing` to RUSTFLAGS which can
 /// be used to detect that build.
+#[allow(unexpected_cfgs)]
 const CHECKSUM_DISABLED: bool = cfg!(fuzzing);
 
 /// Kind of `u32` value that is being read via `State::U32`.


### PR DESCRIPTION
Add `Reader.read_row` for decoding into caller-provided buffer.

`Reader.read_row` is an alternative to `Reader.next_row`.

* `Reader.next_row` is convenient when the caller doesn't want to manage
  their own buffer, and doesn't mind having extended borrows on `Reader`
  to accommodate `Row` data.
* OTOH the new `Reader.read_row` avoids an extra copy in some scanarios
  which may lead to better runtime performance - see the benchmark
  results below.

The PR adds a `row-by-row/128x128-4k-idat` benchmark (initially based on
`Reader.next_row` which requires an extra copy).  Using the new         
`Reader.read_row` results in the following performance gains in the
benchmark:

time:   [-16.414% -16.196% -15.969%] (p = 0.00 < 0.05)
time:   [-15.570% -15.218% -14.856%] (p = 0.00 < 0.05)
time:   [-16.101% -15.864% -15.629%] (p = 0.00 < 0.05)