### PR TITLE
Bump MSRV

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.57.0", stable, beta, nightly]
+        rust: ["1.65.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [""]
     runs-on: ${{ matrix.os }}
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.57.0' }}
+      if: ${{ matrix.rust == '1.65.0' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.57.0' }}
+      if: ${{ matrix.rust == '1.65.0' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ categories = ["multimedia::images"]
 authors = ["The image-rs Developers"]
 repository = "https://github.com/image-rs/image-png"
 
-edition = "2018"
-rust-version = "1.57"
+edition = "2021"
+rust-version = "1.65"
 include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",


### PR DESCRIPTION
1.65 has approximately [99.7% support](https://lib.rs/stats#rustc-usage).