### PR TITLE
Treat most auxiliary chunk errors as benign.

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -346,7 +346,7 @@ fn filter_paeth_stbi(a: u8, b: u8, c: u8) -> u8 {
     let hi = a.max(b);
     let t0 = if hi as i16 <= thresh { lo } else { c };
     let t1 = if thresh <= lo as i16 { hi } else { t0 };
-    return t1;
+    t1
 }
 
 #[cfg(any(test, all(feature = "unstable", target_arch = "x86_64")))]

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -5,9 +5,9 @@
 //! chunks. There are three kinds of text chunks.
 //!  -   `tEXt`: This has a `keyword` and `text` field, and is ISO 8859-1 encoded.
 //!  -   `zTXt`: This is semantically the same as `tEXt`, i.e. it has the same fields and
-//!       encoding, but the `text` field is compressed before being written into the PNG file.
+//!      encoding, but the `text` field is compressed before being written into the PNG file.
 //!  -   `iTXt`: This chunk allows for its `text` field to be any valid UTF-8, and supports
-//!        compression of the text field as well.
+//!      compression of the text field as well.
 //!
 //!  The `ISO 8859-1` encoding technically doesn't allow any control characters
 //!  to be used, but in practice these values are encountered anyway. This can


### PR DESCRIPTION
This commit is based on what `png_handle_...` functions do in `libpng/pngrutil.c`:

* Chunks appearing before IHDR are a fatal error.  `png` crate already detects this in a single, centeralized location and reports `ChunkBeforeIhdr` error.
* Chunks appearing after IDAT chunk, or duplicated chunks are treated as a benign error and ignored.

Note that there are still some places where `png` crate is more strict. In some places this is unavoidable - e.g. the `SrgbRenderingIntent` enum can't represent values greater than 3 and the `Unit` enum can't represent values greater than 1.  There are also some places where `png` crate is more permissive - e.g. in general `parse_...` functions don't complain if the chunk is longer than necessary.