### PR TITLE
Support for resuming decoding after `UnexpectedEof`.

### DIFF
--- a/fuzz/fuzz_targets/buf_independent.rs
+++ b/fuzz/fuzz_targets/buf_independent.rs
@@ -1,8 +1,32 @@
+//! This fuzzer tests that decoding results are the same regardless of the
+//! details of how the `Read` trait exposes the underlying input via
+//! the `fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize>`
+//! method:
+//!
+//! * Whole slice - `impl Read for &[u8]`:
+//!     - The whole slice is available for reading (if it fits into `buf`)
+//!     - No IO errors are expected
+//!     - Motivation: This is the baseline
+//! * Byte-by-byte - `SmalBuf<R>`:
+//!     - At most 1 byte can be read in a single call to `read`
+//!     - Motivation: Testing that decoding works regardless of how the input is split
+//!       into multiple `read` calls.  (The test checks every possible `read` boundary in the input
+//!       buffer, even though in practice file or network buffers would split the input into only a
+//!       handful of chunks.)
+//! * TODO: Intermittent EOFs:
+//!     - Intermittently `read` report 0 available bytes.
+//!     - Still no IO errors at the `Read` trait level
+//!     - Motivation: Testing support for decoding a streaming or partial input
+//!       (i.e. scenarios where initially only the first few interlaced passes
+//!       can be decoded, and where decoding is resumed after getting more complete
+//!       input).
+
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
 
-use std::io::{Read, Result};
+use std::fmt::Debug;
+use std::io::Read;
 
 /// A reader that reads at most `n` bytes.
 struct SmalBuf<R: Read> {
@@ -17,56 +41,149 @@ impl<R: Read> SmalBuf<R> {
 }
 
 impl<R: Read> Read for SmalBuf<R> {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let len = buf.len().min(self.cap);
         self.inner.read(&mut buf[..len])
     }
 }
 
 fuzz_target!(|data: &[u8]| {
-    // Small limits, we don't need them hopefully.
-    let limits = png::Limits { bytes: 1 << 16 };
-
-    let reference = png::Decoder::new_with_limits(data, limits);
-    let smal = png::Decoder::new_with_limits(SmalBuf::new(data, 1), limits);
-
-    let _ = png_compare(reference, smal);
+    let _ = test_data(data);
 });
 
 #[inline(always)]
-fn png_compare<R: Read, S: Read>(reference: png::Decoder<R>, smal: png::Decoder<S>)
-    -> std::result::Result<(), ()>
-{
-    let mut smal = Some(smal);
-    let mut reference = reference.read_info().map_err(|_| {
-        assert!(smal.take().unwrap().read_info().is_err());
-    })?;
+fn test_data<'a>(data: &'a [u8]) -> Result<(), ()> {
+    let baseline_reader = Box::new(data);
+    let byte_by_byte_reader = Box::new(SmalBuf::new(data, 1));
+    let data_readers: Vec<Box<dyn Read + 'a>> = vec![baseline_reader, byte_by_byte_reader];
 
-    let mut smal = smal.take().unwrap().read_info().expect("Deviation");
+    let decoders = data_readers
+        .into_iter()
+        .map(|data_reader| {
+            // Small limits, we don't need them hopefully.
+            let limits = png::Limits { bytes: 1 << 16 };
+            png::Decoder::new_with_limits(data_reader, limits)
+        })
+        .collect::<Vec<_>>();
 
-    assert_eq!(reference.info().raw_bytes(), smal.info().raw_bytes());
-    if reference.info().raw_bytes() > 5_000_000 {
+    let mut png_readers = decoders
+        .into_iter()
+        .map(|decoder| decoder.read_info())
+        .assert_all_results_are_consistent()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| ())?;
+
+    let info = png_readers
+        .iter()
+        .map(|r| r.info().clone())
+        .assert_all_items_are_same(|lhs: &png::Info, rhs: &png::Info| {
+            assert_same_info(lhs, rhs);
+
+            // The assert below is somewhat redundant, but we use `raw_bytes`
+            // later on, so let's double-check that it's the same everywhere.
+            assert_eq!(lhs.raw_bytes(), rhs.raw_bytes());
+        });
+    if info.raw_bytes() > 5_000_000 {
         return Err(());
     }
 
-    let mut ref_data = vec![0; reference.info().raw_bytes()];
-    let mut smal_data = vec![0; reference.info().raw_bytes()];
-
+    let mut buffers = vec![vec![0; info.raw_bytes()]; png_readers.len()];
     loop {
-        let rref = reference.next_frame(&mut ref_data);
-        let rsmal = smal.next_frame(&mut smal_data);
-        match (rref, rsmal) {
-            (Ok(info), Ok(sinfo)) if ref_data == smal_data => assert_eq!(info, sinfo),
-            (Ok(_), Ok(_)) => panic!("Deviating data decoded"),
-            // All errors are treated as equivalent - it is okay to get different errors depending
-            // on how the input is chunked.  One example is deflating [88, 9, 99, 30, 5, 99] in one
-            // chunk will fill up `ZlibStream.out_buffer` and hold onto the final byte in
-            // `fdeflate`'s state.  But when deflating byte-by-byte, `out_buffer` will be resized
-            // before handling the final byte, leading to `InvalidLiteralLengthCode` being returned
-            // by `fdeflate`.
-            (Err(_), Err(_)) => break Ok(()),
-            (Ok(_), Err(err)) => panic!("Small buffer failed {:?}", err),
-            (Err(err), Ok(_)) => panic!("Unexpected success: {:?}", err),
-        }
+        let output_infos = png_readers
+            .iter_mut()
+            .zip(buffers.iter_mut())
+            .map(|(png_reader, buffer)| png_reader.next_frame(buffer.as_mut_slice()))
+            .assert_all_results_are_consistent()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| ())?;
+        output_infos.into_iter().assert_all_items_are_equal();
+        buffers.iter().assert_all_items_are_equal();
     }
 }
+
+fn assert_same_info(lhs: &png::Info, rhs: &png::Info) {
+    // Check that all decoders report the same `IHDR` fields.
+    assert_eq!(lhs.width, rhs.width);
+    assert_eq!(lhs.height, rhs.height);
+    assert_eq!(lhs.bit_depth, rhs.bit_depth);
+    assert_eq!(lhs.color_type, rhs.color_type);
+    assert_eq!(lhs.interlaced, rhs.interlaced);
+
+    // Check all other `Info` fields that implement `Eq`.
+    assert_eq!(lhs.chrm_chunk, rhs.chrm_chunk);
+    assert_eq!(lhs.gama_chunk, rhs.gama_chunk);
+    assert_eq!(lhs.icc_profile, rhs.icc_profile);
+    assert_eq!(lhs.palette, rhs.palette);
+    assert_eq!(lhs.source_chromaticities, rhs.source_chromaticities);
+    assert_eq!(lhs.source_gamma, rhs.source_gamma);
+    assert_eq!(lhs.srgb, rhs.srgb);
+    assert_eq!(lhs.trns, rhs.trns);
+}
+
+trait IteratorExtensionsForFuzzing: Iterator + Sized {
+    /// Verifies that either 1) all items in the iterator are `Ok(_)` or 2) all items in the
+    /// iterator are `Err(_)`.  Passes through unmodified iterator items.
+    fn assert_all_results_are_consistent<T>(self) -> impl Iterator<Item = Self::Item>
+    where
+        Self: Iterator<Item = Result<T, png::DecodingError>>,
+    {
+        // Eagerly collect all the items - this makes sure we check consistency of *all* results,
+        // even if a downstream iterator combinator consumes items lazily and never "pumps" some
+        // items via `next`.  (`iter.take(2)` is one example of such lazy consumer;
+        // `iter_of_results.collect::<Result<Vec<_>, _>>()` is another.)
+        let all_results = self.collect::<Vec<_>>();
+
+        let any_err = all_results.iter().any(|res| res.is_err());
+        let any_ok = all_results.iter().any(|res| res.is_ok());
+        if any_err && any_ok {
+            // Replacing `Self::Item` with an "ok" string, because we want to support items
+            // that do not implement `Debug`.
+            let printable_results = all_results.iter().map(|res| res.as_ref().map(|_| "ok"));
+            for (i, res) in printable_results.enumerate() {
+                eprintln!("Result #{i}: {res:?}");
+            }
+            panic!("Inconsistent results - some are Ok(_) and some are Err(_)");
+        }
+
+        all_results.into_iter()
+    }
+
+    /// Verifies that all items in the iterator are the same (according to their `Eq`
+    /// implementation).  Returns one of the items.
+    fn assert_all_items_are_equal(self) -> Self::Item
+    where
+        Self::Item: Debug + Eq,
+    {
+        self.assert_all_items_are_same(|lhs, rhs| assert_eq!(lhs, rhs))
+    }
+
+    /// Verifies that all items in the iterator are the same (according to the `assert_same`
+    /// function.  Returns one of the items.
+    fn assert_all_items_are_same<F>(self, mut assert_same: F) -> <Self as Iterator>::Item
+    where
+        F: for<'a, 'b> FnMut(&'a Self::Item, &'b Self::Item)
+    {
+        self
+            .enumerate()
+            .reduce(|(i, lhs), (j, rhs)| {
+                let panic = {
+                    let mut assert_same = std::panic::AssertUnwindSafe(&mut assert_same);
+                    let lhs = std::panic::AssertUnwindSafe(&lhs);
+                    let rhs = std::panic::AssertUnwindSafe(&rhs);
+                    std::panic::catch_unwind(move || assert_same(*lhs, *rhs))
+                };
+                match panic {
+                    Ok(_) => (),
+                    Err(panic) => {
+                        eprintln!("Difference found when comparing item #{i} and #{j}.");
+                        std::panic::resume_unwind(panic);
+                    },
+                }
+                (j, lhs /* Arbitrary - could just as well return `rhs` */)
+            })
+            .map(|(_index, item)| item)
+            .expect("Expecting a non-empty iterator")
+    }
+}
+
+impl<T> IteratorExtensionsForFuzzing for T where T: Iterator + Sized {}

--- a/fuzz/fuzz_targets/buf_independent.rs
+++ b/fuzz/fuzz_targets/buf_independent.rs
@@ -28,22 +28,97 @@ use libfuzzer_sys::fuzz_target;
 use std::fmt::Debug;
 use std::io::Read;
 
-/// A reader that reads at most `n` bytes.
-struct SmalBuf<R: Read> {
-    inner: R,
-    cap: usize,
-}
+mod smal_buf {
 
-impl<R: Read> SmalBuf<R> {
-    fn new(inner: R, cap: usize) -> Self {
-        SmalBuf { inner, cap }
+    use std::io::Read;
+
+    /// A reader that reads at most `n` bytes.
+    pub struct SmalBuf<R: Read> {
+        inner: R,
+        cap: usize,
+    }
+
+    impl<R: Read> SmalBuf<R> {
+        pub fn new(inner: R, cap: usize) -> Self {
+            SmalBuf { inner, cap }
+        }
+    }
+
+    impl<R: Read> Read for SmalBuf<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let len = buf.len().min(self.cap);
+            self.inner.read(&mut buf[..len])
+        }
     }
 }
 
-impl<R: Read> Read for SmalBuf<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let len = buf.len().min(self.cap);
-        self.inner.read(&mut buf[..len])
+mod intermittent_eofs {
+
+    use std::cell::RefCell;
+    use std::io::Read;
+    use std::rc::Rc;
+
+    /// A reader that returns `std::io::ErrorKind::UnexpectedEof` errors in every other read.
+    /// EOFs can be temporarily disabled and re-enabled later using the associated `Enabler`.
+    pub struct IntermittentEofs<R: Read> {
+        inner: R,
+
+        /// Controls whether intermittent EOFs happen at all.
+        enabler: Rc<Enabler>,
+
+        /// Controls whether an intermittent EOF will happen during the next `read`
+        /// (when enabled, intermittent EOFs happen every other `read`).
+        eof_soon: bool,
+    }
+
+    impl<R: Read> IntermittentEofs<R> {
+        pub fn new(inner: R) -> Self {
+            Self {
+                inner,
+                enabler: Rc::new(Enabler::new()),
+                eof_soon: true,
+            }
+        }
+
+        pub fn enabler(&self) -> Rc<Enabler> {
+            self.enabler.clone()
+        }
+    }
+
+    impl<R: Read> Read for IntermittentEofs<R> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.enabler.is_enabled() && self.eof_soon {
+                self.eof_soon = false;
+                return Ok(0);
+            }
+
+            self.eof_soon = true;
+            self.inner.read(buf)
+        }
+    }
+
+    pub struct Enabler {
+        is_enabled: RefCell<bool>,
+    }
+
+    impl Enabler {
+        fn new() -> Self {
+            Self {
+                is_enabled: RefCell::new(true),
+            }
+        }
+
+        pub fn enable(&self) {
+            *self.is_enabled.borrow_mut() = true;
+        }
+
+        pub fn disable(&self) {
+            *self.is_enabled.borrow_mut() = false;
+        }
+
+        fn is_enabled(&self) -> bool {
+            *self.is_enabled.borrow()
+        }
     }
 }
 
@@ -54,8 +129,16 @@ fuzz_target!(|data: &[u8]| {
 #[inline(always)]
 fn test_data<'a>(data: &'a [u8]) -> Result<(), ()> {
     let baseline_reader = Box::new(data);
-    let byte_by_byte_reader = Box::new(SmalBuf::new(data, 1));
-    let data_readers: Vec<Box<dyn Read + 'a>> = vec![baseline_reader, byte_by_byte_reader];
+    let byte_by_byte_reader = Box::new(smal_buf::SmalBuf::new(data, 1));
+    let intermittent_eofs_reader = Box::new(intermittent_eofs::IntermittentEofs::new(
+        smal_buf::SmalBuf::new(data, 1),
+    ));
+    let intermittent_eofs_enabler = intermittent_eofs_reader.enabler();
+    let data_readers: Vec<Box<dyn Read + 'a>> = vec![
+        baseline_reader,
+        byte_by_byte_reader,
+        intermittent_eofs_reader,
+    ];
 
     let decoders = data_readers
         .into_iter()
@@ -66,12 +149,16 @@ fn test_data<'a>(data: &'a [u8]) -> Result<(), ()> {
         })
         .collect::<Vec<_>>();
 
+    // `Decoder.read_info` consumes `self` and is therefore not resumable.  To work around that
+    // let's temporarily disable intermittent EOFs:
+    intermittent_eofs_enabler.disable();
     let mut png_readers = decoders
         .into_iter()
         .map(|decoder| decoder.read_info())
         .assert_all_results_are_consistent()
         .collect::<Result<Vec<_>, _>>()
         .map_err(|_| ())?;
+    intermittent_eofs_enabler.enable();
 
     let info = png_readers
         .iter()
@@ -92,12 +179,29 @@ fn test_data<'a>(data: &'a [u8]) -> Result<(), ()> {
         let output_infos = png_readers
             .iter_mut()
             .zip(buffers.iter_mut())
-            .map(|(png_reader, buffer)| png_reader.next_frame(buffer.as_mut_slice()))
+            .map(|(png_reader, buffer)| {
+                retry_after_eofs(|| png_reader.next_frame(buffer.as_mut_slice()))
+            })
             .assert_all_results_are_consistent()
             .collect::<Result<Vec<_>, _>>()
             .map_err(|_| ())?;
         output_infos.into_iter().assert_all_items_are_equal();
         buffers.iter().assert_all_items_are_equal();
+    }
+}
+
+fn retry_after_eofs<T>(
+    mut f: impl FnMut() -> Result<T, png::DecodingError>,
+) -> Result<T, png::DecodingError> {
+    loop {
+        match f() {
+            Err(png::DecodingError::IoError(e))
+                if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+            {
+                ()
+            }
+            other_result => break other_result,
+        }
     }
 }
 
@@ -161,10 +265,9 @@ trait IteratorExtensionsForFuzzing: Iterator + Sized {
     /// function.  Returns one of the items.
     fn assert_all_items_are_same<F>(self, mut assert_same: F) -> <Self as Iterator>::Item
     where
-        F: for<'a, 'b> FnMut(&'a Self::Item, &'b Self::Item)
+        F: for<'a, 'b> FnMut(&'a Self::Item, &'b Self::Item),
     {
-        self
-            .enumerate()
+        self.enumerate()
             .reduce(|(i, lhs), (j, rhs)| {
                 let panic = {
                     let mut assert_same = std::panic::AssertUnwindSafe(&mut assert_same);
@@ -177,9 +280,11 @@ trait IteratorExtensionsForFuzzing: Iterator + Sized {
                     Err(panic) => {
                         eprintln!("Difference found when comparing item #{i} and #{j}.");
                         std::panic::resume_unwind(panic);
-                    },
+                    }
                 }
-                (j, lhs /* Arbitrary - could just as well return `rhs` */)
+                (
+                    j, lhs, /* Arbitrary - could just as well return `rhs` */
+                )
             })
             .map(|(_index, item)| item)
             .expect("Expecting a non-empty iterator")

--- a/src/adam7.rs
+++ b/src/adam7.rs
@@ -5,7 +5,7 @@
 /// [the Adam7 algorithm](https://en.wikipedia.org/wiki/Adam7_algorithm)
 /// applies to a decoded row.
 ///
-/// See also [crate::decoder::Reader::next_interlaced_row].
+/// See also [Reader.next_interlaced_row](crate::decoder::Reader::next_interlaced_row).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Adam7Info {
     pub(crate) pass: u8,
@@ -27,10 +27,10 @@ impl Adam7Info {
     ///   in the 1st `pass`, the `width` is be 1/8th of the image width (rounded up as
     ///   necessary).
     ///
-    /// Note that in typical usage, `Adam7Info`s are returned by [Reader::next_interlaced_row]
+    /// Note that in typical usage, `Adam7Info`s are returned by [Reader.next_interlaced_row]
     /// and there is no need to create them by calling `Adam7Info::new`.  `Adam7Info::new` is
     /// nevertheless exposed as a public API, because it helps to provide self-contained example
-    /// usage of [expand_interlaced_row].
+    /// usage of [expand_interlaced_row](crate::expand_interlaced_row).
     pub fn new(pass: u8, line: u32, width: u32) -> Self {
         assert!(1 <= pass && pass <= 7);
         assert!(width > 0);
@@ -91,11 +91,6 @@ impl Adam7Iterator {
         self.line_width = line_width.ceil() as u32;
         self.lines = lines.ceil() as u32;
         self.line = 0;
-    }
-
-    /// The current pass#.
-    pub fn current_pass(&self) -> u8 {
-        self.current_pass
     }
 }
 

--- a/src/decoder/interlace_info.rs
+++ b/src/decoder/interlace_info.rs
@@ -1,0 +1,128 @@
+use std::ops::Range;
+
+use crate::adam7::{Adam7Info, Adam7Iterator};
+
+/// Describes which interlacing algorithm applies to a decoded row.
+///
+/// PNG (2003) specifies two interlace modes, but reserves future extensions.
+///
+/// See also [Reader.next_interlaced_row](crate::Reader::next_interlaced_row).
+#[derive(Clone, Copy, Debug)]
+pub enum InterlaceInfo {
+    /// The `null` method means no interlacing.
+    Null(NullInfo),
+    /// [The `Adam7` algorithm](https://en.wikipedia.org/wiki/Adam7_algorithm) derives its name
+    /// from doing 7 passes over the image, only decoding a subset of all pixels in each pass.
+    /// The following table shows pictorially what parts of each 8x8 area of the image is found in
+    /// each pass:
+    ///
+    /// ```txt
+    /// 1 6 4 6 2 6 4 6
+    /// 7 7 7 7 7 7 7 7
+    /// 5 6 5 6 5 6 5 6
+    /// 7 7 7 7 7 7 7 7
+    /// 3 6 4 6 3 6 4 6
+    /// 7 7 7 7 7 7 7 7
+    /// 5 6 5 6 5 6 5 6
+    /// 7 7 7 7 7 7 7 7
+    /// ```
+    Adam7(Adam7Info),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct NullInfo {
+    line: u32,
+}
+
+impl InterlaceInfo {
+    pub(crate) fn line_number(&self) -> u32 {
+        match self {
+            InterlaceInfo::Null(NullInfo { line }) => *line,
+            InterlaceInfo::Adam7(Adam7Info { line, .. }) => *line,
+        }
+    }
+
+    pub(crate) fn get_adam7_info(&self) -> Option<&Adam7Info> {
+        match self {
+            InterlaceInfo::Null(_) => None,
+            InterlaceInfo::Adam7(adam7info) => Some(adam7info),
+        }
+    }
+}
+
+pub(crate) struct InterlaceInfoIter(IterImpl);
+
+impl InterlaceInfoIter {
+    pub fn empty() -> Self {
+        Self(IterImpl::None(0..0))
+    }
+
+    pub fn new(width: u32, height: u32, interlaced: bool) -> Self {
+        if interlaced {
+            Self(IterImpl::Adam7(Adam7Iterator::new(width, height)))
+        } else {
+            Self(IterImpl::None(0..height))
+        }
+    }
+}
+
+impl Iterator for InterlaceInfoIter {
+    type Item = InterlaceInfo;
+
+    fn next(&mut self) -> Option<InterlaceInfo> {
+        match self.0 {
+            IterImpl::Adam7(ref mut adam7) => Some(InterlaceInfo::Adam7(adam7.next()?)),
+            IterImpl::None(ref mut height) => Some(InterlaceInfo::Null(NullInfo {
+                line: height.next()?,
+            })),
+        }
+    }
+}
+
+enum IterImpl {
+    None(Range<u32>),
+    Adam7(Adam7Iterator),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn null() {
+        assert_eq!(
+            InterlaceInfoIter::new(8, 8, false)
+                .map(|info| info.line_number())
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+        );
+    }
+
+    #[test]
+    fn adam7() {
+        assert_eq!(
+            InterlaceInfoIter::new(8, 8, true)
+                .map(|info| info.line_number())
+                .collect::<Vec<_>>(),
+            vec![
+                0, // pass 1
+                0, // pass 2
+                0, // pass 3
+                0, 1, // pass 4
+                0, 1, // pass 5
+                0, 1, 2, 3, // pass 6
+                0, 1, 2, 3, // pass 7
+            ],
+        );
+    }
+
+    #[test]
+    fn empty() {
+        assert_eq!(
+            InterlaceInfoIter::empty()
+                .map(|info| info.line_number())
+                .collect::<Vec<_>>(),
+            vec![],
+        );
+    }
+}

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -108,6 +108,11 @@ pub enum Decoded {
 #[derive(Debug)]
 pub enum DecodingError {
     /// An error in IO of the underlying reader.
+    ///
+    /// Note that some IO errors may be recoverable - decoding may be retried after the
+    /// error is resolved.  For example, decoding from a slow stream of data (e.g. decoding from a
+    /// network stream) may occasionally result in [std::io::ErrorKind::UnexpectedEof] kind of
+    /// error, but decoding can resume when more data becomes available.
     IoError(io::Error),
     /// The input image was not a valid PNG.
     ///
@@ -1498,10 +1503,12 @@ mod tests {
     use super::ScaledFloat;
     use super::SourceChromaticities;
     use crate::test_utils::*;
-    use crate::{Decoder, DecodingError};
+    use crate::{Decoder, DecodingError, Reader};
     use byteorder::WriteBytesExt;
+    use std::cell::RefCell;
     use std::fs::File;
-    use std::io::Write;
+    use std::io::{ErrorKind, Read, Write};
+    use std::rc::Rc;
 
     #[test]
     fn image_gamma() -> Result<(), ()> {
@@ -1963,5 +1970,175 @@ mod tests {
         // the current behavior.
         reader.next_frame(&mut buf).unwrap();
         assert_eq!(3093270825, crc32fast::hash(&buf));
+    }
+
+    /// `StremingInput` can be used by tests to simulate a streaming input
+    /// (e.g. a slow http response, where all bytes are not immediately available).
+    #[derive(Clone)]
+    struct StreamingInput(Rc<RefCell<StreamingInputState>>);
+
+    struct StreamingInputState {
+        full_input: Vec<u8>,
+        current_pos: usize,
+        available_len: usize,
+    }
+
+    impl StreamingInput {
+        fn new(full_input: Vec<u8>) -> Self {
+            Self(Rc::new(RefCell::new(StreamingInputState {
+                full_input,
+                current_pos: 0,
+                available_len: 0,
+            })))
+        }
+
+        fn with_noncompressed_png(width: u32, idat_size: usize) -> Self {
+            let mut png = Vec::new();
+            write_noncompressed_png(&mut png, width, idat_size);
+            Self::new(png)
+        }
+
+        fn expose_next_byte(&self) {
+            let mut state = self.0.borrow_mut();
+            assert!(state.available_len < state.full_input.len());
+            state.available_len += 1;
+        }
+
+        fn stream_input_until_reader_is_available(&self) -> Reader<StreamingInput> {
+            loop {
+                self.0.borrow_mut().current_pos = 0;
+                match Decoder::new(self.clone()).read_info() {
+                    Ok(reader) => {
+                        break reader;
+                    }
+                    Err(DecodingError::IoError(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                        self.expose_next_byte();
+                    }
+                    _ => panic!("Unexpected error"),
+                }
+            }
+        }
+
+        fn decode_full_input<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(Reader<&[u8]>) -> R,
+        {
+            let state = self.0.borrow();
+            let decoder = Decoder::new(state.full_input.as_slice());
+            f(decoder.read_info().unwrap())
+        }
+    }
+
+    impl Read for StreamingInput {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let mut state = self.0.borrow_mut();
+            let mut available_bytes = &state.full_input[state.current_pos..state.available_len];
+            let number_of_read_bytes = available_bytes.read(buf)?;
+            state.current_pos += number_of_read_bytes;
+            assert!(state.current_pos <= state.available_len);
+            Ok(number_of_read_bytes)
+        }
+    }
+
+    /// Test resuming/retrying `Reader.next_frame` after `UnexpectedEof`.
+    #[test]
+    fn test_streaming_input_and_decoding_via_next_frame() {
+        const WIDTH: u32 = 16;
+        const IDAT_SIZE: usize = 512;
+        let streaming_input = StreamingInput::with_noncompressed_png(WIDTH, IDAT_SIZE);
+
+        let (whole_output_info, decoded_from_whole_input) =
+            streaming_input.decode_full_input(|mut r| {
+                let mut buf = vec![0; r.output_buffer_size()];
+                let output_info = r.next_frame(&mut buf).unwrap();
+                (output_info, buf)
+            });
+
+        let mut png_reader = streaming_input.stream_input_until_reader_is_available();
+        let mut decoded_from_streaming_input = vec![0; png_reader.output_buffer_size()];
+        let streaming_output_info = loop {
+            match png_reader.next_frame(decoded_from_streaming_input.as_mut_slice()) {
+                Ok(output_info) => break output_info,
+                Err(DecodingError::IoError(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                    streaming_input.expose_next_byte()
+                }
+                e => panic!("Unexpected error: {:?}", e),
+            }
+        };
+        assert_eq!(whole_output_info, streaming_output_info);
+        assert_eq!(
+            crc32fast::hash(&decoded_from_whole_input),
+            crc32fast::hash(&decoded_from_streaming_input)
+        );
+    }
+
+    /// Test resuming/retrying `Reader.next_row` after `UnexpectedEof`.
+    #[test]
+    fn test_streaming_input_and_decoding_via_next_row() {
+        const WIDTH: u32 = 16;
+        const IDAT_SIZE: usize = 512;
+        let streaming_input = StreamingInput::with_noncompressed_png(WIDTH, IDAT_SIZE);
+
+        let decoded_from_whole_input = streaming_input.decode_full_input(|mut r| {
+            let mut buf = vec![0; r.output_buffer_size()];
+            r.next_frame(&mut buf).unwrap();
+            buf
+        });
+
+        let mut png_reader = streaming_input.stream_input_until_reader_is_available();
+        let mut decoded_from_streaming_input = Vec::new();
+        loop {
+            match png_reader.next_row() {
+                Ok(None) => break,
+                Ok(Some(row)) => decoded_from_streaming_input.extend_from_slice(row.data()),
+                Err(DecodingError::IoError(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                    streaming_input.expose_next_byte()
+                }
+                e => panic!("Unexpected error: {:?}", e),
+            }
+        }
+        assert_eq!(
+            crc32fast::hash(&decoded_from_whole_input),
+            crc32fast::hash(&decoded_from_streaming_input)
+        );
+    }
+
+    /// Test resuming/retrying `Decoder.read_header_info` after `UnexpectedEof`.
+    #[test]
+    fn test_streaming_input_and_reading_header_info() {
+        const WIDTH: u32 = 16;
+        const IDAT_SIZE: usize = 512;
+        let streaming_input = StreamingInput::with_noncompressed_png(WIDTH, IDAT_SIZE);
+
+        let info_from_whole_input = streaming_input.decode_full_input(|r| r.info().clone());
+
+        let mut decoder = Decoder::new(streaming_input.clone());
+        let info_from_streaming_input = loop {
+            match decoder.read_header_info() {
+                Ok(info) => break info.clone(),
+                Err(DecodingError::IoError(e)) if e.kind() == ErrorKind::UnexpectedEof => {
+                    streaming_input.expose_next_byte()
+                }
+                e => panic!("Unexpected error: {:?}", e),
+            }
+        };
+
+        assert_eq!(info_from_whole_input.width, info_from_streaming_input.width);
+        assert_eq!(
+            info_from_whole_input.height,
+            info_from_streaming_input.height
+        );
+        assert_eq!(
+            info_from_whole_input.bit_depth,
+            info_from_streaming_input.bit_depth
+        );
+        assert_eq!(
+            info_from_whole_input.color_type,
+            info_from_streaming_input.color_type
+        );
+        assert_eq!(
+            info_from_whole_input.interlaced,
+            info_from_streaming_input.interlaced
+        );
     }
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -160,10 +160,6 @@ pub(crate) enum FormatErrorInner {
     },
     /// Not a PNG, the magic signature is missing.
     InvalidSignature,
-    /// End of file, within a chunk event.
-    UnexpectedEof,
-    /// End of file, while expecting more image data.
-    UnexpectedEndOfChunk,
     // Errors of chunk level ordering, missing etc.
     /// Ihdr must occur.
     MissingIhdr,
@@ -232,8 +228,6 @@ pub(crate) enum FormatErrorInner {
     CorruptFlateStream {
         err: fdeflate::DecompressionError,
     },
-    /// The image data chunk was too short for the expected pixel count.
-    NoMoreImageData,
     /// Bad text encoding
     BadTextEncoding(TextDecodingError),
     /// fdAT shorter than 4 bytes
@@ -323,12 +317,6 @@ impl fmt::Display for FormatError {
             UnknownInterlaceMethod(nr) => write!(fmt, "Unknown interlace method {}.", nr),
             BadSubFrameBounds {} => write!(fmt, "Sub frame is out-of-bounds."),
             InvalidSignature => write!(fmt, "Invalid PNG signature."),
-            UnexpectedEof => write!(fmt, "Unexpected end of data before image end."),
-            UnexpectedEndOfChunk => write!(fmt, "Unexpected end of data within a chunk."),
-            NoMoreImageData => write!(
-                fmt,
-                "IDAT or fDAT chunk does not have enough data for image."
-            ),
             CorruptFlateStream { err } => {
                 write!(fmt, "Corrupt deflate stream. ")?;
                 write!(fmt, "{:?}", err)


### PR DESCRIPTION
This commit supports resuming decoding after `UnexpectedEof` in two ways:

1. Support for detecting an unexpected EOF using the public API of `DecodingError`.  Before this commit `UnexpectedEof`, `UnexpectedEndOfChunk`, and `NoMoreImageData` errors were represented as a crate-internal `FormatErrorInner` type.  After this commit, these errors have a representation that can be detected using the public API: `DecodingError::IoError(std::io::ErrorKind::UnexpectedEof.into())`.

2. Support for resuming decoding after an unexpected EOF.  Before this commit `fn next_interlaced_row` would unconditionally call `next_pass` - advancing to the next row.  After this commit this will only happen if the previous row has been successfully decoded.