### PR TITLE
Don't reset inflater more than necessary

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -857,7 +857,6 @@ impl StreamingDecoder {
                         self.inflater.finish_compressed_chunks(image_data)?;
                     }
 
-                    self.inflater.reset();
                     self.ready_for_idat_chunks = false;
                     self.ready_for_fdat_chunks = false;
                     self.state = Some(State::U32 {


### PR DESCRIPTION
We already reset the inflater at the start of each frame:
https://github.com/image-rs/image-png/blob/a9e05a26bfe13894d9a96b373619b71fe8353e4c/src/decoder/stream.rs#L1094

Thus there's no need to reset it again at the end of each frame. And in particular, PNGs without animation don't need to reset the inflater at all.