### PR TITLE
Reworded docs for encoder::Writer::write_chunk()

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -663,9 +663,9 @@ impl<W: Write> Writer<W> {
     /// Write a raw chunk of PNG data.
     ///
     /// This function calculates the required CRC sum so this should not be included in the input
-    /// `data`, otherwise the data is not filtered in any way. This function panics if the length
-    /// of `data` can't be parsed as a `u32` though the length of the chunk data should not exceed
-    /// `i32::MAX` or 2,147,483,647.
+    /// `data`, otherwise the data is not filtered in any way. This function returns an error if
+    /// the length of `data` can't be parsed as a `u32` though the length of the chunk data should
+    /// not exceed `i32::MAX` or 2,147,483,647.
     pub fn write_chunk(&mut self, name: ChunkType, data: &[u8]) -> Result<()> {
         use std::convert::TryFrom;
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -662,8 +662,10 @@ impl<W: Write> Writer<W> {
 
     /// Write a raw chunk of PNG data.
     ///
-    /// The chunk will have its CRC calculated and correctly. The data is not filtered in any way,
-    /// but the chunk needs to be short enough to have its length encoded correctly.
+    /// This function calculates the required CRC sum so this should not be included in the input
+    /// `data`, otherwise the data is not filtered in any way. This function panics if the length
+    /// of `data` can't be parsed as a `u32` though the length of the chunk data should not exceed
+    /// `i32::MAX` or 2,147,483,647.
     pub fn write_chunk(&mut self, name: ChunkType, data: &[u8]) -> Result<()> {
         use std::convert::TryFrom;
 


### PR DESCRIPTION
Reworded a section from the `write_chunk()` method.

I felt as though the previous doc comment's wording was somewhat awkward. I added the size limit as well based on both the code from the function as well as from the [png spec](https://www.w3.org/TR/png/#table51).