### PR TITLE
Info refactorings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.57.0", stable, beta, nightly]
+        rust: ["1.65.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [""]
     runs-on: ${{ matrix.os }}
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.57.0' }}
+      if: ${{ matrix.rust == '1.65.0' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.57.0' }}
+      if: ${{ matrix.rust == '1.65.0' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ categories = ["multimedia::images"]
 authors = ["The image-rs Developers"]
 repository = "https://github.com/image-rs/image-png"
 
-edition = "2018"
-rust-version = "1.57"
+edition = "2021"
+rust-version = "1.65"
 include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -2,6 +2,7 @@ use std::convert::TryInto;
 use std::error;
 use std::fmt;
 use std::io;
+use std::mem;
 use std::{borrow::Cow, cmp::min};
 
 use crc32fast::Hasher as Crc32;
@@ -1101,9 +1102,7 @@ impl StreamingDecoder {
                 FormatErrorInner::DuplicateChunk { kind: chunk::PLTE }.into(),
             ))
         } else {
-            self.limits
-                .reserve_bytes(self.current_chunk.raw_bytes.len())?;
-            info.palette = Some(Cow::Owned(self.current_chunk.raw_bytes.clone()));
+            info.palette = Some(Cow::Owned(mem::take(&mut self.current_chunk.raw_bytes)));
             Ok(Decoded::Nothing)
         }
     }
@@ -1136,9 +1135,7 @@ impl StreamingDecoder {
             } else {
                 bit_depth
             };
-            self.limits
-                .reserve_bytes(self.current_chunk.raw_bytes.len())?;
-            let vec = self.current_chunk.raw_bytes.clone();
+            let vec = mem::take(&mut self.current_chunk.raw_bytes);
             let len = vec.len();
 
             // expected lenth of the chunk
@@ -1188,9 +1185,7 @@ impl StreamingDecoder {
             ));
         }
         let (color_type, bit_depth) = { (info.color_type, info.bit_depth as u8) };
-        self.limits
-            .reserve_bytes(self.current_chunk.raw_bytes.len())?;
-        let mut vec = self.current_chunk.raw_bytes.clone();
+        let mut vec = mem::take(&mut self.current_chunk.raw_bytes);
         let len = vec.len();
         match color_type {
             ColorType::Grayscale => {
@@ -1760,7 +1755,7 @@ impl StreamingDecoder {
                 ColorType::Grayscale | ColorType::GrayscaleAlpha => 2,
                 ColorType::Rgb | ColorType::Rgba => 6,
             };
-            let vec = self.current_chunk.raw_bytes.clone();
+            let vec = mem::take(&mut self.current_chunk.raw_bytes);
             let len = vec.len();
             if len == expected {
                 info.bkgd = Some(Cow::Owned(vec));

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -62,8 +62,8 @@ enum State {
     /// In this state we are reading chunk data from external input, and appending it to
     /// `ChunkState::raw_bytes`.
     ReadChunkData(ChunkType),
-    /// In this state we check if all chunk data has been already read into `ChunkState::raw_bytes`
-    /// and if so then we parse the chunk.  Otherwise, we go back to the `ReadChunkData` state.
+    /// In this state all chunk data has been already read into `ChunkState::raw_bytes`
+    /// and we parse the chunk.
     ParseChunkData(ChunkType),
     /// In this state we are reading image data from external input and feeding it directly into
     /// `StreamingDecoder::inflater`.
@@ -725,53 +725,40 @@ impl StreamingDecoder {
             }
             ParseChunkData(type_str) => {
                 debug_assert!(type_str != IDAT && type_str != chunk::fdAT);
-                if self.current_chunk.remaining == 0 {
-                    // Got complete chunk.
-                    Ok((0, self.parse_chunk(type_str)?))
-                } else {
-                    // Make sure we have room to read more of the chunk.
-                    // We need it fully before parsing.
-                    self.reserve_current_chunk()?;
-
-                    self.state = Some(ReadChunkData(type_str));
-                    Ok((0, Decoded::PartialChunk(type_str)))
-                }
+                // Got complete chunk.
+                debug_assert_eq!(0, self.current_chunk.remaining);
+                Ok((0, self.parse_chunk(type_str)?))
             }
             ReadChunkData(type_str) => {
                 debug_assert!(type_str != IDAT && type_str != chunk::fdAT);
-                if self.current_chunk.remaining == 0 {
-                    self.state = Some(State::new_u32(U32ValueKind::Crc(type_str)));
-                    Ok((0, Decoded::Nothing))
+                let ChunkState {
+                    crc,
+                    remaining,
+                    raw_bytes,
+                    type_: _,
+                } = &mut self.current_chunk;
+
+                let n = min(*remaining as usize, buf.len());
+                let buf = &buf[..n];
+
+                // the buffer has been reserved ahead of time
+                if raw_bytes.capacity() - raw_bytes.len() >= buf.len() {
+                    raw_bytes.extend_from_slice(buf);
                 } else {
-                    let ChunkState {
-                        crc,
-                        remaining,
-                        raw_bytes,
-                        type_: _,
-                    } = &mut self.current_chunk;
-
-                    let buf_avail = raw_bytes.capacity() - raw_bytes.len();
-                    let bytes_avail = min(buf.len(), buf_avail);
-                    let n = min(*remaining, bytes_avail as u32);
-                    if buf_avail == 0 {
-                        self.state = Some(ParseChunkData(type_str));
-                        Ok((0, Decoded::Nothing))
-                    } else {
-                        let buf = &buf[..n as usize];
-                        if !self.decode_options.ignore_crc {
-                            crc.update(buf);
-                        }
-                        raw_bytes.extend_from_slice(buf);
-
-                        *remaining -= n;
-                        if *remaining == 0 {
-                            self.state = Some(ParseChunkData(type_str));
-                        } else {
-                            self.state = Some(ReadChunkData(type_str));
-                        }
-                        Ok((n as usize, Decoded::Nothing))
-                    }
+                    debug_assert!(false); // this won't happen, but return optimizes better
+                    return Err(DecodingError::LimitsExceeded);
                 }
+                if !self.decode_options.ignore_crc {
+                    crc.update(buf);
+                }
+
+                *remaining -= n as u32;
+                self.state = Some(if *remaining == 0 {
+                    ParseChunkData(type_str)
+                } else {
+                    ReadChunkData(type_str)
+                });
+                Ok((n, Decoded::Nothing))
             }
             ImageData(type_str) => {
                 debug_assert!(type_str == IDAT || type_str == chunk::fdAT);
@@ -847,6 +834,15 @@ impl StreamingDecoder {
                     });
                     return Ok(Decoded::ImageDataFlushed);
                 }
+
+                self.current_chunk.type_ = type_str;
+                if !self.decode_options.ignore_crc {
+                    self.current_chunk.crc.reset();
+                    self.current_chunk.crc.update(&type_str.0);
+                }
+                self.current_chunk.remaining = length;
+                self.current_chunk.raw_bytes.clear();
+
                 self.state = match type_str {
                     chunk::fdAT => {
                         if !self.ready_for_fdat_chunks {
@@ -876,15 +872,12 @@ impl StreamingDecoder {
                         self.have_idat = true;
                         Some(State::ImageData(type_str))
                     }
-                    _ => Some(State::ReadChunkData(type_str)),
+                    _ => {
+                        // IDAT/fDAT won't use current_chunk.raw_bytes, so it won't need it grown
+                        self.reserve_current_chunk()?;
+                        Some(State::ReadChunkData(type_str))
+                    }
                 };
-                self.current_chunk.type_ = type_str;
-                if !self.decode_options.ignore_crc {
-                    self.current_chunk.crc.reset();
-                    self.current_chunk.crc.update(&type_str.0);
-                }
-                self.current_chunk.remaining = length;
-                self.current_chunk.raw_bytes.clear();
                 Ok(Decoded::ChunkBegin(length, type_str))
             }
             U32ValueKind::Crc(type_str) => {
@@ -957,19 +950,24 @@ impl StreamingDecoder {
     }
 
     fn reserve_current_chunk(&mut self) -> Result<(), DecodingError> {
-        let max = self.limits.bytes;
         let buffer = &mut self.current_chunk.raw_bytes;
 
-        // Double if necessary, but no more than until the limit is reached.
-        let reserve_size = max.saturating_sub(buffer.capacity()).min(buffer.len());
-        self.limits.reserve_bytes(reserve_size)?;
-        buffer.reserve_exact(reserve_size);
+        // reserve before any data is read
+        debug_assert_eq!(0, buffer.len());
 
-        if buffer.capacity() == buffer.len() {
-            Err(DecodingError::LimitsExceeded)
-        } else {
-            Ok(())
+        let required_capacity = self.current_chunk.remaining as usize;
+        let actual_capacity = buffer.capacity();
+
+        if required_capacity <= actual_capacity {
+            return Ok(());
         }
+
+        // try_reserve takes the new size, but limits take only size increase
+        self.limits
+            .reserve_bytes(required_capacity - actual_capacity)?;
+        buffer
+            .try_reserve_exact(required_capacity)
+            .map_err(|_| DecodingError::LimitsExceeded)
     }
 
     fn parse_chunk(&mut self, type_str: ChunkType) -> Result<Decoded, DecodingError> {
@@ -1809,7 +1807,7 @@ impl Default for ChunkState {
             type_: ChunkType([0; 4]),
             crc: Crc32::new(),
             remaining: 0,
-            raw_bytes: Vec::with_capacity(CHUNK_BUFFER_SIZE),
+            raw_bytes: Vec::new(),
         }
     }
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1128,47 +1128,7 @@ impl StreamingDecoder {
                 ));
             }
 
-            let (color_type, bit_depth) = { (info.color_type, info.bit_depth) };
-            // The sample depth for color type 3 is fixed at eight bits.
-            let sample_depth = if color_type == ColorType::Indexed {
-                BitDepth::Eight
-            } else {
-                bit_depth
-            };
             let vec = mem::take(&mut self.current_chunk.raw_bytes);
-            let len = vec.len();
-
-            // expected lenth of the chunk
-            let expected = match color_type {
-                ColorType::Grayscale => 1,
-                ColorType::Rgb | ColorType::Indexed => 3,
-                ColorType::GrayscaleAlpha => 2,
-                ColorType::Rgba => 4,
-            };
-
-            // Check if the sbit chunk size is valid.
-            if expected != len {
-                return Err(DecodingError::Format(
-                    FormatErrorInner::InvalidSbitChunkSize {
-                        color_type,
-                        expected,
-                        len,
-                    }
-                    .into(),
-                ));
-            }
-
-            for sbit in &vec {
-                if *sbit < 1 || *sbit > sample_depth as u8 {
-                    return Err(DecodingError::Format(
-                        FormatErrorInner::InvalidSbit {
-                            sample_depth,
-                            sbit: *sbit,
-                        }
-                        .into(),
-                    ));
-                }
-            }
             info.sbit = Some(Cow::Owned(vec));
             Ok(Decoded::Nothing)
         };


### PR DESCRIPTION
* There's no need to have `ParseChunkData` return to reading after reallocating. It wants the whole chunk in memory, and chunk sizes are known ahead of time, so the vec can be allocated without resizing it.
* Since the chunk vec can have the exact size needed now, `Info` can `mem::take` it.
* Chunks can be parsed lazily, using `sBIT` as an example.
* I've added `warnings` to the `StreamingDecoder` to collect errors from optional chunks. Unfortunately it can't easily be in `Info`, because `Info` supports clone, and `DecodingError` does not (`io::Error` can't).
* Bumped MSRV to 1.65 ([99.7% support](https://lib.rs/stats#rustc-usage)) to have `let else`.