### PR TITLE
Inflate into slice rather than Vec

### DIFF
--- a/src/decoder/unfiltering_buffer.rs
+++ b/src/decoder/unfiltering_buffer.rs
@@ -167,7 +167,7 @@ impl UnfilteringBuffer {
         }
 
         UnfilterBuf {
-            buffer: &mut self.data_stream,
+            buffer: &mut self.data_stream[..self.filled + self.growth_bytes],
             filled: &mut self.filled,
             available: &mut self.available,
         }


### PR DESCRIPTION
This PR changes the behavior of the streaming decoder if there's a lot of output buffered by the underlying zlib decoder at the end of a sequence of IDATs. Instead of pushing it all into the unfiltering buffer using `flush_allocate` if necessary, it now flushes as much as there is space for and then returns back to the caller. However, this is mostly a theoretical difference because `fdeflate` at the moment only buffers at most 63-bits of input data and we allocate KBs of space in the output buffer for each decompress operation.

But the bigger reason for this change is that it lets us throttle the decompressor. Even if there's plenty of space in the output buffer, we can limit the amount of data we decompress in one go. This gives tighter interleaving of decompression and unfiltering, and other than on the synthetic benchmarks (see #592) it seems to meaningfully improve performance.

Measuring the decoding speeds on the qoi-bench corpus using [corpus-bench](https://github.com/fintelia/corpus-bench/tree/rc) with a 5600X:
```
v0.18.0-rc:    275.430 MP/s (average) 234.774 MP/s (geomean)
main branch:   297.530 MP/s (average) 254.397 MP/s (geomean)
this pr:       308.406 MP/s (average) 257.760 MP/s (geomean)
```

<details>
<summary><tt>cargo bench --bench decoder</tt> benchmark output</summary>

<pre><font color="#26A269">decode/kodim02.png</font>      time:   [2.4862 ms <b>2.4887 ms</b> 2.4916 ms]
                        thrpt:  [451.51 MiB/s <b>452.05 MiB/s</b> 452.49 MiB/s]
                 change:
                        time:   [-2.2536% <font color="#26A269"><b>-2.0945%</b></font> -1.9432%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+1.9817% <font color="#26A269"><b>+2.1393%</b></font> +2.3055%]
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 5 outliers among 100 measurements (5.00%)</font>
  5 (5.00%) high severe
<font color="#26A269">decode/paletted-zune.png</font>
                        time:   [6.9718 ms <b>6.9741 ms</b> 6.9772 ms]
                        thrpt:  [1.8477 GiB/s <b>1.8485 GiB/s</b> 1.8491 GiB/s]
                 change:
                        time:   [-0.5462% -0.3588% -0.1618%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+0.1621% +0.3600% +0.5492%]
                        Change within noise threshold.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high severe
<font color="#26A269">Benchmarking decode/Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png: Collecting 10 samples in estimated 5.7884 s (330 iteratdecode/Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png</font>
                        time:   [17.563 ms <b>17.599 ms</b> 17.639 ms]
                        thrpt:  [605.40 MiB/s <b>606.76 MiB/s</b> 608.03 MiB/s]
                 change:
                        time:   [+1.1399% <font color="#C01C28"><b>+1.5227%</b></font> +1.9598%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-1.9221% <font color="#C01C28"><b>-1.4998%</b></font> -1.1271%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  2 (20.00%) high mild
<font color="#26A269">decode/kodim17.png</font>      time:   [2.4606 ms <b>2.4656 ms</b> 2.4731 ms]
                        thrpt:  [454.90 MiB/s <b>456.28 MiB/s</b> 457.21 MiB/s]
                 change:
                        time:   [-0.9561% -0.6578% -0.3140%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+0.3150% +0.6621% +0.9653%]
                        Change within noise threshold.
<font color="#26A269">decode/Transparency.png</font> time:   [72.719 µs <b>72.856 µs</b> 73.095 µs]
                        thrpt:  [4.5869 GiB/s <b>4.6019 GiB/s</b> 4.6106 GiB/s]
                 change:
                        time:   [-41.136% <font color="#26A269"><b>-40.817%</b></font> -40.566%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+68.255% <font color="#26A269"><b>+68.966%</b></font> +69.884%]
                        Performance has <font color="#26A269">improved</font>.
<font color="#26A269">decode/kodim07.png</font>      time:   [3.0115 ms <b>3.0341 ms</b> 3.0625 ms]
                        thrpt:  [367.35 MiB/s <b>370.79 MiB/s</b> 373.56 MiB/s]
                 change:
                        time:   [-0.5167% +0.4037% +1.3875%] (p = 0.46 &gt; 0.05)
                        thrpt:  [-1.3685% -0.4021% +0.5194%]
                        No change in performance detected.
<font color="#26A269">decode/kodim23.png</font>      time:   [2.4113 ms <b>2.4229 ms</b> 2.4371 ms]
                        thrpt:  [461.61 MiB/s <b>464.32 MiB/s</b> 466.54 MiB/s]
                 change:
                        time:   [-1.1381% -0.4058% +0.2598%] (p = 0.31 &gt; 0.05)
                        thrpt:  [-0.2591% +0.4075% +1.1512%]
                        No change in performance detected.

<font color="#26A269">generated-noncompressed-4k-idat/8x8.png</font>
                        time:   [1.1547 µs <b>1.1590 µs</b> 1.1641 µs]
                        thrpt:  [209.73 MiB/s <b>210.66 MiB/s</b> 211.42 MiB/s]
                 change:
                        time:   [-20.166% <font color="#26A269"><b>-18.684%</b></font> -17.691%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+21.493% <font color="#26A269"><b>+22.978%</b></font> +25.259%]
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 11 outliers among 100 measurements (11.00%)</font>
  5 (5.00%) high mild
  6 (6.00%) high severe
<font color="#26A269">generated-noncompressed-4k-idat/128x128.png</font>
                        time:   [17.323 µs <b>17.379 µs</b> 17.442 µs]
                        thrpt:  [3.4994 GiB/s <b>3.5120 GiB/s</b> 3.5234 GiB/s]
                 change:
                        time:   [-1.3965% -1.0283% -0.6202%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+0.6241% +1.0390% +1.4163%]
                        Change within noise threshold.
<font color="#A2734C">Found 9 outliers among 100 measurements (9.00%)</font>
  7 (7.00%) high mild
  2 (2.00%) high severe
<font color="#26A269">generated-noncompressed-4k-idat/2048x2048.png</font>
                        time:   [4.1453 ms <b>4.1890 ms</b> 4.2753 ms]
                        thrpt:  [3.6547 GiB/s <b>3.7300 GiB/s</b> 3.7693 GiB/s]
                 change:
                        time:   [+1.7679% <font color="#C01C28"><b>+3.5781%</b></font> +5.4826%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-5.1976% <font color="#C01C28"><b>-3.4545%</b></font> -1.7372%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high mild
Benchmarking generated-noncompressed-4k-idat/12288x12288.png: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.7s or enable flat sampling.
<font color="#26A269">generated-noncompressed-4k-idat/12288x12288.png</font>
                        time:   [177.00 ms <b>177.14 ms</b> 177.32 ms]
                        thrpt:  [3.1723 GiB/s <b>3.1754 GiB/s</b> 3.1779 GiB/s]
                 change:
                        time:   [+3.4556% <font color="#C01C28"><b>+4.2978%</b></font> +5.3794%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-5.1048% <font color="#C01C28"><b>-4.1207%</b></font> -3.3401%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high severe

<font color="#26A269">generated-noncompressed-64k-idat/128x128.png</font>
                        time:   [16.808 µs <b>16.864 µs</b> 16.936 µs]
                        thrpt:  [3.6039 GiB/s <b>3.6194 GiB/s</b> 3.6314 GiB/s]
                 change:
                        time:   [-0.9803% -0.3309% +0.2162%] (p = 0.30 &gt; 0.05)
                        thrpt:  [-0.2157% +0.3320% +0.9900%]
                        No change in performance detected.
<font color="#A2734C">Found 1 outliers among 100 measurements (1.00%)</font>
  1 (1.00%) high mild
<font color="#26A269">generated-noncompressed-64k-idat/2048x2048.png</font>
                        time:   [3.9072 ms <b>3.9173 ms</b> 3.9269 ms]
                        thrpt:  [3.9789 GiB/s <b>3.9888 GiB/s</b> 3.9990 GiB/s]
                 change:
                        time:   [+1.7694% <font color="#C01C28"><b>+2.7513%</b></font> +3.8466%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-3.7041% <font color="#C01C28"><b>-2.6776%</b></font> -1.7386%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  1 (10.00%) low mild
  1 (10.00%) high severe
Benchmarking generated-noncompressed-64k-idat/12288x12288.png: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s or enable flat sampling.
<font color="#26A269">generated-noncompressed-64k-idat/12288x12288.png</font>
                        time:   [168.72 ms <b>168.92 ms</b> 169.18 ms]
                        thrpt:  [3.3250 GiB/s <b>3.3299 GiB/s</b> 3.3340 GiB/s]
                 change:
                        time:   [+5.8804% <font color="#C01C28"><b>+6.1499%</b></font> +6.4111%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-6.0249% <font color="#C01C28"><b>-5.7936%</b></font> -5.5538%]
                        Performance has <font color="#C01C28">regressed</font>.

<font color="#26A269">generated-noncompressed-2g-idat/2048x2048.png</font>
                        time:   [3.8926 ms <b>3.9045 ms</b> 3.9195 ms]
                        thrpt:  [3.9865 GiB/s <b>4.0018 GiB/s</b> 4.0141 GiB/s]
                 change:
                        time:   [-0.0178% +1.8378% +4.4432%] (p = 0.12 &gt; 0.05)
                        thrpt:  [-4.2542% -1.8046% +0.0178%]
                        No change in performance detected.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking generated-noncompressed-2g-idat/12288x12288.png: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s or enable flat sampling.
<font color="#26A269">generated-noncompressed-2g-idat/12288x12288.png</font>
                        time:   [166.65 ms <b>167.47 ms</b> 168.36 ms]
                        thrpt:  [3.3410 GiB/s <b>3.3588 GiB/s</b> 3.3754 GiB/s]
                 change:
                        time:   [+5.9462% <font color="#C01C28"><b>+6.7017%</b></font> +7.5802%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-7.0461% <font color="#C01C28"><b>-6.2808%</b></font> -5.6125%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  1 (10.00%) low severe
  1 (10.00%) high severe

<font color="#26A269">row-by-row/128x128-4k-idat</font>
                        time:   [16.952 µs <b>17.051 µs</b> 17.158 µs]
                        thrpt:  [3.5572 GiB/s <b>3.5796 GiB/s</b> 3.6004 GiB/s]
                 change:
                        time:   [-0.8622% +0.0505% +0.7704%] (p = 0.91 &gt; 0.05)
                        thrpt:  [-0.7645% -0.0505% +0.8697%]
                        No change in performance detected.
<font color="#A2734C">Found 14 outliers among 100 measurements (14.00%)</font>
  4 (4.00%) high mild
  10 (10.00%) high severe
</pre>
</details>