### PR TITLE
Lazy parse sBIT

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -205,14 +205,14 @@ pub(crate) enum FormatErrorInner {
     // Errors specific to particular chunk data to be validated.
     /// The palette did not even contain a single pixel data.
     ShortPalette {
-        expected: usize,
-        len: usize,
+        expected: u32,
+        len: u32,
     },
     /// sBIT chunk size based on color type.
     InvalidSbitChunkSize {
         color_type: ColorType,
-        expected: usize,
-        len: usize,
+        expected: u32,
+        len: u32,
     },
     InvalidSbit {
         sample_depth: BitDepth,
@@ -1152,12 +1152,12 @@ impl StreamingDecoder {
             };
 
             // Check if the sbit chunk size is valid.
-            if expected != len {
+            if expected as usize != len {
                 return Err(DecodingError::Format(
                     FormatErrorInner::InvalidSbitChunkSize {
                         color_type,
                         expected,
-                        len,
+                        len: len as _,
                     }
                     .into(),
                 ));
@@ -1198,7 +1198,11 @@ impl StreamingDecoder {
             ColorType::Grayscale => {
                 if len < 2 {
                     return Err(DecodingError::Format(
-                        FormatErrorInner::ShortPalette { expected: 2, len }.into(),
+                        FormatErrorInner::ShortPalette {
+                            expected: 2,
+                            len: len as _,
+                        }
+                        .into(),
                     ));
                 }
                 if bit_depth < 16 {
@@ -1211,7 +1215,11 @@ impl StreamingDecoder {
             ColorType::Rgb => {
                 if len < 6 {
                     return Err(DecodingError::Format(
-                        FormatErrorInner::ShortPalette { expected: 6, len }.into(),
+                        FormatErrorInner::ShortPalette {
+                            expected: 6,
+                            len: len as _,
+                        }
+                        .into(),
                     ));
                 }
                 if bit_depth < 16 {

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -100,9 +100,7 @@ impl ZlibStream {
         let (in_consumed, out_consumed) = self
             .state
             .read(data, self.out_buffer.as_mut_slice(), self.out_pos, false)
-            .map_err(|err| {
-                DecodingError::Format(FormatErrorInner::CorruptFlateStream { err }.into())
-            })?;
+            .map_err(|err| DecodingError::Format(FormatErrorInner::from(err).into()))?;
 
         self.started = true;
         self.out_pos += out_consumed;
@@ -130,9 +128,7 @@ impl ZlibStream {
             let (_in_consumed, out_consumed) = self
                 .state
                 .read(&[], self.out_buffer.as_mut_slice(), self.out_pos, true)
-                .map_err(|err| {
-                    DecodingError::Format(FormatErrorInner::CorruptFlateStream { err }.into())
-                })?;
+                .map_err(|err| DecodingError::Format(FormatErrorInner::from(err).into()))?;
 
             self.out_pos += out_consumed;
 


### PR DESCRIPTION
Alternative to [`2949036` (#554)](https://github.com/image-rs/image-png/pull/554/commits/29490363ac4cb37b044357b52ead1537569483b6)

Needs https://github.com/image-rs/fdeflate/pull/43

I like the previous solution with `warnings: Vec<Error>`, since it's easy to implement, uniformly handles all ancillary chunks, keeps `Info` small, and is lossless.

Here's an alternative solution that keeps one parse error per chunk.

In either case, I think it's better to keep the errors than to discard them. It seems weird to have all these parsers and error enums that just get discarded. That's dead code.

