### PR TITLE
Ignore errors in all auxiliary chunks other than fcTL and fdAT

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1039,17 +1039,7 @@ impl StreamingDecoder {
         //
         // TODO: Consider supporting a strict mode where even benign errors are reported up.
         // See https://github.com/image-rs/image-png/pull/569#issuecomment-2642062285
-        if matches!(parse_result.as_ref(), Err(DecodingError::Format(_)))
-            && matches!(
-                type_str,
-                chunk::cHRM
-                    | chunk::gAMA
-                    | chunk::iCCP
-                    | chunk::pHYs
-                    | chunk::sBIT
-                    | chunk::sRGB
-                    | chunk::tRNS
-            )
+        if matches!(parse_result.as_ref(), Err(DecodingError::Format(_))) && type_str != chunk::fcTL
         {
             parse_result = Ok(Decoded::Nothing);
         }


### PR DESCRIPTION
PTAL?

I don't know how I managed to miss the text chunks in https://github.com/image-rs/image-png/pull/569... I think it will be most robust to reverse the logic in the `if` statement and ignore errors in all chunks except for `fcTL` chunks.  FWIW I've skimmed through all the `parse_foo` functions and they seem to avoid mutating the decoder state until they are almost ready to return `Ok`.

Context: https://crbug.com/428642967