### PR TITLE
Have streaming encode use fdeflate when requested

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -327,16 +327,23 @@ pub enum Compression {
     /// No compression whatsoever. Fastest, but results in large files.
     NoCompression,
     /// Extremely fast but light compression.
+    ///
+    /// Note: When used in streaming mode, this compression level can actually result in files
+    /// *larger* than would be produced by `NoCompression` because it doesn't do any buffering of
+    /// the output stream to detect whether the data is being compressed or not.
     Fastest,
     /// Extremely fast compression with a decent compression ratio.
     ///
-    /// Significantly outperforms libpng and other popular encoders
-    /// by using a [specialized DEFLATE implementation tuned for PNG](https://crates.io/crates/fdeflate),
-    /// while still providing better compression ratio than the fastest modes of other encoders.
+    /// Significantly outperforms libpng and other popular encoders by using a [specialized DEFLATE
+    /// implementation tuned for PNG](https://crates.io/crates/fdeflate), while still providing
+    /// better compression ratio than the fastest modes of other encoders.
+    ///
+    /// Like `Compression::Fast` this can currently produce files larger than `NoCompression` in
+    /// streaming mode. This may change in the future.
     Fast,
     /// Balances encoding speed and compression ratio
     Balanced,
-    /// Spend more time to produce a slightly smaller file than with `Default`
+    /// Spend much more time to produce a slightly smaller file than with `Balanced`.
     High,
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -365,17 +365,21 @@ impl Default for Compression {
 pub enum DeflateCompression {
     /// Do not compress the data at all.
     ///
-    /// Useful for incompressible images,
-    /// or when speed is paramount and you don't care about size at all.
+    /// Useful for incompressible images, or when speed is paramount and you don't care about size
+    /// at all.
     ///
     /// This mode also disables filters, forcing [Filter::NoFilter].
     NoCompression,
 
     /// Excellent for creating lightly compressed PNG images very quickly.
     ///
-    /// Uses the [fdeflate](https://crates.io/crates/fdeflate) crate under the hood
-    /// to achieve speeds far exceeding what libpng is capable of
-    /// while still providing a decent compression ratio.
+    /// Uses the [fdeflate](https://crates.io/crates/fdeflate) crate under the hood to achieve
+    /// speeds far exceeding what libpng is capable of while still providing a decent compression
+    /// ratio.
+    ///
+    /// Note: When used in streaming mode, this compression level can actually result in files
+    /// *larger* than would be produced by `NoCompression` because it doesn't do any buffering of
+    /// the output stream to detect whether the data is being compressed or not.
     FdeflateUltraFast,
 
     /// Compression level between 1 and 9, where higher values mean better compression at the cost of

--- a/src/common.rs
+++ b/src/common.rs
@@ -406,14 +406,6 @@ impl DeflateCompression {
             Compression::High => Self::Level(flate2::Compression::best().level() as u8),
         }
     }
-
-    pub(crate) fn closest_flate2_level(&self) -> flate2::Compression {
-        match self {
-            DeflateCompression::NoCompression => flate2::Compression::none(),
-            DeflateCompression::FdeflateUltraFast => flate2::Compression::new(1),
-            DeflateCompression::Level(level) => flate2::Compression::new(u32::from(*level)),
-        }
-    }
 }
 
 /// An unsigned integer scaled version of a floating point value,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1733,7 +1733,9 @@ impl<'a, W: Write> Write for StreamWriter<'a, W> {
         match self.writer.take() {
             Wrapper::Flate2(mut wrt) => wrt.flush()?,
             Wrapper::Chunk(mut wrt) => wrt.flush()?,
-            Wrapper::FDeflate(w) => { w.finish()?; }
+            Wrapper::FDeflate(w) => {
+                w.finish()?;
+            }
             // This handles both the case where we entered an unrecoverable state after zlib
             // decoding failure and after a panic while we had taken the chunk/zlib reader.
             Wrapper::Unrecoverable | Wrapper::None => {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1335,13 +1335,29 @@ impl<W: Write> Drop for ChunkWriter<'_, W> {
 /// variant is used to signal that.
 enum Wrapper<'a, W: Write> {
     Chunk(ChunkWriter<'a, W>),
-    Zlib(ZlibEncoder<ChunkWriter<'a, W>>),
+    Flate2(ZlibEncoder<ChunkWriter<'a, W>>),
+    FDeflate(fdeflate::Compressor<ChunkWriter<'a, W>>),
     Unrecoverable,
     /// This is used in-between, should never be matched
     None,
 }
 
 impl<'a, W: Write> Wrapper<'a, W> {
+    fn from_level(writer: ChunkWriter<'a, W>, compression: DeflateCompression) -> io::Result<Self> {
+        Ok(match compression {
+            DeflateCompression::NoCompression => {
+                Wrapper::Flate2(ZlibEncoder::new(writer, flate2::Compression::none()))
+            }
+            DeflateCompression::FdeflateUltraFast => {
+                Wrapper::FDeflate(fdeflate::Compressor::new(writer)?)
+            }
+            DeflateCompression::Level(level) => Wrapper::Flate2(ZlibEncoder::new(
+                writer,
+                flate2::Compression::new(u32::from(level)),
+            )),
+        })
+    }
+
     /// Like `Option::take` this returns the `Wrapper` contained
     /// in `self` and replaces it with `Wrapper::None`
     fn take(&mut self) -> Wrapper<'a, W> {
@@ -1399,10 +1415,9 @@ impl<'a, W: Write> StreamWriter<'a, W> {
         let mut chunk_writer = ChunkWriter::new(writer, buf_len);
         let (line_len, to_write) = chunk_writer.next_frame_info();
         chunk_writer.write_header()?;
-        let zlib = ZlibEncoder::new(chunk_writer, compression.closest_flate2_level());
 
         Ok(StreamWriter {
-            writer: Wrapper::Zlib(zlib),
+            writer: Wrapper::from_level(chunk_writer, compression)?,
             index: 0,
             prev_buf,
             curr_buf,
@@ -1610,7 +1625,9 @@ impl<'a, W: Write> StreamWriter<'a, W> {
                 let err = FormatErrorKind::Unrecoverable.into();
                 return Err(EncodingError::Format(err));
             }
-            Wrapper::Zlib(_) => unreachable!("never called on a half-finished frame"),
+            Wrapper::Flate2(_) | Wrapper::FDeflate(_) => {
+                unreachable!("never called on a half-finished frame")
+            }
             Wrapper::None => unreachable!(),
         };
         wrt.flush()?;
@@ -1628,10 +1645,13 @@ impl<'a, W: Write> StreamWriter<'a, W> {
 
         // now it can be taken because the next statements cannot cause any errors
         match self.writer.take() {
-            Wrapper::Chunk(wrt) => {
-                let encoder = ZlibEncoder::new(wrt, self.compression.closest_flate2_level());
-                self.writer = Wrapper::Zlib(encoder);
-            }
+            Wrapper::Chunk(wrt) => match Wrapper::from_level(wrt, self.compression) {
+                Ok(writer) => self.writer = writer,
+                Err(err) => {
+                    self.writer = Wrapper::Unrecoverable;
+                    return Err(err.into());
+                }
+            },
             _ => unreachable!(),
         };
 
@@ -1652,7 +1672,14 @@ impl<'a, W: Write> Write for StreamWriter<'a, W> {
 
         if self.to_write == 0 {
             match self.writer.take() {
-                Wrapper::Zlib(wrt) => match wrt.finish() {
+                Wrapper::Flate2(wrt) => match wrt.finish() {
+                    Ok(chunk) => self.writer = Wrapper::Chunk(chunk),
+                    Err(err) => {
+                        self.writer = Wrapper::Unrecoverable;
+                        return Err(err);
+                    }
+                },
+                Wrapper::FDeflate(wrt) => match wrt.finish() {
                     Ok(chunk) => self.writer = Wrapper::Chunk(chunk),
                     Err(err) => {
                         self.writer = Wrapper::Unrecoverable;
@@ -1683,13 +1710,18 @@ impl<'a, W: Write> Write for StreamWriter<'a, W> {
                 &mut filtered,
             );
             // This can't fail as the other variant is used only to allow the zlib encoder to finish
-            let wrt = match &mut self.writer {
-                Wrapper::Zlib(wrt) => wrt,
+            match &mut self.writer {
+                Wrapper::Flate2(wrt) => {
+                    wrt.write_all(&[filter_type as u8])?;
+                    wrt.write_all(&filtered)?;
+                }
+                Wrapper::FDeflate(wrt) => {
+                    wrt.write_data(&[filter_type as u8])?;
+                    wrt.write_data(&filtered)?;
+                }
                 _ => unreachable!(),
             };
 
-            wrt.write_all(&[filter_type as u8])?;
-            wrt.write_all(&filtered)?;
             mem::swap(&mut self.prev_buf, &mut self.curr_buf);
             self.index = 0;
         }
@@ -1698,9 +1730,10 @@ impl<'a, W: Write> Write for StreamWriter<'a, W> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        match &mut self.writer {
-            Wrapper::Zlib(wrt) => wrt.flush()?,
-            Wrapper::Chunk(wrt) => wrt.flush()?,
+        match self.writer.take() {
+            Wrapper::Flate2(mut wrt) => wrt.flush()?,
+            Wrapper::Chunk(mut wrt) => wrt.flush()?,
+            Wrapper::FDeflate(w) => { w.finish()?; }
             // This handles both the case where we entered an unrecoverable state after zlib
             // decoding failure and after a panic while we had taken the chunk/zlib reader.
             Wrapper::Unrecoverable | Wrapper::None => {


### PR DESCRIPTION
This makes the streaming encoder also use fdeflate when the relevant compression level is requested. The main downside is that unlike when using `write_image_data`, this can actually produce PNGs up to 50% larger than storing the pixel data fully uncompressed.

Fixes #586 