### PR TITLE
Avoid infinite loop when retrying after earlier fatal error.

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -791,6 +791,10 @@ pub(crate) enum ParameterErrorKind {
     /// library will perform the checks necessary to ensure that data was accurate or error with a
     /// format error otherwise.
     PolledAfterEndOfImage,
+    /// Attempt to continue decoding after a fatal, non-resumable error was reported (e.g. after
+    /// [`DecodingError::Format`]).  The only case when it is possible to resume after an error
+    /// is an `UnexpectedEof` scenario - see [`DecodingError::IoError`].
+    PolledAfterFatalError,
 }
 
 impl From<ParameterErrorKind> for ParameterError {
@@ -807,6 +811,9 @@ impl fmt::Display for ParameterError {
                 write!(fmt, "wrong data size, expected {} got {}", expected, actual)
             }
             PolledAfterEndOfImage => write!(fmt, "End of image has been reached"),
+            PolledAfterFatalError => {
+                write!(fmt, "A fatal decoding error has been encounted earlier")
+            }
         }
     }
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -10,7 +10,7 @@ use super::zlib::ZlibStream;
 use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
 use crate::common::{
     AnimationControl, BitDepth, BlendOp, ColorType, DisposeOp, FrameControl, Info, ParameterError,
-    PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
+    ParameterErrorKind, PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
 };
 use crate::text_metadata::{ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk};
 use crate::traits::ReadBytesExt;
@@ -627,15 +627,24 @@ impl StreamingDecoder {
         mut buf: &[u8],
         image_data: &mut Vec<u8>,
     ) -> Result<(usize, Decoded), DecodingError> {
+        if self.state.is_none() {
+            return Err(DecodingError::Parameter(
+                ParameterErrorKind::PolledAfterFatalError.into(),
+            ));
+        }
+
         let len = buf.len();
-        while !buf.is_empty() && self.state.is_some() {
+        while !buf.is_empty() {
             match self.next_state(buf, image_data) {
                 Ok((bytes, Decoded::Nothing)) => buf = &buf[bytes..],
                 Ok((bytes, result)) => {
                     buf = &buf[bytes..];
                     return Ok((len - buf.len(), result));
                 }
-                Err(err) => return Err(err),
+                Err(err) => {
+                    debug_assert!(self.state.is_none());
+                    return Err(err);
+                }
             }
         }
         Ok((len - buf.len(), Decoded::Nothing))
@@ -1918,8 +1927,18 @@ mod tests {
         // 0-length fdAT should result in an error.
         let err = reader.next_frame(&mut buf).unwrap_err();
         assert!(matches!(&err, DecodingError::Format(_)));
-        let msg = format!("{err}");
-        assert_eq!("fdAT chunk shorter than 4 bytes", msg);
+        assert_eq!("fdAT chunk shorter than 4 bytes", format!("{err}"));
+
+        // Calling `next_frame` again should return an error.  Same error as above would be nice,
+        // but it is probably unnecessary and infeasible (`DecodingError` can't derive `Clone`
+        // because `std::io::Error` doesn't implement `Clone`)..  But it definitely shouldn't enter
+        // an infinite loop.
+        let err2 = reader.next_frame(&mut buf).unwrap_err();
+        assert!(matches!(&err2, DecodingError::Parameter(_)));
+        assert_eq!(
+            "A fatal decoding error has been encounted earlier",
+            format!("{err2}")
+        );
     }
 
     #[test]
@@ -1936,8 +1955,7 @@ mod tests {
         // 3-bytes-long fdAT should result in an error.
         let err = reader.next_frame(&mut buf).unwrap_err();
         assert!(matches!(&err, DecodingError::Format(_)));
-        let msg = format!("{err}");
-        assert_eq!("fdAT chunk shorter than 4 bytes", msg);
+        assert_eq!("fdAT chunk shorter than 4 bytes", format!("{err}"));
     }
 
     #[test]


### PR DESCRIPTION
When `StreamingDecoder` reports an error, it leaves `state` set to `None`.  Before this commit, calling `next_frame` in this state would have led to an infinite loop:

* `ReadDecoder::decode_next` would loop forever (`!self.at_eof` is true after an error) and would fail to make progress, because
* When `StreamingDecoder::update` saw `state` set to `None` then before this commit it wouldn't enter the `next_state` loop and would immediately return no progress (`Ok((/* consumed bytes = */ 0, Decoded::Nothing))`).

After this commit, `StreamingDecoder::update` checks if the `state` is `None` and treats this as an error.

Code links:

* `ReadDecoder::decode_next`: https://github.com/image-rs/image-png/blob/272ae6051c3fcd9a4250a6b0c760829d4a7a37a5/src/decoder/mod.rs#L299-L316
* `StreamingDecoder::update`: https://github.com/image-rs/image-png/blob/272ae6051c3fcd9a4250a6b0c760829d4a7a37a5/src/decoder/stream.rs#L625-L642