### PR TITLE
Pass through nightly feature to crc32fast crate to get SIMD crc32 on Aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "0.8.4"
 term = "0.7"
 
 [features]
-unstable = []
+unstable = ["crc32fast/nightly"]
 benchmarks = []
 
 [[bench]]


### PR DESCRIPTION
`crc32fast` crate contains an SIMD implementation of crc32 for Aarch64, but it's gated behind the `nightly` feature flag.

The relevant intrinsics have actually been stable since Rust 1.80, but the PR to make use of them on stable seems to have stalled: https://github.com/srijs/rust-crc32fast/pull/36

This PR lets us make use of them on nightly at least until upstream sorts out stable support.