### PR TITLE
Add validation of the gAMA chunk

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1352,8 +1352,13 @@ impl StreamingDecoder {
         } else {
             let mut buf = &self.current_chunk.raw_bytes[..];
             let source_gamma: u32 = buf.read_be()?;
-            let source_gamma = ScaledFloat::from_scaled(source_gamma);
+            // The spec says that "A gAMA chunk containing zero is meaningless".
+            // So let's ignore such `gAMA` chunks.
+            if source_gamma == 0 {
+                return Ok(Decoded::Nothing);
+            }
 
+            let source_gamma = ScaledFloat::from_scaled(source_gamma);
             info.gama_chunk = Some(source_gamma);
             Ok(Decoded::Nothing)
         }


### PR DESCRIPTION
PNG v3 spec 13.13 states "A gAMA chunk containing zero is meaningless but could appear by mistake. Decoders should ignore it, and editors may discard it and issue a warning to the user." Add this validation similar to how it is done in the `parse_actl` function.