### PR TITLE
Release notes and metadata for v0.18.0-rc.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,10 @@
 * The decoding of Adam7 interlaced data is now much faster.
 * The `acTL` chunk is now ignored when it is invalid, instead of producing
   errors while reading or decoding the following APNG chunks.
+* The requirement of the `fcTL` chunk for the default image to match the IHDR's
+  indicate image size is now enforced.
+* More minor format errors in auxiliary chunks are now ignored by the decoder,
+  instead disregarding the malformed chunk.
 * Adam7 Interlacing on 32-bit targets now handles some cases correctly that
   previously wrote some bytes to the wrong pixel indices due to overflows.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,12 +9,29 @@
 * `StreamingDecoder::update` now takes a structured `UnfilterBuf` argument
   instead of a direct reference to a vector. This allows in-place
   decompression. There is a public constructor for `UnfilterBuf`.
+* The methods `Decoder::output_buffer_size` and `output_line_size` now return
+  `Option<usize>` to reflect that these calculations no longer overflow on some
+  targets where the required buffers can not be represented in the address
+  space. They return the mathematically correct size where possible.
 
-### Other additions
+### Additions
 
 * Added `Reader::read_row` method.
 * Add support for parsing eXIf chunk.
 * Treat most auxiliary chunk errors as benign.
+* Added `splat_interlaced_row`, which implements an alternative method for
+  merging Adam7 interlaced lines into the output buffer that is more suitable
+  for the presentation of progressive states of the buffer.
+* Added `Adam7Variant` documenting the various methods for applying interlaced
+  rows and to prepare an API to progressively read frames through `Decoder`.
+
+### Changes
+
+* The decoding of Adam7 interlaced data is now much faster.
+* The `acTL` chunk is now ignored when it is invalid, instead of producing
+  errors while reading or decoding the following APNG chunks.
+* Adam7 Interlacing on 32-bit targets now handles some cases correctly that
+  previously wrote some bytes to the wrong pixel indices due to overflows.
 
 ## 0.17.16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "png"
-version = "0.18.0-rc.2"
+version = "0.18.0-rc.3"
 license = "MIT OR Apache-2.0"
 
 description = "PNG decoding and encoding library in pure Rust"


### PR DESCRIPTION
Given that all reported Chromium issues have been addressed, I would cut a release. We can also do version `v0.18` proper if your encoder API concerns do not feel critical.