### PR TITLE
Check output size overflow when reading frames

### DIFF
--- a/benches/decoder.rs
+++ b/benches/decoder.rs
@@ -66,7 +66,7 @@ fn bench_file(g: &mut BenchmarkGroup<WallTime>, data: Vec<u8>, name: String) {
     }
 
     let mut reader = create_reader(data.as_slice());
-    let mut image = vec![0; reader.output_buffer_size()];
+    let mut image = vec![0; reader.output_buffer_size().unwrap()];
     let info = reader.next_frame(&mut image).unwrap();
 
     g.throughput(Throughput::Bytes(info.buffer_size() as u64));
@@ -81,8 +81,8 @@ fn bench_file(g: &mut BenchmarkGroup<WallTime>, data: Vec<u8>, name: String) {
 /// This benchmarks decoding via a sequence of `Reader::read_row` calls.
 fn bench_read_row(g: &mut BenchmarkGroup<WallTime>, data: Vec<u8>, name: &str) {
     let reader = create_reader(data.as_slice());
-    let mut image = vec![0; reader.output_buffer_size()];
-    let bytes_per_row = reader.output_line_size(reader.info().width);
+    let mut image = vec![0; reader.output_buffer_size().unwrap()];
+    let bytes_per_row = reader.output_line_size(reader.info().width).unwrap();
     g.throughput(Throughput::Bytes(image.len() as u64));
     g.bench_with_input(name, &data, |b, data| {
         b.iter(|| {

--- a/examples/corpus-bench.rs
+++ b/examples/corpus-bench.rs
@@ -119,7 +119,7 @@ fn main() {
                 Ok(reader) => reader,
                 Err(_) => continue,
             };
-            let mut image = vec![0; reader.output_buffer_size()];
+            let mut image = vec![0; reader.output_buffer_size().unwrap()];
             let info = match reader.next_frame(&mut image) {
                 Ok(info) => info,
                 Err(_) => continue,

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -2342,7 +2342,7 @@ mod tests {
 
         let decoder = Decoder::new(Cursor::new(&png));
         let mut reader = decoder.read_info().unwrap();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
         reader.next_frame(&mut buf).unwrap();
 
         // 0-length fdAT should result in an error.
@@ -2370,7 +2370,7 @@ mod tests {
 
         let decoder = Decoder::new(Cursor::new(&png));
         let mut reader = decoder.read_info().unwrap();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
         reader.next_frame(&mut buf).unwrap();
 
         // 3-bytes-long fdAT should result in an error.
@@ -2408,7 +2408,7 @@ mod tests {
         // Start decoding.
         let decoder = Decoder::new(Cursor::new(&png));
         let mut reader = decoder.read_info().unwrap();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
         let Some(animation_control) = reader.info().animation_control else {
             panic!("No acTL");
         };
@@ -2471,7 +2471,7 @@ mod tests {
         };
         let decoder = Decoder::new(Cursor::new(&png));
         let mut reader = decoder.read_info().unwrap();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 
         // TODO: Should this return an error instead?  For now let's just have test assertions for
         // the current behavior.
@@ -2609,13 +2609,13 @@ mod tests {
 
         let (whole_output_info, decoded_from_whole_input) =
             streaming_input.decode_full_input(|mut r| {
-                let mut buf = vec![0; r.output_buffer_size()];
+                let mut buf = vec![0; r.output_buffer_size().unwrap()];
                 let output_info = r.next_frame(&mut buf).unwrap();
                 (output_info, buf)
             });
 
         let mut png_reader = streaming_input.stream_input_until_reader_is_available();
-        let mut decoded_from_streaming_input = vec![0; png_reader.output_buffer_size()];
+        let mut decoded_from_streaming_input = vec![0; png_reader.output_buffer_size().unwrap()];
         let streaming_output_info = loop {
             match png_reader.next_frame(decoded_from_streaming_input.as_mut_slice()) {
                 Ok(output_info) => break output_info,
@@ -2640,7 +2640,7 @@ mod tests {
         let streaming_input = StreamingInput::with_noncompressed_png(WIDTH, IDAT_SIZE);
 
         let decoded_from_whole_input = streaming_input.decode_full_input(|mut r| {
-            let mut buf = vec![0; r.output_buffer_size()];
+            let mut buf = vec![0; r.output_buffer_size().unwrap()];
             r.next_frame(&mut buf).unwrap();
             buf
         });
@@ -2799,7 +2799,7 @@ mod tests {
     #[test]
     fn test_next_frame_polling_after_end_non_animated() {
         let mut reader = create_reader_of_ihdr_idat();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
         reader
             .next_frame(&mut buf)
             .expect("Expecting no error for IDAT frame");
@@ -2836,7 +2836,7 @@ mod tests {
     #[test]
     fn test_next_frame_polling_after_end_idat_part_of_animation() {
         let mut reader = create_reader_of_ihdr_actl_fctl_idat_fctl_fdat();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 
         assert_eq!(get_fctl_sequence_number(&reader), 0);
         reader
@@ -2867,7 +2867,7 @@ mod tests {
     #[test]
     fn test_next_frame_polling_after_end_idat_not_part_of_animation() {
         let mut reader = create_reader_of_ihdr_actl_idat_fctl_fdat_fctl_fdat();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 
         assert!(reader.info().frame_control.is_none());
         reader
@@ -2902,7 +2902,7 @@ mod tests {
     #[test]
     fn test_row_by_row_then_next_frame() {
         let mut reader = create_reader_of_ihdr_actl_fctl_idat_fctl_fdat();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 
         assert_eq!(get_fctl_sequence_number(&reader), 0);
         while let Some(_) = reader.next_row().unwrap() {}
@@ -2960,7 +2960,7 @@ mod tests {
     #[test]
     fn test_next_frame_info_after_next_frame() {
         let mut reader = create_reader_of_ihdr_actl_fctl_idat_fctl_fdat();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 
         assert_eq!(get_fctl_sequence_number(&reader), 0);
         reader
@@ -2994,7 +2994,7 @@ mod tests {
     #[test]
     fn test_next_frame_info_to_skip_first_frame() {
         let mut reader = create_reader_of_ihdr_actl_idat_fctl_fdat_fctl_fdat();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 
         // First (IDAT) frame doesn't have frame control info, which means
         // that it is not part of the animation.
@@ -3043,7 +3043,7 @@ mod tests {
         };
         let decoder = Decoder::new(Cursor::new(&png));
         let mut reader = decoder.read_info().unwrap();
-        let mut buf = vec![0; reader.output_buffer_size()];
+        let mut buf = vec![0; reader.output_buffer_size().unwrap()];
         assert!(reader.info().trns.is_none());
         reader.next_frame(&mut buf).unwrap();
         assert_eq!(3093270825, crc32fast::hash(&buf));

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1760,7 +1760,7 @@ mod tests {
                 // Decode image
                 let decoder = Decoder::new(BufReader::new(File::open(path).unwrap()));
                 let mut reader = decoder.read_info().unwrap();
-                let mut buf = vec![0; reader.output_buffer_size()];
+                let mut buf = vec![0; reader.output_buffer_size().unwrap()];
                 let info = reader.next_frame(&mut buf).unwrap();
                 use DeflateCompression::*;
                 for compression in [NoCompression, FdeflateUltraFast, Level(4)] {
@@ -1785,7 +1785,7 @@ mod tests {
                     // Decode encoded decoded image
                     let decoder = Decoder::new(Cursor::new(&*out));
                     let mut reader = decoder.read_info().unwrap();
-                    let mut buf2 = vec![0; reader.output_buffer_size()];
+                    let mut buf2 = vec![0; reader.output_buffer_size().unwrap()];
                     reader.next_frame(&mut buf2).unwrap();
                     // check if the encoded image is ok:
                     assert_eq!(buf, buf2);
@@ -1818,7 +1818,7 @@ mod tests {
                 // Decode image
                 let decoder = Decoder::new(BufReader::new(File::open(path).unwrap()));
                 let mut reader = decoder.read_info().unwrap();
-                let mut buf = vec![0; reader.output_buffer_size()];
+                let mut buf = vec![0; reader.output_buffer_size().unwrap()];
                 let info = reader.next_frame(&mut buf).unwrap();
                 use DeflateCompression::*;
                 for compression in [NoCompression, FdeflateUltraFast, Level(4)] {
@@ -1850,7 +1850,7 @@ mod tests {
                     // Decode encoded decoded image
                     let decoder = Decoder::new(Cursor::new(&*out));
                     let mut reader = decoder.read_info().unwrap();
-                    let mut buf2 = vec![0; reader.output_buffer_size()];
+                    let mut buf2 = vec![0; reader.output_buffer_size().unwrap()];
                     reader.next_frame(&mut buf2).unwrap();
                     // check if the encoded image is ok:
                     assert_eq!(buf, buf2);
@@ -1867,7 +1867,7 @@ mod tests {
             let decoder = Decoder::new(BufReader::new(File::open(&path).unwrap()));
             let mut reader = decoder.read_info().unwrap();
 
-            let mut decoded_pixels = vec![0; reader.output_buffer_size()];
+            let mut decoded_pixels = vec![0; reader.output_buffer_size().unwrap()];
             let info = reader.info();
             assert_eq!(
                 info.width as usize * info.height as usize * usize::from(bit_depth),
@@ -1891,7 +1891,7 @@ mod tests {
             // Decode re-encoded image
             let decoder = Decoder::new(Cursor::new(&*out));
             let mut reader = decoder.read_info().unwrap();
-            let mut redecoded = vec![0; reader.output_buffer_size()];
+            let mut redecoded = vec![0; reader.output_buffer_size().unwrap()];
             reader.next_frame(&mut redecoded).unwrap();
             // check if the encoded image is ok:
             assert_eq!(indexed_data, redecoded);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! let decoder = png::Decoder::new(BufReader::new(File::open("tests/pngsuite/basi0g01.png").unwrap()));
 //! let mut reader = decoder.read_info().unwrap();
 //! // Allocate the output buffer.
-//! let mut buf = vec![0; reader.output_buffer_size()];
+//! let mut buf = vec![0; reader.output_buffer_size().unwrap()];
 //! // Read the next frame. An APNG might contain multiple frames.
 //! let info = reader.next_frame(&mut buf).unwrap();
 //! // Grab the bytes of the image.

--- a/tests/check_testimages.rs
+++ b/tests/check_testimages.rs
@@ -97,7 +97,7 @@ fn render_images() {
         let mut decoder = png::Decoder::new(BufReader::new(File::open(path)?));
         decoder.set_transformations(png::Transformations::normalize_to_color8());
         let mut reader = decoder.read_info()?;
-        let mut img_data = vec![0; reader.output_buffer_size()];
+        let mut img_data = vec![0; reader.output_buffer_size().unwrap()];
         let info = reader.next_frame(&mut img_data)?;
         // First sanity check:
         assert_eq!(
@@ -119,7 +119,7 @@ fn render_images_identity() {
     process_images("results_identity.txt", &TEST_SUITES, |path| {
         let decoder = png::Decoder::new(BufReader::new(File::open(&path)?));
         let mut reader = decoder.read_info()?;
-        let mut img_data = vec![0; reader.output_buffer_size()];
+        let mut img_data = vec![0; reader.output_buffer_size().unwrap()];
         let info = reader.next_frame(&mut img_data)?;
         let bits =
             ((info.width as usize * info.color_type.samples() * info.bit_depth as usize + 7) & !7)
@@ -145,7 +145,7 @@ fn render_images_alpha() {
         let mut decoder = png::Decoder::new(BufReader::new(File::open(&path)?));
         decoder.set_transformations(png::Transformations::ALPHA);
         let mut reader = decoder.read_info()?;
-        let mut img_data = vec![0; reader.output_buffer_size()];
+        let mut img_data = vec![0; reader.output_buffer_size().unwrap()];
         let info = reader.next_frame(&mut img_data)?;
         let bits =
             ((info.width as usize * info.color_type.samples() * info.bit_depth as usize + 7) & !7)
@@ -186,7 +186,7 @@ fn apng_images() {
         let mut decoder = png::Decoder::new(BufReader::new(File::open(&path)?));
         decoder.set_transformations(png::Transformations::normalize_to_color8());
         let mut reader = decoder.read_info()?;
-        let mut img_data = vec![0; reader.output_buffer_size()];
+        let mut img_data = vec![0; reader.output_buffer_size().unwrap()];
         let real_frames = reader.info().animation_control().unwrap().num_frames;
         // Print out frame info, helps with blessing the result file for new images.
         println!(


### PR DESCRIPTION
Closes: #603 

I'm not entirely certain this fix is complete but it is a good shot. Crucially, we only check the condition at the start of reading a frame. This ensure the viral effect is minimal, assuming we only require the buffer size to be address space representable when *actually* writing into the output buffer. For instance, `StreamReader` is unaffected. This is by design as any reader path not interacting with image data can proceed working regardless. (Since the `UnfilterBuf` argument is optional this is a blessed use case by our API design).