### PR TITLE
Limit zlib output to 8 KB per iteration

### DIFF
--- a/src/decoder/unfiltering_buffer.rs
+++ b/src/decoder/unfiltering_buffer.rs
@@ -26,11 +26,11 @@ pub(crate) struct UnfilteringBuffer {
     available: usize,
     /// The number of bytes before we shift the buffer back.
     shift_back_limit: usize,
-    /// The number of bytes to grow when we hit the buffer end.
-    growth_bytes: usize,
 }
 
 impl UnfilteringBuffer {
+    pub const GROWTH_BYTES: usize = 8 * 1024;
+
     /// Asserts in debug builds that all the invariants hold.  No-op in release
     /// builds.  Intended to be called after creating or mutating `self` to
     /// ensure that the final state preserves the invariants.
@@ -92,7 +92,6 @@ impl UnfilteringBuffer {
             filled: 0,
             available: 0,
             shift_back_limit,
-            growth_bytes: 8 * 1024,
         };
 
         result.debug_assert_invariants();
@@ -162,8 +161,8 @@ impl UnfilteringBuffer {
             self.prev_start = 0;
         }
 
-        if self.filled + self.growth_bytes > self.data_stream.len() {
-            self.data_stream.resize(self.filled + self.growth_bytes, 0);
+        if self.filled + Self::GROWTH_BYTES > self.data_stream.len() {
+            self.data_stream.resize(self.filled + Self::GROWTH_BYTES, 0);
         }
 
         UnfilterBuf {

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -115,12 +115,12 @@ impl ZlibStream {
 
         let (buffer, filled) = image_data.borrow_mut();
         let output_limit = (filled + 8 * 1024).min(buffer.len());
-        let (in_consumed, out_consumed) =
-            self.state
-                .read(data, &mut buffer[..output_limit], filled, false)
-                .map_err(|err| {
-                    DecodingError::Format(FormatErrorInner::CorruptFlateStream { err }.into())
-                })?;
+        let (in_consumed, out_consumed) = self
+            .state
+            .read(data, &mut buffer[..output_limit], filled, false)
+            .map_err(|err| {
+                DecodingError::Format(FormatErrorInner::CorruptFlateStream { err }.into())
+            })?;
 
         self.started = true;
         let filled = filled + out_consumed;

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -1,4 +1,4 @@
-use super::{stream::FormatErrorInner, DecodingError};
+use super::{stream::FormatErrorInner, unfiltering_buffer::UnfilteringBuffer, DecodingError};
 
 use fdeflate::Decompressor;
 
@@ -114,7 +114,7 @@ impl ZlibStream {
         }
 
         let (buffer, filled) = image_data.borrow_mut();
-        let output_limit = (filled + 8 * 1024).min(buffer.len());
+        let output_limit = (filled + UnfilteringBuffer::GROWTH_BYTES).min(buffer.len());
         let (in_consumed, out_consumed) = self
             .state
             .read(data, &mut buffer[..output_limit], filled, false)

--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -114,9 +114,10 @@ impl ZlibStream {
         }
 
         let (buffer, filled) = image_data.borrow_mut();
+        let output_limit = (filled + 8 * 1024).min(buffer.len());
         let (in_consumed, out_consumed) =
             self.state
-                .read(data, buffer, filled, false)
+                .read(data, &mut buffer[..output_limit], filled, false)
                 .map_err(|err| {
                     DecodingError::Format(FormatErrorInner::CorruptFlateStream { err }.into())
                 })?;


### PR DESCRIPTION
This is a much simpler way to get a similar/perhaps better performance improvement to #594. I don't love splitting the buffer management logic between unfiltering_buffer.rs and zlib.rs, but probably not a big issue.

The general motivation is to match the zlib output size between when we're growing the UnfilteringBuffer and once that buffer has already hit its max size. In particular, the buffer grows by 8 KB at a time until there's enough space to shift-back the last ~128 KB of image data. At that point, the zlib decoder will always get output Vecs with 128 KB of additional capacity. But we picked 8 KB because it seems to work well as an output size, so we should probably keep using it.

Decoding speeds on the qoi-bench corpus using [corpus-bench](https://github.com/fintelia/corpus-bench/tree/rc) with a 5600X:
```
v0.18.0-rc:    275.430 MP/s (average) 234.774 MP/s (geomean)
main branch:   297.530 MP/s (average) 254.397 MP/s (geomean)
pr-594:        308.406 MP/s (average) 257.760 MP/s (geomean)
this pr:       312.025 MP/s (average) 261.219 MP/s (geomean)
```

Improvements on most "normal" images and regressions on most "uncompressed" images in the crate bencharks:
<details>
<summary><tt>cargo bench --bench decoder</tt> benchmark output.</summary>
<pre><font color="#26A269">decode/kodim02.png</font>      time:   [2.5319 ms <b>2.5370 ms</b> 2.5431 ms]
                        thrpt:  [442.38 MiB/s <b>443.44 MiB/s</b> 444.33 MiB/s]
                 change:
                        time:   [-0.4311% -0.1940% +0.0666%] (p = 0.13 &gt; 0.05)
                        thrpt:  [-0.0666% +0.1943% +0.4330%]
                        No change in performance detected.
<font color="#A2734C">Found 12 outliers among 100 measurements (12.00%)</font>
  3 (3.00%) high mild
  9 (9.00%) high severe
<font color="#26A269">decode/paletted-zune.png</font>
                        time:   [6.9553 ms <b>6.9587 ms</b> 6.9628 ms]
                        thrpt:  [1.8515 GiB/s <b>1.8526 GiB/s</b> 1.8535 GiB/s]
                 change:
                        time:   [-0.7914% -0.6346% -0.4962%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+0.4986% +0.6387% +0.7977%]
                        Change within noise threshold.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high mild
<font color="#26A269">decode/Lohengrin_-_Illustrated_Sporting_and_Dramatic_News.png</font>
                        time:   [17.632 ms <b>17.651 ms</b> 17.663 ms]
                        thrpt:  [604.58 MiB/s <b>605.00 MiB/s</b> 605.64 MiB/s]
                 change:
                        time:   [+1.4574% <font color="#C01C28"><b>+1.6793%</b></font> +1.9240%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-1.8877% <font color="#C01C28"><b>-1.6515%</b></font> -1.4365%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  2 (20.00%) high mild
<font color="#26A269">decode/kodim17.png</font>      time:   [2.4460 ms <b>2.4484 ms</b> 2.4509 ms]
                        thrpt:  [459.02 MiB/s <b>459.48 MiB/s</b> 459.93 MiB/s]
                 change:
                        time:   [-1.6072% <font color="#26A269"><b>-1.3959%</b></font> -1.1991%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+1.2136% <font color="#26A269"><b>+1.4157%</b></font> +1.6335%]
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  2 (20.00%) high mild
<font color="#26A269">decode/Transparency.png</font> time:   [73.715 µs <b>73.862 µs</b> 73.995 µs]
                        thrpt:  [4.5311 GiB/s <b>4.5392 GiB/s</b> 4.5483 GiB/s]
                 change:
                        time:   [-40.273% <font color="#26A269"><b>-39.951%</b></font> -39.705%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+65.851% <font color="#26A269"><b>+66.531%</b></font> +67.427%]
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 3 outliers among 10 measurements (30.00%)</font>
  2 (20.00%) low mild
  1 (10.00%) high mild
<font color="#26A269">decode/kodim07.png</font>      time:   [3.0071 ms <b>3.0090 ms</b> 3.0129 ms]
                        thrpt:  [373.39 MiB/s <b>373.88 MiB/s</b> 374.11 MiB/s]
                 change:
                        time:   [-1.0709% -0.8350% -0.6195%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+0.6233% +0.8421% +1.0825%]
                        Change within noise threshold.
<font color="#A2734C">Found 2 outliers among 10 measurements (20.00%)</font>
  1 (10.00%) high mild
  1 (10.00%) high severe
<font color="#26A269">decode/kodim23.png</font>      time:   [2.3852 ms <b>2.3883 ms</b> 2.3940 ms]
                        thrpt:  [469.92 MiB/s <b>471.06 MiB/s</b> 471.66 MiB/s]
                 change:
                        time:   [-1.9946% -1.3609% -0.8082%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+0.8148% +1.3797% +2.0352%]
                        Change within noise threshold.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high mild

<font color="#26A269">generated-noncompressed-4k-idat/8x8.png</font>
                        time:   [1.1320 µs <b>1.1329 µs</b> 1.1348 µs]
                        thrpt:  [215.15 MiB/s <b>215.49 MiB/s</b> 215.67 MiB/s]
                 change:
                        time:   [-22.185% <font color="#26A269"><b>-20.815%</b></font> -19.988%] (p = 0.00 &lt; 0.05)
                        thrpt:  [+24.981% <font color="#26A269"><b>+26.286%</b></font> +28.510%]
                        Performance has <font color="#26A269">improved</font>.
<font color="#A2734C">Found 12 outliers among 100 measurements (12.00%)</font>
  4 (4.00%) high mild
  8 (8.00%) high severe
<font color="#26A269">generated-noncompressed-4k-idat/128x128.png</font>
                        time:   [18.466 µs <b>18.477 µs</b> 18.491 µs]
                        thrpt:  [3.3009 GiB/s <b>3.3033 GiB/s</b> 3.3052 GiB/s]
                 change:
                        time:   [+4.8186% <font color="#C01C28"><b>+5.0651%</b></font> +5.2821%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-5.0171% <font color="#C01C28"><b>-4.8209%</b></font> -4.5970%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 9 outliers among 100 measurements (9.00%)</font>
  5 (5.00%) high mild
  4 (4.00%) high severe
<font color="#26A269">generated-noncompressed-4k-idat/2048x2048.png</font>
                        time:   [4.4012 ms <b>4.4746 ms</b> 4.5327 ms]
                        thrpt:  [3.4472 GiB/s <b>3.4920 GiB/s</b> 3.5502 GiB/s]
                 change:
                        time:   [+7.2652% <font color="#C01C28"><b>+8.9197%</b></font> +10.631%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-9.6092% <font color="#C01C28"><b>-8.1892%</b></font> -6.7731%]
                        Performance has <font color="#C01C28">regressed</font>.
Benchmarking generated-noncompressed-4k-idat/12288x12288.png: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.8s or enable flat sampling.
<font color="#26A269">generated-noncompressed-4k-idat/12288x12288.png</font>
                        time:   [177.81 ms <b>178.44 ms</b> 179.44 ms]
                        thrpt:  [3.1347 GiB/s <b>3.1523 GiB/s</b> 3.1635 GiB/s]
                 change:
                        time:   [+4.0649% <font color="#C01C28"><b>+4.6901%</b></font> +5.3608%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-5.0881% <font color="#C01C28"><b>-4.4800%</b></font> -3.9061%]
                        Performance has <font color="#C01C28">regressed</font>.

<font color="#26A269">generated-noncompressed-64k-idat/128x128.png</font>
                        time:   [17.802 µs <b>17.818 µs</b> 17.837 µs]
                        thrpt:  [3.4218 GiB/s <b>3.4255 GiB/s</b> 3.4285 GiB/s]
                 change:
                        time:   [+4.0074% <font color="#C01C28"><b>+4.7008%</b></font> +5.3752%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-5.1010% <font color="#C01C28"><b>-4.4897%</b></font> -3.8530%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 12 outliers among 100 measurements (12.00%)</font>
  1 (1.00%) low mild
  2 (2.00%) high mild
  9 (9.00%) high severe
<font color="#26A269">generated-noncompressed-64k-idat/2048x2048.png</font>
                        time:   [4.1617 ms <b>4.1843 ms</b> 4.2168 ms]
                        thrpt:  [3.7054 GiB/s <b>3.7342 GiB/s</b> 3.7545 GiB/s]
                 change:
                        time:   [+8.8161% <font color="#C01C28"><b>+10.187%</b></font> +11.874%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-10.614% <font color="#C01C28"><b>-9.2456%</b></font> -8.1018%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high severe
Benchmarking generated-noncompressed-64k-idat/12288x12288.png: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.5s or enable flat sampling.
<font color="#26A269">generated-noncompressed-64k-idat/12288x12288.png</font>
                        time:   [170.37 ms <b>170.79 ms</b> 171.22 ms]
                        thrpt:  [3.2852 GiB/s <b>3.2936 GiB/s</b> 3.3016 GiB/s]
                 change:
                        time:   [+7.0631% <font color="#C01C28"><b>+7.5026%</b></font> +8.0662%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-7.4642% <font color="#C01C28"><b>-6.9790%</b></font> -6.5972%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high severe

<font color="#26A269">generated-noncompressed-2g-idat/2048x2048.png</font>
                        time:   [4.1402 ms <b>4.1797 ms</b> 4.2289 ms]
                        thrpt:  [3.6948 GiB/s <b>3.7383 GiB/s</b> 3.7740 GiB/s]
                 change:
                        time:   [+6.0416% <font color="#C01C28"><b>+8.0939%</b></font> +10.454%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-9.4647% <font color="#C01C28"><b>-7.4878%</b></font> -5.6974%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high severe
Benchmarking generated-noncompressed-2g-idat/12288x12288.png: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s or enable flat sampling.
<font color="#26A269">generated-noncompressed-2g-idat/12288x12288.png</font>
                        time:   [168.25 ms <b>168.62 ms</b> 168.93 ms]
                        thrpt:  [3.3297 GiB/s <b>3.3360 GiB/s</b> 3.3432 GiB/s]
                 change:
                        time:   [+6.3200% <font color="#C01C28"><b>+6.7428%</b></font> +7.1533%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-6.6757% <font color="#C01C28"><b>-6.3169%</b></font> -5.9443%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 1 outliers among 10 measurements (10.00%)</font>
  1 (10.00%) high mild

<font color="#26A269">row-by-row/128x128-4k-idat</font>
                        time:   [17.942 µs <b>17.977 µs</b> 18.021 µs]
                        thrpt:  [3.3868 GiB/s <b>3.3952 GiB/s</b> 3.4018 GiB/s]
                 change:
                        time:   [+5.0681% <font color="#C01C28"><b>+5.9350%</b></font> +6.6242%] (p = 0.00 &lt; 0.05)
                        thrpt:  [-6.2127% <font color="#C01C28"><b>-5.6025%</b></font> -4.8236%]
                        Performance has <font color="#C01C28">regressed</font>.
<font color="#A2734C">Found 11 outliers among 100 measurements (11.00%)</font>
  3 (3.00%) high mild
  8 (8.00%) high severe
</pre>
</details>