### PR TITLE
Patch notes for 0.18.0-rc.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 * Improved the compression settings API for encoding.
 * `Decoder` now requires a reader that implements `Seek` and `BufRead` traits.
 * Bump bitflags dependency to 2.0.
+* `StreamingDecoder::update` now takes a structured `UnfilterBuf` argument
+  instead of a direct reference to a vector. This allows in-place
+  decompression. There is a public constructor for `UnfilterBuf`.
 
 ### Other additions
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.18.0-rc"
+version = "0.18.0-rc.2"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"


### PR DESCRIPTION
Given performance improvements and the changes to `StreamingDecoder` I would suppose we publish a new release. This can be `0.18` if we're confident or another rc. Both seem acceptable to me at this stage with the regression testing in the Chromium limited trial noting 'no functional bugs so far'.