### PR TITLE
Unit tests for roundtripping of `pHYs` and `sRGB` chunks.

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -21,7 +21,7 @@ jobs:
        fuzz-seconds: 120
        output-sarif: true
    - name: Upload Crash
-     uses: actions/upload-artifact@v3
+     uses: actions/upload-artifact@v4
      if: failure() && steps.build.outcome == 'success'
      with:
        name: artifacts


### PR DESCRIPTION
Before this commit all the tests would pass even if `parse_phys` and `parse_srgb` functions were deleted.