### PR TITLE
Adjust buffer sizes

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -6,7 +6,7 @@ mod unfiltering_buffer;
 mod zlib;
 
 use self::read_decoder::{ImageDataCompletionStatus, ReadDecoder};
-use self::stream::{DecodeOptions, DecodingError, FormatErrorInner, CHUNK_BUFFER_SIZE};
+use self::stream::{DecodeOptions, DecodingError, FormatErrorInner};
 use self::transform::{create_transform_fn, TransformFn};
 use self::unfiltering_buffer::UnfilteringBuffer;
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -17,8 +17,7 @@ use crate::text_metadata::{ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk};
 use crate::traits::ReadBytesExt;
 use crate::{CodingIndependentCodePoints, Limits};
 
-/// TODO check if these size are reasonable
-pub const CHUNK_BUFFER_SIZE: usize = 32 * 1024;
+pub const CHUNK_BUFFER_SIZE: usize = 128;
 
 /// Determines if checksum checks should be disabled globally.
 ///
@@ -571,7 +570,12 @@ impl StreamingDecoder {
 
         StreamingDecoder {
             state: Some(State::new_u32(U32ValueKind::Signature1stU32)),
-            current_chunk: ChunkState::default(),
+            current_chunk: ChunkState {
+                type_: ChunkType([0; 4]),
+                crc: Crc32::new(),
+                remaining: 0,
+                raw_bytes: Vec::with_capacity(CHUNK_BUFFER_SIZE),
+            },
             inflater,
             info: None,
             current_seq_no: None,
@@ -1836,17 +1840,6 @@ impl Info<'_> {
 impl Default for StreamingDecoder {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl Default for ChunkState {
-    fn default() -> Self {
-        ChunkState {
-            type_: ChunkType([0; 4]),
-            crc: Crc32::new(),
-            remaining: 0,
-            raw_bytes: Vec::with_capacity(CHUNK_BUFFER_SIZE),
-        }
     }
 }
 

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -1,6 +1,8 @@
-use super::{stream::FormatErrorInner, DecodingError, CHUNK_BUFFER_SIZE};
+use super::{stream::FormatErrorInner, DecodingError};
 
 use fdeflate::Decompressor;
+
+const OUT_BUFFER_CHUNK_SIZE: usize = 8 * 1024;
 
 /// Ergonomics wrapper around `miniz_oxide::inflate::stream` for zlib compressed data.
 pub(super) struct ZlibStream {
@@ -166,7 +168,7 @@ impl ZlibStream {
         let current_len = self.out_buffer.len();
         let desired_len = self
             .out_pos
-            .saturating_add(CHUNK_BUFFER_SIZE)
+            .saturating_add(OUT_BUFFER_CHUNK_SIZE)
             .min(self.max_total_output);
         if current_len >= desired_len {
             return;
@@ -182,7 +184,7 @@ impl ZlibStream {
         // allocation is valid and that any cursor within it will be valid.
         len
             // This keeps the buffer size a power-of-two, required by miniz_oxide.
-            .saturating_add(CHUNK_BUFFER_SIZE.max(len))
+            .saturating_add(OUT_BUFFER_CHUNK_SIZE.max(len))
             // Ensure all buffer indices are valid cursor positions.
             // Note: both cut off and zero extension give correct results.
             .min(u64::MAX as usize)


### PR DESCRIPTION
The `CHUNK_BUFFER_SIZE` constant was set to 32KB which applied to two rather different buffer sizes:
1. The buffer that the `StreamingDecoder` uses to read metadata chunks into.
2. How much the `ZlibStream` object grows its output buffer by each time it fills up.

There's no particular reason that these should be the same size. For (1) I wasn't able to tell any performance different with different sizes so I set it to 128 bytes to reduce the amount of memory allocated when starting the decoder.

Decreasing the size used by `ZlibStream` seems to significantly improve performance. On my machine decoding the qoi-bench corpus, I saw a ~2.5% improvement in average end-to-end PNG decoding speed and a nearly 5% improvement in the geomean speed.