### PR TITLE
Unfilter buffer for decoded stream

### DIFF
--- a/examples/pngcheck.rs
+++ b/examples/pngcheck.rs
@@ -170,7 +170,7 @@ fn check_image<P: AsRef<Path>>(c: Config, fname: P) -> io::Result<()> {
             }
             buf = &data[..n];
         }
-        match decoder.update(buf, &mut Vec::new()) {
+        match decoder.update(buf, None) {
             Ok((_, ImageEnd)) => {
                 if !have_idat {
                     // This isn't beautiful. But it works.

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -188,12 +188,7 @@ impl<R: BufRead + Seek> Decoder<R> {
     /// Reads all meta data until the first IDAT chunk
     pub fn read_info(mut self) -> Result<Reader<R>, DecodingError> {
         let info = self.read_header_info()?;
-
-        let unfiltering_buffer = {
-            let max_rowline = info.width as usize * info.bytes_per_pixel();
-            let unfilter_height = info.height as usize;
-            UnfilteringBuffer::new(max_rowline, unfilter_height)
-        };
+        let unfiltering_buffer = UnfilteringBuffer::new(info);
 
         let mut reader = Reader {
             decoder: self.read_decoder,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -187,14 +187,15 @@ impl<R: BufRead + Seek> Decoder<R> {
 
     /// Reads all meta data until the first IDAT chunk
     pub fn read_info(mut self) -> Result<Reader<R>, DecodingError> {
-        self.read_header_info()?;
+        let info = self.read_header_info()?;
+        let max_rowline = info.width as usize * info.bytes_per_pixel();
 
         let mut reader = Reader {
             decoder: self.read_decoder,
             bpp: BytesPerPixel::One,
             subframe: SubframeInfo::not_yet_init(),
             remaining_frames: 0, // Temporary value - fixed below after reading `acTL` and `fcTL`.
-            unfiltering_buffer: UnfilteringBuffer::new(),
+            unfiltering_buffer: UnfilteringBuffer::new(max_rowline),
             transform: self.transform,
             transform_fn: None,
             scratch_buffer: Vec::new(),
@@ -360,7 +361,7 @@ impl<R: BufRead + Seek> Reader<R> {
 
         self.subframe = SubframeInfo::new(self.info());
         self.bpp = self.info().bpp_in_prediction();
-        self.unfiltering_buffer = UnfilteringBuffer::new();
+        self.unfiltering_buffer.reset_all();
 
         // Allocate output buffer.
         let buflen = self.output_line_size(self.subframe.width);
@@ -559,7 +560,7 @@ impl<R: BufRead + Seek> Reader<R> {
         }
 
         self.remaining_frames = 0;
-        self.unfiltering_buffer = UnfilteringBuffer::new();
+        self.unfiltering_buffer.reset_all();
         self.decoder.read_until_end_of_input()?;
 
         self.finished = true;
@@ -649,10 +650,8 @@ impl<R: BufRead + Seek> Reader<R> {
                 ));
             }
 
-            match self
-                .decoder
-                .decode_image_data(self.unfiltering_buffer.as_mut_vec())?
-            {
+            let mut buffer = self.unfiltering_buffer.as_unfilled_buffer();
+            match self.decoder.decode_image_data(Some(&mut buffer))? {
                 ImageDataCompletionStatus::ExpectingMoreData => (),
                 ImageDataCompletionStatus::Done => self.mark_subframe_as_consumed_and_flushed(),
             }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -18,6 +18,7 @@ use crate::common::{
     BitDepth, BytesPerPixel, ColorType, Info, ParameterErrorKind, Transformations,
 };
 use crate::FrameControl;
+pub use zlib::{UnfilterBuf, UnfilterRegion};
 
 pub use interlace_info::InterlaceInfo;
 use interlace_info::InterlaceInfoIter;

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1681,19 +1681,6 @@ impl StreamingDecoder {
             }
         };
 
-        if let Some(mut raw_row_len) = color_type.checked_raw_row_length(bit_depth, width) {
-            if interlaced {
-                // This overshoots, but overestimating should be fine.
-                // TODO: Calculate **exact** IDAT size for interlaced images.
-                raw_row_len = raw_row_len.saturating_mul(2);
-            }
-
-            /* FIXME: we can still track this
-            self.inflater
-                .set_max_total_output((height as usize).saturating_mul(raw_row_len));
-            */
-        }
-
         self.info = Some(Info {
             width,
             height,

--- a/src/decoder/unfiltering_buffer.rs
+++ b/src/decoder/unfiltering_buffer.rs
@@ -40,7 +40,7 @@ impl UnfilteringBuffer {
 
     pub fn new(max_rowlen: usize) -> Self {
         let result = Self {
-            data_stream: Vec::new(),
+            data_stream: Vec::with_capacity(max_rowlen * 32),
             prev_start: 0,
             current_start: 0,
             filled: 0,

--- a/src/decoder/unfiltering_buffer.rs
+++ b/src/decoder/unfiltering_buffer.rs
@@ -1,4 +1,5 @@
 use super::stream::{DecodingError, FormatErrorInner};
+use super::zlib::UnfilterBuf;
 use crate::common::BytesPerPixel;
 use crate::filter::{unfilter, RowFilter};
 
@@ -9,12 +10,21 @@ pub(crate) struct UnfilteringBuffer {
     /// Index in `data_stream` where the previous row starts.
     /// This excludes the filter type byte - it points at the first byte of actual pixel data.
     /// The pixel data is already-`unfilter`-ed.
+    ///
     /// If `prev_start == current_start` then it means that there is no previous row.
     prev_start: usize,
     /// Index in `data_stream` where the current row starts.
     /// This points at the filter type byte of the current row (i.e. the actual pixel data starts at `current_start + 1`)
     /// The pixel data is not-yet-`unfilter`-ed.
+    ///
+    /// `current_start` can wrap around the length.
     current_start: usize,
+    /// Logical length of data that must be preserved.
+    filled: usize,
+    /// Length of data that can be modified.
+    available: usize,
+    /// The maximum number of bytes that we should allocate in the `data_stream`.
+    allocation_limit: usize,
 }
 
 impl UnfilteringBuffer {
@@ -23,16 +33,21 @@ impl UnfilteringBuffer {
     /// ensure that the final state preserves the invariants.
     fn debug_assert_invariants(&self) {
         debug_assert!(self.prev_start <= self.current_start);
-        debug_assert!(self.prev_start <= self.data_stream.len());
-        debug_assert!(self.current_start <= self.data_stream.len());
+        debug_assert!(self.current_start <= self.available);
+        debug_assert!(self.available <= self.filled);
+        debug_assert!(self.filled <= self.data_stream.len());
     }
 
-    pub fn new() -> Self {
+    pub fn new(max_rowlen: usize) -> Self {
         let result = Self {
             data_stream: Vec::new(),
             prev_start: 0,
             current_start: 0,
+            filled: 0,
+            available: 0,
+            allocation_limit: max_rowlen * 32,
         };
+
         result.debug_assert_invariants();
         result
     }
@@ -44,17 +59,22 @@ impl UnfilteringBuffer {
         self.debug_assert_invariants();
     }
 
+    pub fn reset_all(&mut self) {
+        self.data_stream.clear();
+        self.prev_start = 0;
+        self.current_start = 0;
+        self.filled = 0;
+        self.available = 0;
+    }
+
     /// Returns the previous (already `unfilter`-ed) row.
     pub fn prev_row(&self) -> &[u8] {
-        // No point calling this if there is no previous row.
-        debug_assert!(self.prev_start < self.current_start);
-
         &self.data_stream[self.prev_start..self.current_start]
     }
 
     /// Returns how many bytes of the current row are present in the buffer.
     pub fn curr_row_len(&self) -> usize {
-        self.data_stream.len() - self.current_start
+        self.available - self.current_start
     }
 
     /// Returns a `&mut Vec<u8>` suitable for passing to
@@ -65,19 +85,65 @@ impl UnfilteringBuffer {
     /// `ReadDecoder` and `StreamingDecoder`).  TODO: Consider protecting the
     /// invariants by returning an append-only view of the vector
     /// (`FnMut(&[u8])`??? or maybe `std::io::Write`???).
-    pub fn as_mut_vec(&mut self) -> &mut Vec<u8> {
-        // Opportunistically compact the current buffer by discarding bytes
-        // before `prev_start`.
-        if self.prev_start > 0 {
-            self.data_stream.copy_within(self.prev_start.., 0);
-            self.data_stream
-                .truncate(self.data_stream.len() - self.prev_start);
-            self.current_start -= self.prev_start;
-            self.prev_start = 0;
-            self.debug_assert_invariants();
+    pub fn as_unfilled_buffer(&mut self) -> UnfilterBuf<'_> {
+        const GROWTH: usize = 128 * 1024;
+        let grown_len = self.filled + GROWTH;
+
+        if grown_len < self.data_stream.len() {
+            return UnfilterBuf {
+                buffer: &mut self.data_stream,
+                filled: &mut self.filled,
+                available: &mut self.available,
+            };
         }
 
-        &mut self.data_stream
+        // We may want to grow the stream. That is if it has not yet allocated across our
+        // limit or if we must because there is not enough space at the start..
+        debug_assert!(self.current_start <= self.data_stream.len());
+
+        // We really only need to preserve the part from `available` onwards but but we do not
+        // separate lines so here we compress everything from the previous data onwards.
+        debug_assert!(self.prev_start <= self.available);
+        debug_assert!(self.prev_start <= self.filled);
+
+        // Grow if we're not yet at the limit anyways. And We need to be able to buffer at
+        // least a line to not starve the reader. And we must be able to relocate the current
+        // data. So grow in these instances too even if it is beyond the limit, it's a soft
+        // limit in this sense.
+        if grown_len < self.allocation_limit
+            // There is not enough room gained by shuffling. Plus we actually do want to grow a bit
+            // so avoid copying only a little bit of the input.
+            || self.allocation_limit / 2 >= self.prev_start
+        {
+            // There is never a reason to ever contract the vector.
+            let actual_len = self.data_stream.len().max(grown_len);
+            self.data_stream.resize(actual_len, 0);
+            return UnfilterBuf {
+                buffer: &mut self.data_stream,
+                filled: &mut self.filled,
+                available: &mut self.available,
+            };
+        }
+
+        // We have to relocate the data to the start of the buffer.
+        self.data_stream
+            .copy_within(self.prev_start..self.filled, 0);
+
+        // The data kept its relative position to `filled` which now lands exactly at
+        // the distance between prev_start and filled.
+        self.current_start -= self.prev_start;
+        self.available -= self.prev_start;
+        self.filled -= self.prev_start;
+        self.prev_start = 0;
+
+        let actual_len = self.data_stream.len().max(self.filled + GROWTH);
+        self.data_stream.resize(actual_len, 0);
+
+        UnfilterBuf {
+            buffer: &mut self.data_stream,
+            filled: &mut self.filled,
+            available: &mut self.available,
+        }
     }
 
     /// Runs `unfilter` on the current row, and then shifts rows so that the current row becomes the previous row.
@@ -91,8 +157,8 @@ impl UnfilteringBuffer {
         debug_assert!(rowlen >= 2); // 1 byte for `FilterType` and at least 1 byte of pixel data.
 
         let (prev, row) = self.data_stream.split_at_mut(self.current_start);
-        let prev: &[u8] = prev; // `prev` is immutable
-        let prev = &prev[self.prev_start..];
+        let prev: &[u8] = &prev[self.prev_start..];
+
         debug_assert!(prev.is_empty() || prev.len() == (rowlen - 1));
 
         // Get the filter type.
@@ -105,6 +171,7 @@ impl UnfilteringBuffer {
 
         self.prev_start = self.current_start + 1;
         self.current_start += rowlen;
+
         self.debug_assert_invariants();
 
         Ok(())

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -13,11 +13,13 @@ use fdeflate::Decompressor;
 /// Violating the invariants, i.e. modifying bytes in the marked region, results in absurdly wacky
 /// decompression output or panics but not undefined behavior.
 pub struct UnfilterBuf<'data> {
-    // The data to be fed into the decoder for (zlib) decompression.
+    /// The data container. Starts with arbitrary data unrelated to the decoder, a slice of decoder
+    /// private data followed by free space for further decoder output. The regions are delimited
+    /// by `filled` and `available` which must be updated accordingly.
     pub(crate) buffer: &'data mut Vec<u8>,
-    // Where we record changes to the out position.
+    /// Where we record changes to the out position.
     pub(crate) filled: &'data mut usize,
-    // Where we record changes to the available byte.
+    /// Where we record changes to the available byte.
     pub(crate) available: &'data mut usize,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub use crate::adam7::Adam7Info;
 pub use crate::common::*;
 pub use crate::decoder::stream::{DecodeOptions, Decoded, DecodingError, StreamingDecoder};
 pub use crate::decoder::{Decoder, InterlaceInfo, InterlacedRow, Limits, OutputInfo, Reader};
+pub use crate::decoder::{UnfilterBuf, UnfilterRegion};
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
 pub use crate::filter::Filter;
 


### PR DESCRIPTION
An alternative to #589 where we preserve having an argument in `StreamDecoder::update`, so roughly keeping the previous API intact. Instead, the internals for the `UnfilterBuffer` are modified such that a reference to it and its state tracking are being passed into `zlib`. The interface is even kept flexible in the sense that it does not know the details of the required preserved data length (which it must not modify in `unfilter`, I did that on accident and that was a hard bug to discover :smiley:).

As an additional tweaking parameter, we pass the maximum rowlength (in bytes) to that buffer. This way we can pre-allocate and tune the resizing steps. I think I've improperly tuned for very large widths for now (see performance logs) but this additional information should enable serving all sizes more reliably.

<details>
<summary>i7-8565U / 16GB</summary>

```
decode/Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png
                        time:   [53.514 ms 56.304 ms 58.575 ms]
                        thrpt:  [182.31 MiB/s 189.66 MiB/s 199.55 MiB/s]
                 change:
                        time:   [-0.9990% +3.4599% +7.5301%] (p = 0.16 > 0.05)
                        thrpt:  [-7.0028% -3.3442% +1.0091%]
                        No change in performance detected.
decode/Transparency.png time:   [208.74 µs 209.25 µs 209.94 µs]
                        thrpt:  [1.5970 GiB/s 1.6023 GiB/s 1.6062 GiB/s]
                 change:
                        time:   [-20.036% -19.583% -19.174%] (p = 0.00 < 0.05)
                        thrpt:  [+23.723% +24.352% +25.057%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
decode/kodim02.png      time:   [7.1647 ms 7.1879 ms 7.2262 ms]
                        thrpt:  [155.68 MiB/s 156.51 MiB/s 157.02 MiB/s]
                 change:
                        time:   [-4.0359% -3.5946% -3.1558%] (p = 0.00 < 0.05)
                        thrpt:  [+3.2587% +3.7286% +4.2057%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
decode/kodim07.png      time:   [8.9415 ms 8.9682 ms 9.0092 ms]
                        thrpt:  [124.87 MiB/s 125.44 MiB/s 125.82 MiB/s]
                 change:
                        time:   [-2.6469% -2.3210% -1.9620%] (p = 0.00 < 0.05)
                        thrpt:  [+2.0012% +2.3762% +2.7188%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
decode/kodim17.png      time:   [7.8792 ms 7.9080 ms 7.9600 ms]
                        thrpt:  [141.33 MiB/s 142.26 MiB/s 142.78 MiB/s]
                 change:
                        time:   [-0.7567% -0.3538% +0.0279%] (p = 0.10 > 0.05)
                        thrpt:  [-0.0279% +0.3551% +0.7624%]
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
decode/kodim23.png      time:   [6.9631 ms 7.0373 ms 7.1254 ms]
                        thrpt:  [157.89 MiB/s 159.86 MiB/s 161.56 MiB/s]
                 change:
                        time:   [-4.0047% -3.2122% -2.2962%] (p = 0.00 < 0.05)
                        thrpt:  [+2.3502% +3.3188% +4.1718%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
decode/paletted-zune.png
                        time:   [21.529 ms 21.535 ms 21.539 ms]
                        thrpt:  [612.89 MiB/s 613.02 MiB/s 613.17 MiB/s]
                 change:
                        time:   [-5.8343% -5.3339% -4.8609%] (p = 0.00 < 0.05)
                        thrpt:  [+5.1092% +5.6344% +6.1958%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high severe

generated-noncompressed-4k-idat/8x8.png
                        time:   [9.2325 µs 9.2650 µs 9.2971 µs]
                        thrpt:  [26.260 MiB/s 26.351 MiB/s 26.444 MiB/s]
                 change:
                        time:   [+158.51% +160.57% +163.19%] (p = 0.00 < 0.05)
                        thrpt:  [-62.005% -61.623% -61.316%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
generated-noncompressed-4k-idat/128x128.png
                        time:   [35.735 µs 35.771 µs 35.821 µs]
                        thrpt:  [1.7039 GiB/s 1.7063 GiB/s 1.7080 GiB/s]
                 change:
                        time:   [+11.833% +12.682% +13.860%] (p = 0.00 < 0.05)
                        thrpt:  [-12.173% -11.255% -10.581%]
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe
generated-noncompressed-4k-idat/2048x2048.png
                        time:   [6.1074 ms 6.1472 ms 6.1908 ms]
                        thrpt:  [2.5239 GiB/s 2.5418 GiB/s 2.5584 GiB/s]
                 change:
                        time:   [-22.167% -21.251% -20.386%] (p = 0.00 < 0.05)
                        thrpt:  [+25.606% +26.986% +28.480%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
generated-noncompressed-4k-idat/12288x12288.png
                        time:   [223.83 ms 224.67 ms 225.64 ms]
                        thrpt:  [2.4929 GiB/s 2.5037 GiB/s 2.5130 GiB/s]
                 change:
                        time:   [-21.772% -21.458% -21.124%] (p = 0.00 < 0.05)
                        thrpt:  [+26.781% +27.320% +27.831%]
                        Performance has improved.

generated-noncompressed-64k-idat/128x128.png
                        time:   [30.349 µs 30.430 µs 30.526 µs]
                        thrpt:  [1.9994 GiB/s 2.0058 GiB/s 2.0111 GiB/s]
                 change:
                        time:   [-0.9004% +0.1082% +1.1976%] (p = 0.86 > 0.05)
                        thrpt:  [-1.1834% -0.1081% +0.9086%]
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
generated-noncompressed-64k-idat/2048x2048.png
                        time:   [5.3736 ms 5.3861 ms 5.3986 ms]
                        thrpt:  [2.8943 GiB/s 2.9010 GiB/s 2.9077 GiB/s]
                 change:
                        time:   [-15.321% -14.622% -13.986%] (p = 0.00 < 0.05)
                        thrpt:  [+16.260% +17.127% +18.093%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
generated-noncompressed-64k-idat/12288x12288.png
                        time:   [192.39 ms 193.20 ms 194.03 ms]
                        thrpt:  [2.8990 GiB/s 2.9115 GiB/s 2.9237 GiB/s]
                 change:
                        time:   [-28.494% -28.177% -27.832%] (p = 0.00 < 0.05)
                        thrpt:  [+38.566% +39.231% +39.848%]
                        Performance has improved.

generated-noncompressed-2g-idat/2048x2048.png
                        time:   [5.5494 ms 5.5722 ms 5.5981 ms]
                        thrpt:  [2.7911 GiB/s 2.8041 GiB/s 2.8156 GiB/s]
                 change:
                        time:   [-19.904% -18.913% -17.780%] (p = 0.00 < 0.05)
                        thrpt:  [+21.625% +23.324% +24.850%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
generated-noncompressed-2g-idat/12288x12288.png
                        time:   [215.38 ms 215.87 ms 216.57 ms]
                        thrpt:  [2.5973 GiB/s 2.6058 GiB/s 2.6117 GiB/s]
                 change:
                        time:   [-15.673% -15.471% -15.225%] (p = 0.00 < 0.05)
                        thrpt:  [+17.959% +18.303% +18.586%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

row-by-row/128x128-4k-idat
                        time:   [38.033 µs 38.055 µs 38.082 µs]
                        thrpt:  [1.6027 GiB/s 1.6039 GiB/s 1.6048 GiB/s]
                 change:
                        time:   [+27.552% +28.116% +28.664%] (p = 0.00 < 0.05)
                        thrpt:  [-22.278% -21.946% -21.601%]
                        Performance has regressed.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  9 (9.00%) high severe
```

</details>

<details>
<summary>Ryzen 9 7900X</summary>

```
decode/Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png
                        time:   [13.082 ms 13.083 ms 13.084 ms]
                        thrpt:  [816.16 MiB/s 816.20 MiB/s 816.27 MiB/s]
                 change:
                        time:   [-7.6118% -7.6013% -7.5900%] (p = 0.00 < 0.05)
                        thrpt:  [+8.2134% +8.2266% +8.2389%]
                        Performance has improved.
decode/Transparency.png time:   [47.622 µs 47.626 µs 47.632 µs]
                        thrpt:  [7.0389 GiB/s 7.0397 GiB/s 7.0403 GiB/s]
                 change:
                        time:   [-16.164% -16.151% -16.138%] (p = 0.00 < 0.05)
                        thrpt:  [+19.243% +19.262% +19.281%]
                        Performance has improved.
decode/kodim02.png      time:   [1.9901 ms 1.9902 ms 1.9902 ms]
                        thrpt:  [565.26 MiB/s 565.28 MiB/s 565.31 MiB/s]
                 change:
                        time:   [-0.6936% -0.6826% -0.6717%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6762% +0.6873% +0.6984%]
                        Change within noise threshold.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
decode/kodim07.png      time:   [2.4414 ms 2.4416 ms 2.4418 ms]
                        thrpt:  [460.73 MiB/s 460.76 MiB/s 460.80 MiB/s]
                 change:
                        time:   [-0.3345% -0.3172% -0.3015%] (p = 0.00 < 0.05)
                        thrpt:  [+0.3024% +0.3182% +0.3356%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
decode/kodim17.png      time:   [1.9752 ms 1.9753 ms 1.9754 ms]
                        thrpt:  [569.49 MiB/s 569.52 MiB/s 569.56 MiB/s]
                 change:
                        time:   [-1.5709% -1.5603% -1.5498%] (p = 0.00 < 0.05)
                        thrpt:  [+1.5742% +1.5850% +1.5960%]
                        Performance has improved.
decode/kodim23.png      time:   [1.9155 ms 1.9157 ms 1.9159 ms]
                        thrpt:  [587.19 MiB/s 587.24 MiB/s 587.30 MiB/s]
                 change:
                        time:   [-1.0609% -1.0423% -1.0272%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0378% +1.0533% +1.0722%]
                        Performance has improved.
decode/paletted-zune.png
                        time:   [5.2877 ms 5.2878 ms 5.2880 ms]
                        thrpt:  [2.4379 GiB/s 2.4380 GiB/s 2.4381 GiB/s]
                 change:
                        time:   [-0.8779% -0.8707% -0.8637%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8712% +0.8783% +0.8856%]
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

generated-noncompressed-4k-idat/8x8.png
                        time:   [1.6506 µs 1.6508 µs 1.6509 µs]
                        thrpt:  [147.88 MiB/s 147.89 MiB/s 147.91 MiB/s]
                 change:
                        time:   [+102.52% +102.61% +102.68%] (p = 0.00 < 0.05)
                        thrpt:  [-50.662% -50.644% -50.623%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
generated-noncompressed-4k-idat/128x128.png
                        time:   [9.8813 µs 9.8821 µs 9.8829 µs]
                        thrpt:  [6.1758 GiB/s 6.1763 GiB/s 6.1768 GiB/s]
                 change:
                        time:   [+13.103% +13.158% +13.219%] (p = 0.00 < 0.05)
                        thrpt:  [-11.675% -11.628% -11.585%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
generated-noncompressed-4k-idat/2048x2048.png
                        time:   [1.9009 ms 1.9016 ms 1.9026 ms]
                        thrpt:  [8.2124 GiB/s 8.2166 GiB/s 8.2198 GiB/s]
                 change:
                        time:   [-14.217% -14.110% -14.012%] (p = 0.00 < 0.05)
                        thrpt:  [+16.295% +16.428% +16.573%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
generated-noncompressed-4k-idat/12288x12288.png
                        time:   [81.240 ms 81.258 ms 81.270 ms]
                        thrpt:  [6.9214 GiB/s 6.9224 GiB/s 6.9240 GiB/s]
                 change:
                        time:   [-21.585% -21.561% -21.537%] (p = 0.00 < 0.05)
                        thrpt:  [+27.448% +27.488% +27.527%]
                        Performance has improved.

generated-noncompressed-64k-idat/128x128.png
                        time:   [10.185 µs 10.185 µs 10.186 µs]
                        thrpt:  [5.9920 GiB/s 5.9924 GiB/s 5.9929 GiB/s]
                 change:
                        time:   [+21.508% +21.550% +21.587%] (p = 0.00 < 0.05)
                        thrpt:  [-17.755% -17.729% -17.701%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) low mild
  4 (4.00%) high severe
generated-noncompressed-64k-idat/2048x2048.png
                        time:   [1.6706 ms 1.6711 ms 1.6715 ms]
                        thrpt:  [9.3477 GiB/s 9.3500 GiB/s 9.3530 GiB/s]
                 change:
                        time:   [-13.490% -13.427% -13.373%] (p = 0.00 < 0.05)
                        thrpt:  [+15.437% +15.509% +15.594%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
generated-noncompressed-64k-idat/12288x12288.png
                        time:   [74.747 ms 74.816 ms 74.870 ms]
                        thrpt:  [7.5131 GiB/s 7.5185 GiB/s 7.5254 GiB/s]
                 change:
                        time:   [-19.972% -19.886% -19.812%] (p = 0.00 < 0.05)
                        thrpt:  [+24.707% +24.822% +24.956%]
                        Performance has improved.

generated-noncompressed-2g-idat/2048x2048.png
                        time:   [1.5923 ms 1.5931 ms 1.5942 ms]
                        thrpt:  [9.8015 GiB/s 9.8079 GiB/s 9.8126 GiB/s]
                 change:
                        time:   [-13.986% -13.882% -13.780%] (p = 0.00 < 0.05)
                        thrpt:  [+15.982% +16.120% +16.260%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
generated-noncompressed-2g-idat/12288x12288.png
                        time:   [71.693 ms 71.703 ms 71.717 ms]
                        thrpt:  [7.8434 GiB/s 7.8448 GiB/s 7.8459 GiB/s]
                 change:
                        time:   [-17.182% -17.142% -17.115%] (p = 0.00 < 0.05)
                        thrpt:  [+20.650% +20.688% +20.747%]
                        Performance has improved.

row-by-row/128x128-4k-idat
                        time:   [10.086 µs 10.086 µs 10.087 µs]
                        thrpt:  [6.0508 GiB/s 6.0512 GiB/s 6.0516 GiB/s]
                 change:
                        time:   [+3.6800% +3.7056% +3.7289%] (p = 0.00 < 0.05)
                        thrpt:  [-3.5949% -3.5732% -3.5494%]
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```

</details>


Closes: #589 