### PR TITLE
New public API `pub fn expand_interlaced_row`

### DIFF
--- a/src/adam7.rs
+++ b/src/adam7.rs
@@ -148,16 +148,10 @@ fn expand_adam7_bits(
 }
 
 /// Expands an Adam 7 pass
-pub fn expand_pass(
-    img: &mut [u8],
-    width: u32,
-    scanline: &[u8],
-    pass: u8,
-    line_no: u32,
-    bits_pp: u8,
-) {
+pub fn expand_pass(img: &mut [u8], width: u32, scanline: &[u8], info: &Adam7Info, bits_pp: u8) {
     let width = width as usize;
-    let line_no = line_no as usize;
+    let line_no = info.line as usize;
+    let pass = info.pass;
     let bits_pp = bits_pp as usize;
 
     // pass is out of range but don't blow up
@@ -318,56 +312,57 @@ fn test_expand_pass_subbyte() {
     let mut img = [0u8; 8];
     let width = 8;
     let bits_pp = 1;
+    let info = create_adam7_info_for_tests;
 
-    expand_pass(&mut img, width, &[0b10000000], 1, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b10000000], &info(1, 0, width), bits_pp);
     assert_eq!(img, [0b10000000u8, 0, 0, 0, 0, 0, 0, 0]);
 
-    expand_pass(&mut img, width, &[0b10000000], 2, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b10000000], &info(2, 0, width), bits_pp);
     assert_eq!(img, [0b10001000u8, 0, 0, 0, 0, 0, 0, 0]);
 
-    expand_pass(&mut img, width, &[0b11000000], 3, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b11000000], &info(3, 0, width), bits_pp);
     assert_eq!(img, [0b10001000u8, 0, 0, 0, 0b10001000, 0, 0, 0]);
 
-    expand_pass(&mut img, width, &[0b11000000], 4, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b11000000], &info(4, 0, width), bits_pp);
     assert_eq!(img, [0b10101010u8, 0, 0, 0, 0b10001000, 0, 0, 0]);
 
-    expand_pass(&mut img, width, &[0b11000000], 4, 1, bits_pp);
+    expand_pass(&mut img, width, &[0b11000000], &info(4, 1, width), bits_pp);
     assert_eq!(img, [0b10101010u8, 0, 0, 0, 0b10101010, 0, 0, 0]);
 
-    expand_pass(&mut img, width, &[0b11110000], 5, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b11110000], &info(5, 0, width), bits_pp);
     assert_eq!(img, [0b10101010u8, 0, 0b10101010, 0, 0b10101010, 0, 0, 0]);
 
-    expand_pass(&mut img, width, &[0b11110000], 5, 1, bits_pp);
+    expand_pass(&mut img, width, &[0b11110000], &info(5, 1, width), bits_pp);
     assert_eq!(
         img,
         [0b10101010u8, 0, 0b10101010, 0, 0b10101010, 0, 0b10101010, 0]
     );
 
-    expand_pass(&mut img, width, &[0b11110000], 6, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b11110000], &info(6, 0, width), bits_pp);
     assert_eq!(
         img,
         [0b11111111u8, 0, 0b10101010, 0, 0b10101010, 0, 0b10101010, 0]
     );
 
-    expand_pass(&mut img, width, &[0b11110000], 6, 1, bits_pp);
+    expand_pass(&mut img, width, &[0b11110000], &info(6, 1, width), bits_pp);
     assert_eq!(
         img,
         [0b11111111u8, 0, 0b11111111, 0, 0b10101010, 0, 0b10101010, 0]
     );
 
-    expand_pass(&mut img, width, &[0b11110000], 6, 2, bits_pp);
+    expand_pass(&mut img, width, &[0b11110000], &info(6, 2, width), bits_pp);
     assert_eq!(
         img,
         [0b11111111u8, 0, 0b11111111, 0, 0b11111111, 0, 0b10101010, 0]
     );
 
-    expand_pass(&mut img, width, &[0b11110000], 6, 3, bits_pp);
+    expand_pass(&mut img, width, &[0b11110000], &info(6, 3, width), bits_pp);
     assert_eq!(
         [0b11111111u8, 0, 0b11111111, 0, 0b11111111, 0, 0b11111111, 0],
         img
     );
 
-    expand_pass(&mut img, width, &[0b11111111], 7, 0, bits_pp);
+    expand_pass(&mut img, width, &[0b11111111], &info(7, 0, width), bits_pp);
     assert_eq!(
         [
             0b11111111u8,
@@ -382,7 +377,7 @@ fn test_expand_pass_subbyte() {
         img
     );
 
-    expand_pass(&mut img, width, &[0b11111111], 7, 1, bits_pp);
+    expand_pass(&mut img, width, &[0b11111111], &info(7, 1, width), bits_pp);
     assert_eq!(
         [
             0b11111111u8,
@@ -397,7 +392,7 @@ fn test_expand_pass_subbyte() {
         img
     );
 
-    expand_pass(&mut img, width, &[0b11111111], 7, 2, bits_pp);
+    expand_pass(&mut img, width, &[0b11111111], &info(7, 2, width), bits_pp);
     assert_eq!(
         [
             0b11111111u8,
@@ -412,7 +407,7 @@ fn test_expand_pass_subbyte() {
         img
     );
 
-    expand_pass(&mut img, width, &[0b11111111], 7, 3, bits_pp);
+    expand_pass(&mut img, width, &[0b11111111], &info(7, 3, width), bits_pp);
     assert_eq!(
         [
             0b11111111u8,
@@ -426,4 +421,18 @@ fn test_expand_pass_subbyte() {
         ],
         img
     );
+}
+
+#[cfg(test)]
+fn create_adam7_info_for_tests(pass: u8, line: u32, img_width: u32) -> Adam7Info {
+    let width = {
+        let img_height = 8;
+        Adam7Iterator::new(img_width, img_height)
+            .filter(|info| info.pass == pass)
+            .map(|info| info.width)
+            .next()
+            .unwrap()
+    };
+
+    Adam7Info { pass, line, width }
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -554,7 +554,7 @@ impl<R: Read> Reader<R> {
         self.current_start = 0;
         self.prev_start = 0;
         if self.info().interlaced {
-            let width = self.info().width;
+            let stride = self.output_line_size(self.info().width);
             let samples = color_type.samples() as u8;
             let bits_pp = samples * (bit_depth as u8);
             while let Some(InterlacedRow {
@@ -565,7 +565,7 @@ impl<R: Read> Reader<R> {
             {
                 // `unwrap` won't panic, because we checked `self.info().interlaced` above.
                 let adam7info = interlace.get_adam7_info().unwrap();
-                adam7::expand_pass(buf, width, row, &adam7info, bits_pp);
+                adam7::expand_pass(buf, stride, row, &adam7info, bits_pp);
             }
         } else {
             for row in buf

--- a/src/decoder/transform/palette.rs
+++ b/src/decoder/transform/palette.rs
@@ -5,7 +5,7 @@
 //!
 //! To achieve higher throughput, `create_rgba_palette` combines entries from
 //! `PLTE` and `trNS` chunks into a single lookup table.  This is based on the
-//! ideas explored in https://crbug.com/706134.
+//! ideas explored in <https://crbug.com/706134>.
 //!
 //! Memoization is a trade-off:
 //! * On one hand, memoization requires spending X ns before starting to call

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,9 +71,12 @@ mod srgb;
 pub mod text_metadata;
 mod traits;
 
+pub use crate::adam7::expand_pass as expand_interlaced_row;
+pub use crate::adam7::Adam7Info;
 pub use crate::common::*;
 pub use crate::decoder::{
-    DecodeOptions, Decoded, Decoder, DecodingError, Limits, OutputInfo, Reader, StreamingDecoder,
+    DecodeOptions, Decoded, Decoder, DecodingError, InterlaceInfo, InterlacedRow, Limits,
+    OutputInfo, Reader, StreamingDecoder,
 };
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
 pub use crate::filter::{AdaptiveFilterType, FilterType};

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -145,7 +145,7 @@ pub(crate) enum TextDecodingError {
 
 /// A generalized text chunk trait
 pub trait EncodableTextChunk {
-    /// Encode text chunk as Vec<u8> to a `Write`
+    /// Encode text chunk as `Vec<u8>` to a `Write`
     fn encode<W: Write>(&self, w: &mut W) -> Result<(), EncodingError>;
 }
 


### PR DESCRIPTION
Currently users of [`Reader.next_interlaced_row`](https://docs.rs/png/latest/png/struct.Reader.html#method.next_interlaced_row) can't handle interlaced rows without re-implementing significant chunks of the `png` crate.  This PR resolves this by exposing a new public API:  `pub fn expand_interlaced_row` + `pub enum InterlaceInfo`.