### PR TITLE
perf: portable_simd 4bpp filtering

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -895,7 +895,7 @@ pub(crate) fn unfilter(
                     BytesPerPixel::Three => {
                         #[cfg(all(feature = "unstable", not(target_vendor = "apple")))]
                         {
-                            // Results in PR: https://github.com/image-rs/image-png/pull/63
+                            // Results in PR: https://github.com/image-rs/image-png/pull/632
                             // Approximately 30% better on Arm Cortex A520, 7%
                             // regression on Arm Cortex X4. Switched off on Apple
                             // Silicon due to 10-12% regression.
@@ -1052,7 +1052,7 @@ pub(crate) fn unfilter(
                     BytesPerPixel::Three => {
                         #[cfg(feature = "unstable")]
                         {
-                            // Results in PR: https://github.com/image-rs/image-png/pull/63
+                            // Results in PR: https://github.com/image-rs/image-png/pull/632
                             // 23% better on an Epyc 7B13, 10% on a Zen 3 part.
                             // ~30% when targeting x86-64-v2.
                             simd::paeth_unfilter_3bpp(current, previous);


### PR DESCRIPTION
Results on an AMD EPYC 7B13 system with `-C target-cpu=native` are basically unchanged, though micro-architectural simulation indicates a 40% reduction in cycles on a 768 pixel row. This could indicate the system is bottlenecked somewhere else (e.g. memory). 

```
$ RUSTFLAGS="-C target-cpu=native" taskset -c 64-68 cargo +nightly bench --features=benchmarks -- unfilter/filter=Paeth/bpp=4
    unfilter/filter=Paeth/bpp=4
                        time:   [11.241 µs 11.246 µs 11.252 µs]
                        thrpt:  [1.3561 GiB/s 1.3568 GiB/s 1.3574 GiB/s]
                 change:
                        time:   [-0.3785% -0.2463% -0.1349%] (p = 0.00 < 0.05)
                        thrpt:  [+0.1351% +0.2469% +0.3800%]

$ RUSTFLAGS="-C target-cpu=native" taskset -c 64-68 cargo +nightly bench --features=benchmarks,unstable -- unfilter/filter=Paeth/bpp=4
    unfilter/filter=Paeth/bpp=4
                        time:   [11.243 µs 11.253 µs 11.263 µs]
                        thrpt:  [1.3548 GiB/s 1.3560 GiB/s 1.3572 GiB/s]
                 change:
                        time:   [-0.0754% +0.0009% +0.0761%] (p = 0.98 > 0.05)
                        thrpt:  [-0.0760% -0.0009% +0.0754%]
                        No change in performance detected.
```

The micro-arch simulation also indicates a 21.56% improvement on Cortex A520, an 8.5% improvement on the Cortex X4, and a 56.61% improvement on x64 Arrow Lake.

Marking as draft until PR #632 is completed.
