### PR TITLE
Decode-only Info (part 1/x)

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -597,7 +597,6 @@ pub struct Info<'a> {
 
     pub frame_control: Option<FrameControl>,
     pub animation_control: Option<AnimationControl>,
-    pub compression: Compression,
     /// Gamma of the source system.
     /// Set by both `gAMA` as well as to a replacement by `sRGB` chunk.
     pub source_gamma: Option<ScaledFloat>,
@@ -643,9 +642,6 @@ impl Default for Info<'_> {
             pixel_dims: None,
             frame_control: None,
             animation_control: None,
-            // Default to `deflate::Compression::Fast` and `filter::FilterType::Sub`
-            // to maintain backward compatible output.
-            compression: Compression::Fast,
             source_gamma: None,
             source_chromaticities: None,
             srgb: None,

--- a/src/common.rs
+++ b/src/common.rs
@@ -731,6 +731,24 @@ impl Info<'_> {
             .raw_row_length_from_width(self.bit_depth, width)
     }
 
+    /// Gamma dependent on sRGB chunk
+    pub fn gamma(&self) -> Option<ScaledFloat> {
+        if self.srgb.is_some() {
+            Some(crate::srgb::substitute_gamma())
+        } else {
+            self.gama_chunk
+        }
+    }
+
+    /// Chromaticities dependent on sRGB chunk
+    pub fn chromaticities(&self) -> Option<SourceChromaticities> {
+        if self.srgb.is_some() {
+            Some(crate::srgb::substitute_chromaticities())
+        } else {
+            self.chrm_chunk
+        }
+    }
+
     /// Mark the image data as conforming to the SRGB color space with the specified rendering intent.
     ///
     /// Any ICC profiles will be ignored.

--- a/src/common.rs
+++ b/src/common.rs
@@ -77,6 +77,16 @@ impl ColorType {
                 || self == ColorType::Rgba))
             || (bit_depth == BitDepth::Sixteen && self == ColorType::Indexed)
     }
+
+    pub(crate) fn bits_per_pixel(&self, bit_depth: BitDepth) -> usize {
+        self.samples() * bit_depth as usize
+    }
+
+    pub(crate) fn bytes_per_pixel(&self, bit_depth: BitDepth) -> usize {
+        // If adjusting this for expansion or other transformation passes, remember to keep the old
+        // implementation for bpp_in_prediction, which is internal to the png specification.
+        self.samples() * ((bit_depth as usize + 7) >> 3)
+    }
 }
 
 /// Bit depth of the PNG file.
@@ -683,14 +693,14 @@ impl Info<'_> {
 
     /// Returns the number of bits per pixel.
     pub fn bits_per_pixel(&self) -> usize {
-        self.color_type.samples() * self.bit_depth as usize
+        self.color_type.bits_per_pixel(self.bit_depth)
     }
 
     /// Returns the number of bytes per pixel.
     pub fn bytes_per_pixel(&self) -> usize {
         // If adjusting this for expansion or other transformation passes, remember to keep the old
         // implementation for bpp_in_prediction, which is internal to the png specification.
-        self.color_type.samples() * ((self.bit_depth as usize + 7) >> 3)
+        self.color_type.bytes_per_pixel(self.bit_depth)
     }
 
     /// Return the number of bytes for this pixel used in prediction.

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1315,11 +1315,6 @@ impl StreamingDecoder {
             };
 
             info.chrm_chunk = Some(source_chromaticities);
-            // Ignore chromaticities if sRGB profile is used.
-            if info.srgb.is_none() {
-                info.source_chromaticities = Some(source_chromaticities);
-            }
-
             Ok(Decoded::Nothing)
         }
     }
@@ -1340,11 +1335,6 @@ impl StreamingDecoder {
             let source_gamma = ScaledFloat::from_scaled(source_gamma);
 
             info.gama_chunk = Some(source_gamma);
-            // Ignore chromaticities if sRGB profile is used.
-            if info.srgb.is_none() {
-                info.source_gamma = Some(source_gamma);
-            }
-
             Ok(Decoded::Nothing)
         }
     }
@@ -1368,8 +1358,6 @@ impl StreamingDecoder {
 
             // Set srgb and override source gamma and chromaticities.
             info.srgb = Some(rendering_intent);
-            info.source_gamma = Some(crate::srgb::substitute_gamma());
-            info.source_chromaticities = Some(crate::srgb::substitute_chromaticities());
             Ok(Decoded::Nothing)
         }
     }
@@ -1846,7 +1834,7 @@ mod tests {
         fn trial(path: &str, expected: Option<ScaledFloat>) {
             let decoder = crate::Decoder::new(File::open(path).unwrap());
             let reader = decoder.read_info().unwrap();
-            let actual: Option<ScaledFloat> = reader.info().source_gamma;
+            let actual: Option<ScaledFloat> = reader.info().gamma();
             assert!(actual == expected);
         }
         trial("tests/pngsuite/f00n0g08.png", None);
@@ -1887,7 +1875,7 @@ mod tests {
         fn trial(path: &str, expected: Option<SourceChromaticities>) {
             let decoder = crate::Decoder::new(File::open(path).unwrap());
             let reader = decoder.read_info().unwrap();
-            let actual: Option<SourceChromaticities> = reader.info().source_chromaticities;
+            let actual: Option<SourceChromaticities> = reader.info().chromaticities();
             assert!(actual == expected);
         }
         trial(

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1737,9 +1737,18 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn roundtrip() {
+    fn roundtrip1() {
+        roundtrip_inner();
+    }
+
+    #[test]
+    fn roundtrip2() {
+        roundtrip_inner();
+    }
+
+    fn roundtrip_inner() {
         // More loops = more random testing, but also more test wait time
-        for _ in 0..10 {
+        for _ in 0..5 {
             for path in glob::glob("tests/pngsuite/*.png")
                 .unwrap()
                 .map(|r| r.unwrap())
@@ -1783,9 +1792,18 @@ mod tests {
     }
 
     #[test]
-    fn roundtrip_stream() {
+    fn roundtrip_stream1() {
+        roundtrip_stream_inner();
+    }
+
+    #[test]
+    fn roundtrip_stream2() {
+        roundtrip_stream_inner();
+    }
+
+    fn roundtrip_stream_inner() {
         // More loops = more random testing, but also more test wait time
-        for _ in 0..10 {
+        for _ in 0..5 {
             for path in glob::glob("tests/pngsuite/*.png")
                 .unwrap()
                 .map(|r| r.unwrap())

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -514,33 +514,20 @@ impl PartialInfo {
     }
 
     fn bpp_in_prediction(&self) -> BytesPerPixel {
-        // Passthrough
-        self.to_info().bpp_in_prediction()
+        BytesPerPixel::from_usize(self.bytes_per_pixel())
+    }
+
+    fn bytes_per_pixel(&self) -> usize {
+        self.color_type.bytes_per_pixel(self.bit_depth)
     }
 
     fn raw_row_length(&self) -> usize {
-        // Passthrough
-        self.to_info().raw_row_length()
+        self.raw_row_length_from_width(self.width)
     }
 
     fn raw_row_length_from_width(&self, width: u32) -> usize {
-        // Passthrough
-        self.to_info().raw_row_length_from_width(width)
-    }
-
-    /// Converts this partial info to an owned Info struct,
-    /// setting missing values to their defaults
-    fn to_info(&self) -> Info<'static> {
-        Info {
-            width: self.width,
-            height: self.height,
-            bit_depth: self.bit_depth,
-            color_type: self.color_type,
-            frame_control: self.frame_control,
-            animation_control: self.animation_control,
-            compression: self.compression,
-            ..Default::default()
-        }
+        self.color_type
+            .raw_row_length_from_width(self.bit_depth, width)
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -2183,7 +2183,7 @@ mod tests {
             let decoder = crate::Decoder::new(Cursor::new(buffer));
             let mut reader = decoder.read_info()?;
             assert_eq!(
-                reader.info().source_gamma,
+                reader.info().gamma(),
                 gamma,
                 "Deviation with gamma {:?}",
                 gamma


### PR DESCRIPTION
My plan is to make `Info` purely into information about a decoded image, without living in `Encoder` as a *third* type storing encoding options. Here's a small step with a couple of fields.
