### PR TITLE
Add validation of the gAMA chunk and don't set if it is 0.

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1354,6 +1354,12 @@ impl StreamingDecoder {
             let source_gamma: u32 = buf.read_be()?;
             let source_gamma = ScaledFloat::from_scaled(source_gamma);
 
+            // The spec says that "A gAMA chunk containing zero is meaningless".
+            // So let's ignore such `gAMA` chunks.
+            if source_gamma == 0 {
+                return Ok(Decoded::Nothing);
+            }
+
             info.gama_chunk = Some(source_gamma);
             Ok(Decoded::Nothing)
         }


### PR DESCRIPTION
PNG v3 Spec 13.13 states "A gAMA chunk containing zero is meaningless but could appear by mistake. Decoders should ignore it, and editors may discard it and issue a warning to the user." Add this validation similar to how it is done in the `parse_actl` function.