### PR TITLE
Port of stb_image optimized paeth unfiltering

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,8 +32,9 @@ jobs:
   feature_check:
     strategy:
       matrix:
-        features: ["", "benchmarks"]
-    runs-on: ubuntu-latest
+        features: ["", "unstable", "benchmarks"]
+        os: [ubuntu-latest, macos-latest] # macos-latest is ARM
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,10 @@ jobs:
         rustup target add powerpc-unknown-linux-gnu
         cargo build --target powerpc-unknown-linux-gnu
   test_all:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest] # macos-latest is ARM
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
     - run: rustup default stable

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -9,6 +9,8 @@ use crate::common::BytesPerPixel;
 /// feature of Rust gets stabilized.
 #[cfg(feature = "unstable")]
 mod simd {
+    // unused imports may ocur in this module due to conditional compilation
+    #![allow(unused_imports)]
     use std::simd::cmp::{SimdOrd, SimdPartialEq, SimdPartialOrd};
     use std::simd::num::{SimdInt, SimdUint};
     use std::simd::{u8x4, u8x8, LaneCount, Simd, SimdElement, SupportedLaneCount};
@@ -24,6 +26,7 @@ mod simd {
     /// Funnily, the autovectorizer does a better job here
     /// than a handwritten algorithm using std::simd!
     /// We used to have a handwritten one but this is just faster.
+    #[cfg(target_arch = "x86_64")]
     fn paeth_predictor<const N: usize>(
         a: Simd<i16, N>,
         b: Simd<i16, N>,
@@ -75,6 +78,7 @@ mod simd {
     ///
     /// `b` is the current pixel in the previous row.  `x` is the current pixel in the current row.
     /// See also https://www.w3.org/TR/png/#filter-byte-positions
+    #[cfg(target_arch = "x86_64")]
     fn paeth_step<const N: usize>(
         state: &mut PaethState<i16, N>,
         b: Simd<u8, N>,
@@ -112,15 +116,18 @@ mod simd {
         state.a = *x;
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn load3(src: &[u8]) -> u8x4 {
         u8x4::from_array([src[0], src[1], src[2], 0])
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn store3(src: u8x4, dest: &mut [u8]) {
         dest[0..3].copy_from_slice(&src.to_array()[0..3])
     }
 
     /// Undoes `FilterType::Paeth` for `BytesPerPixel::Three`.
+    #[cfg(target_arch = "x86_64")]
     pub fn unfilter_paeth3(mut prev_row: &[u8], mut curr_row: &mut [u8]) {
         debug_assert_eq!(prev_row.len(), curr_row.len());
         debug_assert_eq!(prev_row.len() % 3, 0);
@@ -175,15 +182,18 @@ mod simd {
         }
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn load6(src: &[u8]) -> u8x8 {
         u8x8::from_array([src[0], src[1], src[2], src[3], src[4], src[5], 0, 0])
     }
 
+    #[cfg(target_arch = "x86_64")]
     fn store6(src: u8x8, dest: &mut [u8]) {
         dest[0..6].copy_from_slice(&src.to_array()[0..6])
     }
 
     /// Undoes `FilterType::Paeth` for `BytesPerPixel::Six`.
+    #[cfg(target_arch = "x86_64")]
     pub fn unfilter_paeth6(mut prev_row: &[u8], mut curr_row: &mut [u8]) {
         debug_assert_eq!(prev_row.len(), curr_row.len());
         debug_assert_eq!(prev_row.len() % 6, 0);

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -338,22 +338,12 @@ fn filter_paeth_decode(a: u8, b: u8, c: u8) -> u8 {
 #[cfg(feature = "unstable")]
 fn filter_paeth_decode_i16(a: i16, b: i16, c: i16) -> i16 {
     // Like `filter_paeth_decode` but vectorizes better when wrapped in SIMD
-    let pa = (b - c).abs();
-    let pb = (a - c).abs();
-    let pc = ((a - c) + (b - c)).abs();
-
-    let mut out = a;
-    let mut min = pa;
-
-    if pb < min {
-        min = pb;
-        out = b;
-    }
-    if pc < min {
-        out = c;
-    }
-
-    out
+    let thresh = c * 3 - (a + b);
+    let lo = a.min(b);
+    let hi = a.max(b);
+    let t0 = if hi <= thresh { lo } else { c };
+    let t1 = if thresh <= lo { hi } else { t0 };
+    return t1;
 }
 
 fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1158,6 +1158,18 @@ mod test {
     }
 
     #[test]
+    fn paeth_impls_are_equivalent() {
+        use super::{filter_paeth, filter_paeth_decode};
+        for a in 0..=255 {
+            for b in 0..=255 {
+                for c in 0..=255 {
+                    assert_eq!(filter_paeth(a, b, c), filter_paeth_decode(a, b, c));
+                }
+            }
+        }
+    }
+
+    #[test]
     fn roundtrip_ascending_previous_line() {
         // A multiple of 8, 6, 4, 3, 2, 1
         const LEN: u8 = 240;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -319,6 +319,8 @@ impl Default for AdaptiveFilterType {
 }
 
 fn filter_paeth_decode(a: u8, b: u8, c: u8) -> u8 {
+    // Decoding optimizes better with this algorithm than with `filter_paeth()`
+    //
     // This formulation looks very different from the reference in the PNG spec, but is
     // actually equivalent and has favorable data dependencies and admits straightforward
     // generation of branch-free code, which helps performance significantly.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1113,6 +1113,7 @@ mod test {
     }
 
     #[test]
+    #[ignore] // takes ~20s without optimizations
     fn paeth_impls_are_equivalent() {
         use super::{filter_paeth, filter_paeth_decode};
         for a in 0..=255 {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -41,7 +41,7 @@ mod simd {
 
     /// This is an equivalent of the `PaethPredictor` function from
     /// [the spec](http://www.libpng.org/pub/png/spec/1.2/PNG-Filters.html#Filter-type-4-Paeth)
-    /// 
+    ///
     /// Mapping between parameter names and pixel positions can be found in
     /// [a diagram here](https://www.w3.org/TR/png/#filter-byte-positions).
     ///

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -39,16 +39,6 @@ mod simd {
         out.into()
     }
 
-    /// This is an equivalent of the `PaethPredictor` function from
-    /// [the spec](http://www.libpng.org/pub/png/spec/1.2/PNG-Filters.html#Filter-type-4-Paeth)
-    ///
-    /// Mapping between parameter names and pixel positions can be found in
-    /// [a diagram here](https://www.w3.org/TR/png/#filter-byte-positions).
-    ///
-    /// Examples of how different pixel types may be represented as multiple SIMD lanes:
-    /// - RGBA => 4 lanes of `i16x4` contain R, G, B, A
-    /// - RGB  => 4 lanes of `i16x4` contain R, G, B, and a ignored 4th value
-    ///
     /// Functionally equivalent to `simd::paeth_predictor` but does not temporarily convert
     /// the SIMD elements to `i16`.
     fn paeth_predictor_u8<const N: usize>(

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -325,13 +325,16 @@ fn filter_paeth_decode(a: u8, b: u8, c: u8) -> u8 {
     //
     // Adapted from public domain PNG implementation:
     // https://github.com/nothings/stb/blob/5c205738c191bcb0abc65c4febfa9bd25ff35234/stb_image.h#L4657-L4668
-    let thresh = i16::from(c) * 3 - (i16::from(a) + i16::from(b));
-    let thresh = thresh as u8;
+    let a = i16::from(a);
+    let b = i16::from(b);
+    let c = i16::from(c);
+
+    let thresh = c * 3 - (a + b);
     let lo = a.min(b);
     let hi = a.max(b);
     let t0 = if hi <= thresh { lo } else { c };
     let t1 = if thresh <= lo { hi } else { t0 };
-    return t1;
+    return t1 as u8;
 }
 
 #[cfg(feature = "unstable")]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -325,16 +325,12 @@ fn filter_paeth_decode(a: u8, b: u8, c: u8) -> u8 {
     //
     // Adapted from public domain PNG implementation:
     // https://github.com/nothings/stb/blob/5c205738c191bcb0abc65c4febfa9bd25ff35234/stb_image.h#L4657-L4668
-    let a = i16::from(a);
-    let b = i16::from(b);
-    let c = i16::from(c);
-
-    let thresh = c * 3 - (a + b);
+    let thresh = i16::from(c) * 3 - (i16::from(a) + i16::from(b));
     let lo = a.min(b);
     let hi = a.max(b);
-    let t0 = if hi <= thresh { lo } else { c };
-    let t1 = if thresh <= lo { hi } else { t0 };
-    return t1 as u8;
+    let t0 = if hi as i16 <= thresh { lo } else { c };
+    let t1 = if thresh <= lo as i16 { hi } else { t0 };
+    return t1;
 }
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
10% end-to-end performance gain on a Paeth-filtered image I concocted with `convert -quality 49 in.png out.png`, which is comparatively big and Paeth images are rather common.

Godbolt shows much shorter assembly that gets autovectorized even in the bpp=3 case: https://godbolt.org/z/fq3EjvT4b

TODO:

 - [x] Have someone else confirm this performance boost exists and isn't isolated to my machine
 - [x] Exhaustively test this implementation against the reference
 - [x] Do something about the nightly variant of Paeth unfiltering

Also done:

- [x] Fix `unstable` feature dramatically regressing performance on ARM
- [x] Add CI job to make sure `unstable` feature compiles
- [x] Add CI job to run tests on ARM
