### PR TITLE
Performance: Add an internal `skip_frame_decoding` flag to `DecodeOptions`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,18 @@ name = "decoder"
 harness = false
 
 [[bench]]
-path = "benches/unfilter.rs"
-name = "unfilter"
+path = "benches/expand_paletted.rs"
+name = "expand_paletted"
 harness = false
 required-features = ["benchmarks"]
 
 [[bench]]
-path = "benches/expand_paletted.rs"
-name = "expand_paletted"
+path = "benches/next_frame_info.rs"
+name = "next_frame_info"
+harness = false
+
+[[bench]]
+path = "benches/unfilter.rs"
+name = "unfilter"
 harness = false
 required-features = ["benchmarks"]

--- a/benches/next_frame_info.rs
+++ b/benches/next_frame_info.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::path::Path;
+
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+};
+use png::Decoder;
+
+criterion_group! {benches, load_all}
+criterion_main!(benches);
+
+fn load_all(c: &mut Criterion) {
+    let mut g = c.benchmark_group("next_frame_info");
+    bench_file(&mut g, Path::new("tests/animated/basic_f20.png"), 18, 35);
+}
+
+fn bench_file(
+    g: &mut BenchmarkGroup<WallTime>,
+    png_path: &Path,
+    number_of_frames_to_skip: usize,
+    expected_fctl_sequence_number: u32,
+) {
+    let data = fs::read(png_path).unwrap();
+    let name = format!("{}: {} skips", png_path.display(), number_of_frames_to_skip);
+    g.bench_with_input(&name, data.as_slice(), |b, data| {
+        b.iter(|| {
+            let decoder = Decoder::new(data);
+            let mut reader = decoder.read_info().unwrap();
+            for _ in 0..number_of_frames_to_skip {
+                reader.next_frame_info().unwrap();
+            }
+            assert_eq!(
+                reader
+                    .info()
+                    .frame_control
+                    .as_ref()
+                    .unwrap()
+                    .sequence_number,
+                expected_fctl_sequence_number,
+            );
+        })
+    });
+}

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -325,6 +325,12 @@ impl<R: Read> Reader<R> {
     /// Returns a [`ParameterError`] when there are no more animation frames.
     /// To avoid this the caller can check if [`Info::animation_control`] exists
     /// and consult [`AnimationControl::num_frames`].
+    ///
+    /// Note that this method may end up skipping and discarding some image data.
+    /// When the whole image frame is skipped in this way, then (for better runtime
+    /// performance) the image data is not decompressed.  This may result in some
+    /// format errors being undetected (e.g. Adler 32 checksums would not be checked
+    /// in this case).
     pub fn next_frame_info(&mut self) -> Result<&FrameControl, DecodingError> {
         let remaining_frames = if self.subframe.consumed_and_flushed {
             self.remaining_frames


### PR DESCRIPTION
PTAL?

This PR improves the performance of scenarios where [`Reader.next_frame_info`](https://github.com/image-rs/image-png/pull/518) is used to skip N frames (such scenarios may arise from the way how seeking to an arbitrary frame is implemented currently in `SkPngRustCodec` - see [my earlier comment here](https://github.com/image-rs/image-png/issues/510#issuecomment-2389908506) and https://crbug.com/371060427).

It's not entirely clear to me how often the scenarios above occur in practice (i.e. what is the practical performance impact of this PR), but the PR is relatively simple and improves such scenarios by 90%, so it seems worth it?