### PR TITLE
New release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
-## Unreleased
+## 0.17.14
 
 * Updated to miniz_oxide 0.8.0.
+* Added public API to consume interlaced rows one by one ([#495])
+* Improved support for resuming decoding after an `UnexpectedEof`, which lets you start parsing a file before it's fully received over the network ([#496])
+* Fixed some broken links in documentation, improved some documentation comments
+
+[#495]: https://github.com/image-rs/image-png/pull/495
+[#496]: https://github.com/image-rs/image-png/pull/496
+
 
 ## 0.17.13
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.17.13"
+version = "0.17.14"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"


### PR DESCRIPTION
Ship a point release to get the semver-compatible changes out of the door, and clear the way for a semver-breaking release.