### PR TITLE
Fix doclinks, use rustdoc link format to have them automatically checked

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -394,7 +394,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// at the end of the delay (before rendering the next frame)
     ///
     /// *Note that this parameter can be set for each individual frame after
-    /// [`write_header`] is called (see [`Writer::set_dispose_op`])*
+    /// [`write_header`](Self::write_header) is called (see [`Writer::set_dispose_op`])*
     ///
     /// See the [`DisposeOp`] documentation for the possible values and their effects.
     ///
@@ -404,15 +404,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// The default value is [`DisposeOp::None`].
     ///
     /// This method will return an error if the image is not animated.
-    /// (see [`set_animated`])
-    ///
-    /// [`DisposeOp`]: ../common/enum.BlendOp.html
-    /// [`DisposeOp::Previous`]: ../common/enum.BlendOp.html#variant.Previous
-    /// [`DisposeOp::Background`]: ../common/enum.BlendOp.html#variant.Background
-    /// [`DisposeOp::None`]: ../common/enum.BlendOp.html#variant.None
-    /// [`write_header`]: struct.Encoder.html#method.write_header
-    /// [`set_animated`]: struct.Encoder.html#method.set_animated
-    /// [`Writer::set_dispose_op`]: struct.Writer#method.set_dispose_op
+    /// (see [`set_animated`](Self::set_animated))
     pub fn set_dispose_op(&mut self, op: DisposeOp) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.dispose_op = op;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -809,9 +809,6 @@ impl<W: Write> Writer<W> {
     /// The default filter is [`FilterType::Sub`] which provides a basic prediction algorithm for
     /// sample values based on the previous. For a potentially better compression ratio, at the
     /// cost of more complex processing, try out [`FilterType::Paeth`].
-    ///
-    /// [`FilterType::Sub`]: enum.FilterType.html#variant.Sub
-    /// [`FilterType::Paeth`]: enum.FilterType.html#variant.Paeth
     pub fn set_filter(&mut self, filter: FilterType) {
         self.options.filter = filter;
     }
@@ -822,8 +819,6 @@ impl<W: Write> Writer<W> {
     /// based on heuristics which minimize the file size for compression rather
     /// than use a single filter for the entire image. The default method is
     /// [`AdaptiveFilterType::NonAdaptive`].
-    ///
-    /// [`AdaptiveFilterType::NonAdaptive`]: enum.AdaptiveFilterType.html
     pub fn set_adaptive_filter(&mut self, adaptive_filter: AdaptiveFilterType) {
         self.options.adaptive_filter = adaptive_filter;
     }
@@ -911,7 +906,7 @@ impl<W: Write> Writer<W> {
     ///
     /// This method will return an error if the image is not animated.
     ///
-    /// [`reset_frame_position`]: struct.Writer.html#method.reset_frame_position
+    /// [`reset_frame_position`]: Writer::reset_frame_position
     pub fn reset_frame_dimension(&mut self) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.width = self.info.width - fctl.x_offset;
@@ -928,7 +923,7 @@ impl<W: Write> Writer<W> {
     ///
     /// This method will return an error if the image is not animated.
     ///
-    /// [`set_frame_position(0, 0)`]: struct.Writer.html#method.set_frame_position
+    /// [`set_frame_position(0, 0)`]: Writer::set_frame_position
     pub fn reset_frame_position(&mut self) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.x_offset = 0;
@@ -952,8 +947,6 @@ impl<W: Write> Writer<W> {
     /// of each play.*
     ///
     /// This method will return an error if the image is not animated.
-    ///
-    /// [`BlendOP`]: enum.BlendOp.html
     pub fn set_blend_op(&mut self, op: BlendOp) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.blend_op = op;
@@ -1284,9 +1277,10 @@ impl<'a, W: Write> Wrapper<'a, W> {
 /// Streaming PNG writer
 ///
 /// This may silently fail in the destructor, so it is a good idea to call
-/// [`finish`](#method.finish) or [`flush`] before dropping.
+/// [`finish`] or [`flush`] before dropping.
 ///
-/// [`flush`]: https://doc.rust-lang.org/stable/std/io/trait.Write.html#tymethod.flush
+/// [`finish`]: Self::finish
+/// [`flush`]: Write::flush
 pub struct StreamWriter<'a, W: Write> {
     /// The option here is needed in order to access the inner `ChunkWriter` in-between
     /// each frame, which is needed for writing the fcTL chunks between each frame

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -394,7 +394,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// at the end of the delay (before rendering the next frame)
     ///
     /// *Note that this parameter can be set for each individual frame after
-    /// [`write_header`](Self::write_header) is called (see [`Writer::set_dispose_op`])*
+    /// [`write_header`] is called (see [`Writer::set_dispose_op`])*
     ///
     /// See the [`DisposeOp`] documentation for the possible values and their effects.
     ///
@@ -404,7 +404,10 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// The default value is [`DisposeOp::None`].
     ///
     /// This method will return an error if the image is not animated.
-    /// (see [`set_animated`](Self::set_animated))
+    /// (see [`set_animated`])
+    ///
+    /// [`set_animated`]: Self::set_animated
+    /// [`write_header`]: Self::write_header
     pub fn set_dispose_op(&mut self, op: DisposeOp) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.dispose_op = op;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -307,9 +307,6 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// The default filter is [`FilterType::Sub`] which provides a basic prediction algorithm for
     /// sample values based on the previous. For a potentially better compression ratio, at the
     /// cost of more complex processing, try out [`FilterType::Paeth`].
-    ///
-    /// [`FilterType::Sub`]: enum.FilterType.html#variant.Sub
-    /// [`FilterType::Paeth`]: enum.FilterType.html#variant.Paeth
     pub fn set_filter(&mut self, filter: FilterType) {
         self.options.filter = filter;
     }
@@ -320,8 +317,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// based on heuristics which minimize the file size for compression rather
     /// than use a single filter for the entire image. The default method is
     /// [`AdaptiveFilterType::NonAdaptive`].
-    ///
-    /// [`AdaptiveFilterType::NonAdaptive`]: enum.AdaptiveFilterType.html
+
     pub fn set_adaptive_filter(&mut self, adaptive_filter: AdaptiveFilterType) {
         self.options.adaptive_filter = adaptive_filter;
     }
@@ -341,9 +337,8 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// This method will return an error if the image is not animated.
     /// (see [`set_animated`])
     ///
-    /// [`write_header`]: struct.Encoder.html#method.write_header
-    /// [`set_animated`]: struct.Encoder.html#method.set_animated
-    /// [`Writer::set_frame_delay`]: struct.Writer#method.set_frame_delay
+    /// [`write_header`]: Self::write_header
+    /// [`set_animated`]: Self::set_animated
     pub fn set_frame_delay(&mut self, numerator: u16, denominator: u16) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.delay_den = denominator;
@@ -374,11 +369,8 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// This method will return an error if the image is not animated.
     /// (see [`set_animated`])
     ///
-    /// [`BlendOP`]: enum.BlendOp.html
-    /// [`BlendOP::Source`]: enum.BlendOp.html#variant.Source
-    /// [`write_header`]: struct.Encoder.html#method.write_header
-    /// [`set_animated`]: struct.Encoder.html#method.set_animated
-    /// [`Writer::set_blend_op`]: struct.Writer#method.set_blend_op
+    /// [`write_header`]: Self::write_header
+    /// [`set_animated`]: Self::set_animated
     pub fn set_blend_op(&mut self, op: BlendOp) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.blend_op = op;
@@ -982,10 +974,6 @@ impl<W: Write> Writer<W> {
     /// it will be treated as [`DisposeOp::Background`].*
     ///
     /// This method will return an error if the image is not animated.
-    ///
-    /// [`DisposeOp`]: ../common/enum.BlendOp.html
-    /// [`DisposeOp::Previous`]: ../common/enum.BlendOp.html#variant.Previous
-    /// [`DisposeOp::Background`]: ../common/enum.BlendOp.html#variant.Background
     pub fn set_dispose_op(&mut self, op: DisposeOp) -> Result<()> {
         if let Some(ref mut fctl) = self.info.frame_control {
             fctl.dispose_op = op;
@@ -1011,7 +999,7 @@ impl<W: Write> Writer<W> {
     ///
     /// See [`stream_writer`].
     ///
-    /// [`stream_writer`]: #fn.stream_writer
+    /// [`stream_writer`]: Self::stream_writer
     pub fn stream_writer_with_size(&mut self, size: usize) -> Result<StreamWriter<W>> {
         StreamWriter::new(ChunkOutput::Borrowed(self), size)
     }
@@ -1019,8 +1007,10 @@ impl<W: Write> Writer<W> {
     /// Turn this into a stream writer for image data.
     ///
     /// This allows you to create images that do not fit in memory. The default
-    /// chunk size is 4K, use `stream_writer_with_size` to set another chunk
+    /// chunk size is 4K, use [`stream_writer_with_size`] to set another chunk
     /// size.
+    ///
+    /// [`stream_writer_with_size`]: Self::stream_writer_with_size
     pub fn into_stream_writer(self) -> Result<StreamWriter<'static, W>> {
         self.into_stream_writer_with_size(DEFAULT_BUFFER_LENGTH)
     }
@@ -1029,7 +1019,7 @@ impl<W: Write> Writer<W> {
     ///
     /// See [`into_stream_writer`].
     ///
-    /// [`into_stream_writer`]: #fn.into_stream_writer
+    /// [`into_stream_writer`]: Self::into_stream_writer
     pub fn into_stream_writer_with_size(self, size: usize) -> Result<StreamWriter<'static, W>> {
         StreamWriter::new(ChunkOutput::Owned(self), size)
     }
@@ -1177,7 +1167,7 @@ impl<'a, W: Write> ChunkWriter<'a, W> {
         Ok(())
     }
 
-    /// Set the `FrameControl` for the following frame
+    /// Set the [`FrameControl`] for the following frame
     ///
     /// It will ignore the `sequence_number` of the parameter
     /// as it is updated internally.
@@ -1364,9 +1354,6 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     /// The default filter is [`FilterType::Sub`] which provides a basic prediction algorithm for
     /// sample values based on the previous. For a potentially better compression ratio, at the
     /// cost of more complex processing, try out [`FilterType::Paeth`].
-    ///
-    /// [`FilterType::Sub`]: enum.FilterType.html#variant.Sub
-    /// [`FilterType::Paeth`]: enum.FilterType.html#variant.Paeth
     pub fn set_filter(&mut self, filter: FilterType) {
         self.filter = filter;
     }
@@ -1377,8 +1364,6 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     /// based on heuristics which minimize the file size for compression rather
     /// than use a single filter for the entire image. The default method is
     /// [`AdaptiveFilterType::NonAdaptive`].
-    ///
-    /// [`AdaptiveFilterType::NonAdaptive`]: enum.AdaptiveFilterType.html
     pub fn set_adaptive_filter(&mut self, adaptive_filter: AdaptiveFilterType) {
         self.adaptive_filter = adaptive_filter;
     }
@@ -1462,7 +1447,7 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     ///
     /// This method will return an error if the image is not animated.
     ///
-    /// [`reset_frame_position`]: struct.Writer.html#method.reset_frame_position
+    /// [`reset_frame_position`]: Writer::reset_frame_position
     pub fn reset_frame_dimension(&mut self) -> Result<()> {
         if let Some(ref mut fctl) = self.fctl {
             fctl.width = self.width - fctl.x_offset;
@@ -1479,7 +1464,7 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     ///
     /// This method will return an error if the image is not animated.
     ///
-    /// [`set_frame_position(0, 0)`]: struct.Writer.html#method.set_frame_position
+    /// [`set_frame_position(0, 0)`]: Writer::set_frame_position
     pub fn reset_frame_position(&mut self) -> Result<()> {
         if let Some(ref mut fctl) = self.fctl {
             fctl.x_offset = 0;
@@ -1503,8 +1488,6 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     /// of each play.*
     ///
     /// This method will return an error if the image is not animated.
-    ///
-    /// [`BlendOP`]: enum.BlendOp.html
     pub fn set_blend_op(&mut self, op: BlendOp) -> Result<()> {
         if let Some(ref mut fctl) = self.fctl {
             fctl.blend_op = op;
@@ -1525,10 +1508,6 @@ impl<'a, W: Write> StreamWriter<'a, W> {
     /// it will be treated as [`DisposeOp::Background`].*
     ///
     /// This method will return an error if the image is not animated.
-    ///
-    /// [`DisposeOp`]: ../common/enum.BlendOp.html
-    /// [`DisposeOp::Previous`]: ../common/enum.BlendOp.html#variant.Previous
-    /// [`DisposeOp::Background`]: ../common/enum.BlendOp.html#variant.Background
     pub fn set_dispose_op(&mut self, op: DisposeOp) -> Result<()> {
         if let Some(ref mut fctl) = self.fctl {
             fctl.dispose_op = op;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -302,7 +302,7 @@ impl FilterType {
 /// Adaptive filtering performs additional computation in an attempt to maximize
 /// the compression of the data. [`NonAdaptive`] filtering is the default.
 ///
-/// [`NonAdaptive`]: enum.AdaptiveFilterType.html#variant.NonAdaptive
+/// [`NonAdaptive`]: AdaptiveFilterType::NonAdaptive
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AdaptiveFilterType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 //!
 //! ## The decoder
 //!
-//! The most important types for decoding purposes are [`Decoder`](struct.Decoder.html) and
-//! [`Reader`](struct.Reader.html). They both wrap a `std::io::Read`.
-//! `Decoder` serves as a builder for `Reader`. Calling `Decoder::read_info` reads from the `Read` until the
+//! The most important types for decoding purposes are [`Decoder`] and
+//! [`Reader`]. They both wrap a [`std::io::Read`].
+//! `Decoder` serves as a builder for `Reader`. Calling [`Decoder::read_info`] reads from the `Read` until the
 //! image data is reached.
 //!
 //! ### Using the decoder


### PR DESCRIPTION
- Fix some broken doclinks
- Convert doclinks to rustdoc link format so that `cargo doc` would verify the links for us

I also ran `linkchecker` on the generated documentation to verify that there are no broken doc links left.