### PR TITLE
Release 0.18.0-rc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+## 0.18.0
+
+### API Breaking Changes
+
+* Removed deprecated `Info::encode` method.
+* Improved the compression settings API.
+* `Decoder` now requires a reader that implements `Seek` and `BufRead` traits.
+* Bump bitflags dependency to 2.0.
+
+### Other additions
+
+* Added `Reader::read_row` method.
+* Add support for parsing eXIf chunk.
+* Treat most auxiliary chunk errors as benign.
+
 ## 0.17.16
 
 * Make gAMA and cHRM fallback optional for sRGB ([#547])

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ### API Breaking Changes
 
-* Removed deprecated `Info::encode` method.
-* Improved the compression settings API.
+* Removed deprecated `Info::encode` and `Encoder::set_srgb` methods.
+* Improved the compression settings API for encoding.
 * `Decoder` now requires a reader that implements `Seek` and `BufRead` traits.
 * Bump bitflags dependency to 2.0.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.17.16"
+version = "0.18.0-rc"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -268,18 +268,6 @@ impl<'a, W: Write> Encoder<'a, W> {
 
     /// Mark the image data as conforming to the SRGB color space with the specified rendering intent.
     ///
-    /// Matching source gamma and chromaticities chunks are added automatically.
-    /// Any manually specified source gamma, chromaticities, or ICC profiles will be ignored.
-    #[doc(hidden)]
-    #[deprecated(note = "use set_source_srgb")]
-    pub fn set_srgb(&mut self, rendering_intent: super::SrgbRenderingIntent) {
-        self.info.set_source_srgb(rendering_intent);
-        self.info.source_gamma = Some(crate::srgb::substitute_gamma());
-        self.info.source_chromaticities = Some(crate::srgb::substitute_chromaticities());
-    }
-
-    /// Mark the image data as conforming to the SRGB color space with the specified rendering intent.
-    ///
     /// Any ICC profiles will be ignored.
     ///
     /// Source gamma and chromaticities will be written only if they're set to fallback


### PR DESCRIPTION
One open question is whether we should take this chance to remove `Decoder::{next_row, next_interlaced_row}` in favor of `Decoder::read_row`  (added in #493)