### PR TITLE
perf: Improve Paeth unfilter auto-vectorization by changing how loop state is maintained

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -93,31 +93,6 @@ impl RowFilter {
     }
 }
 
-// This code path is used on non-x86_64 architectures but we allow dead code
-// for the test module to be able to access it.
-#[allow(dead_code)]
-fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
-    // On ARM this algorithm performs much better than the one above adapted from stb,
-    // and this is the better-studied algorithm we've always used here,
-    // so we default to it on all non-x86 platforms.
-    let pa = (i16::from(b) - i16::from(c)).abs();
-    let pb = (i16::from(a) - i16::from(c)).abs();
-    let pc = ((i16::from(a) - i16::from(c)) + (i16::from(b) - i16::from(c))).abs();
-
-    let mut out = a;
-    let mut min = pa;
-
-    if pb < min {
-        min = pb;
-        out = b;
-    }
-    if pc < min {
-        out = c;
-    }
-
-    out
-}
-
 fn filter_paeth_stbi(a: i16, b: i16, c: i16) -> u8 {
     // Decoding optimizes better with this algorithm than with `filter_paeth`
     //
@@ -535,304 +510,174 @@ pub(crate) fn unfilter(
                 }
             }
         },
-        #[allow(unreachable_code)]
         Paeth => {
-            #[cfg(not(target_arch = "x86_64"))]
-            {
-                // Paeth filter pixels:
-                // C B D
-                // A X
-                match tbpp {
-                    BytesPerPixel::One => {
-                        let mut a_bpp = [0; 1];
-                        let mut c_bpp = [0; 1];
-                        for (chunk, b_bpp) in
-                            current.chunks_exact_mut(1).zip(previous.chunks_exact(1))
-                        {
-                            let new_chunk = [
-                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0]))
-                            ];
-                            *TryInto::<&mut [u8; 1]>::try_into(chunk).unwrap() = new_chunk;
-                            a_bpp = new_chunk;
-                            c_bpp = b_bpp.try_into().unwrap();
+            // These functions are designed to avoid casting between
+            // u8xN and i16xN SIMD representations when possible by maintaining
+            // [i16; BPP] arrays between iterations instead of [u8; BPP].
+
+            // Paeth filter pixels:
+            // C B D
+            // A X
+            match tbpp {
+                BytesPerPixel::One => {
+                    const BPP: usize = 1;
+                    let mut a_bpp = [0; BPP];
+                    let mut c_bpp = [0; BPP];
+
+                    for (c, p) in current
+                        .chunks_exact_mut(BPP)
+                        .zip(previous.chunks_exact(BPP))
+                    {
+                        for i in 0..BPP {
+                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                a_bpp[i],
+                                p[i] as i16,
+                                c_bpp[i],
+                            ));
                         }
-                    }
-                    BytesPerPixel::Two => {
-                        let mut a_bpp = [0; 2];
-                        let mut c_bpp = [0; 2];
-                        for (chunk, b_bpp) in
-                            current.chunks_exact_mut(2).zip(previous.chunks_exact(2))
-                        {
-                            let new_chunk = [
-                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
-                                chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
-                            ];
-                            *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
-                            a_bpp = new_chunk;
-                            c_bpp = b_bpp.try_into().unwrap();
-                        }
-                    }
-                    BytesPerPixel::Three => {
-                        let mut a_bpp = [0; 3];
-                        let mut c_bpp = [0; 3];
 
-                        let mut previous = &previous[..previous.len() / 3 * 3];
-                        let current_len = current.len();
-                        let mut current = &mut current[..current_len / 3 * 3];
-
-                        while let ([c0, c1, c2, c_rest @ ..], [p0, p1, p2, p_rest @ ..]) =
-                            (current, previous)
-                        {
-                            current = c_rest;
-                            previous = p_rest;
-
-                            *c0 = c0.wrapping_add(filter_paeth(a_bpp[0], *p0, c_bpp[0]));
-                            *c1 = c1.wrapping_add(filter_paeth(a_bpp[1], *p1, c_bpp[1]));
-                            *c2 = c2.wrapping_add(filter_paeth(a_bpp[2], *p2, c_bpp[2]));
-
-                            a_bpp = [*c0, *c1, *c2];
-                            c_bpp = [*p0, *p1, *p2];
-                        }
-                    }
-                    BytesPerPixel::Four => {
-                        // Using the `simd` module here has no effect on Linux
-                        // and appears to regress performance on Windows, so we don't use it here.
-                        // See https://github.com/image-rs/image-png/issues/567
-
-                        let mut a_bpp = [0; 4];
-                        let mut c_bpp = [0; 4];
-
-                        let mut previous = &previous[..previous.len() & !3];
-                        let current_len = current.len();
-                        let mut current = &mut current[..current_len & !3];
-
-                        while let ([c0, c1, c2, c3, c_rest @ ..], [p0, p1, p2, p3, p_rest @ ..]) =
-                            (current, previous)
-                        {
-                            current = c_rest;
-                            previous = p_rest;
-
-                            *c0 = c0.wrapping_add(filter_paeth(a_bpp[0], *p0, c_bpp[0]));
-                            *c1 = c1.wrapping_add(filter_paeth(a_bpp[1], *p1, c_bpp[1]));
-                            *c2 = c2.wrapping_add(filter_paeth(a_bpp[2], *p2, c_bpp[2]));
-                            *c3 = c3.wrapping_add(filter_paeth(a_bpp[3], *p3, c_bpp[3]));
-
-                            a_bpp = [*c0, *c1, *c2, *c3];
-                            c_bpp = [*p0, *p1, *p2, *p3];
-                        }
-                    }
-                    BytesPerPixel::Six => {
-                        let mut a_bpp = [0; 6];
-                        let mut c_bpp = [0; 6];
-                        for (chunk, b_bpp) in
-                            current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
-                        {
-                            let new_chunk = [
-                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
-                                chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
-                                chunk[2].wrapping_add(filter_paeth(a_bpp[2], b_bpp[2], c_bpp[2])),
-                                chunk[3].wrapping_add(filter_paeth(a_bpp[3], b_bpp[3], c_bpp[3])),
-                                chunk[4].wrapping_add(filter_paeth(a_bpp[4], b_bpp[4], c_bpp[4])),
-                                chunk[5].wrapping_add(filter_paeth(a_bpp[5], b_bpp[5], c_bpp[5])),
-                            ];
-                            *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
-                            a_bpp = new_chunk;
-                            c_bpp = b_bpp.try_into().unwrap();
-                        }
-                    }
-                    BytesPerPixel::Eight => {
-                        let mut a_bpp = [0; 8];
-                        let mut c_bpp = [0; 8];
-                        for (chunk, b_bpp) in
-                            current.chunks_exact_mut(8).zip(previous.chunks_exact(8))
-                        {
-                            let new_chunk = [
-                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
-                                chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
-                                chunk[2].wrapping_add(filter_paeth(a_bpp[2], b_bpp[2], c_bpp[2])),
-                                chunk[3].wrapping_add(filter_paeth(a_bpp[3], b_bpp[3], c_bpp[3])),
-                                chunk[4].wrapping_add(filter_paeth(a_bpp[4], b_bpp[4], c_bpp[4])),
-                                chunk[5].wrapping_add(filter_paeth(a_bpp[5], b_bpp[5], c_bpp[5])),
-                                chunk[6].wrapping_add(filter_paeth(a_bpp[6], b_bpp[6], c_bpp[6])),
-                                chunk[7].wrapping_add(filter_paeth(a_bpp[7], b_bpp[7], c_bpp[7])),
-                            ];
-                            *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
-                            a_bpp = new_chunk;
-                            c_bpp = b_bpp.try_into().unwrap();
-                        }
+                        a_bpp = [c[0] as i16];
+                        c_bpp = [p[0] as i16];
                     }
                 }
-            }
+                BytesPerPixel::Two => {
+                    const BPP: usize = 2;
+                    let mut a_bpp = [0; BPP];
+                    let mut c_bpp = [0; BPP];
 
-            // The x86_64 functions avoid casting between u8xN and i16xN SIMD
-            // representations when possible by maintaining [i16; BPP] arrays
-            // between iterations instead of [u8; BPP].
-            #[cfg(target_arch = "x86_64")]
-            {
-                // Paeth filter pixels:
-                // C B D
-                // A X
-                match tbpp {
-                    BytesPerPixel::One => {
-                        const BPP: usize = 1;
-                        let mut a_bpp = [0; BPP];
-                        let mut c_bpp = [0; BPP];
-
-                        for (c, p) in current
-                            .chunks_exact_mut(BPP)
-                            .zip(previous.chunks_exact(BPP))
-                        {
-                            for i in 0..BPP {
-                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                    a_bpp[i],
-                                    p[i] as i16,
-                                    c_bpp[i],
-                                ));
-                            }
-
-                            a_bpp = [c[0] as i16];
-                            c_bpp = [p[0] as i16];
+                    for (c, p) in current
+                        .chunks_exact_mut(BPP)
+                        .zip(previous.chunks_exact(BPP))
+                    {
+                        for i in 0..BPP {
+                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                a_bpp[i],
+                                p[i] as i16,
+                                c_bpp[i],
+                            ));
                         }
+
+                        a_bpp = [c[0] as i16, c[1] as i16];
+                        c_bpp = [p[0] as i16, p[1] as i16];
                     }
-                    BytesPerPixel::Two => {
-                        const BPP: usize = 2;
-                        let mut a_bpp = [0; BPP];
-                        let mut c_bpp = [0; BPP];
+                }
+                BytesPerPixel::Three => {
+                    const BPP: usize = 3;
+                    let mut a_bpp = [0; BPP];
+                    let mut c_bpp = [0; BPP];
 
-                        for (c, p) in current
-                            .chunks_exact_mut(BPP)
-                            .zip(previous.chunks_exact(BPP))
-                        {
-                            for i in 0..BPP {
-                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                    a_bpp[i],
-                                    p[i] as i16,
-                                    c_bpp[i],
-                                ));
-                            }
-
-                            a_bpp = [c[0] as i16, c[1] as i16];
-                            c_bpp = [p[0] as i16, p[1] as i16];
+                    for (c, p) in current
+                        .chunks_exact_mut(BPP)
+                        .zip(previous.chunks_exact(BPP))
+                    {
+                        for i in 0..BPP {
+                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                a_bpp[i],
+                                p[i] as i16,
+                                c_bpp[i],
+                            ));
                         }
+
+                        a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16];
+                        c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16];
                     }
-                    BytesPerPixel::Three => {
-                        const BPP: usize = 3;
-                        let mut a_bpp = [0; BPP];
-                        let mut c_bpp = [0; BPP];
+                }
+                BytesPerPixel::Four => {
+                    // Using the `simd` module here has no effect on Linux
+                    // and appears to regress performance on Windows, so we don't use it here.
+                    // See https://github.com/image-rs/image-png/issues/567
+                    const BPP: usize = 4;
+                    let mut a_bpp = [0; BPP];
+                    let mut c_bpp = [0; BPP];
 
-                        for (c, p) in current
-                            .chunks_exact_mut(BPP)
-                            .zip(previous.chunks_exact(BPP))
-                        {
-                            for i in 0..BPP {
-                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                    a_bpp[i],
-                                    p[i] as i16,
-                                    c_bpp[i],
-                                ));
-                            }
-
-                            a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16];
-                            c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16];
+                    for (c, p) in current
+                        .chunks_exact_mut(BPP)
+                        .zip(previous.chunks_exact(BPP))
+                    {
+                        for i in 0..BPP {
+                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                a_bpp[i],
+                                p[i] as i16,
+                                c_bpp[i],
+                            ));
                         }
+
+                        a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16, c[3] as i16];
+                        c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16, p[3] as i16];
                     }
-                    BytesPerPixel::Four => {
-                        // Using the `simd` module here has no effect on Linux
-                        // and appears to regress performance on Windows, so we don't use it here.
-                        // See https://github.com/image-rs/image-png/issues/567
-                        const BPP: usize = 4;
-                        let mut a_bpp = [0; BPP];
-                        let mut c_bpp = [0; BPP];
+                }
+                BytesPerPixel::Six => {
+                    const BPP: usize = 6;
+                    let mut a_bpp = [0; BPP];
+                    let mut c_bpp = [0; BPP];
 
-                        for (c, p) in current
-                            .chunks_exact_mut(BPP)
-                            .zip(previous.chunks_exact(BPP))
-                        {
-                            for i in 0..BPP {
-                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                    a_bpp[i],
-                                    p[i] as i16,
-                                    c_bpp[i],
-                                ));
-                            }
-
-                            a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16, c[3] as i16];
-                            c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16, p[3] as i16];
+                    for (c, p) in current
+                        .chunks_exact_mut(BPP)
+                        .zip(previous.chunks_exact(BPP))
+                    {
+                        for i in 0..BPP {
+                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                a_bpp[i],
+                                p[i] as i16,
+                                c_bpp[i],
+                            ));
                         }
+
+                        a_bpp = [
+                            c[0] as i16,
+                            c[1] as i16,
+                            c[2] as i16,
+                            c[3] as i16,
+                            c[4] as i16,
+                            c[5] as i16,
+                        ];
+                        c_bpp = [
+                            p[0] as i16,
+                            p[1] as i16,
+                            p[2] as i16,
+                            p[3] as i16,
+                            p[4] as i16,
+                            p[5] as i16,
+                        ];
                     }
-                    BytesPerPixel::Six => {
-                        const BPP: usize = 6;
-                        let mut a_bpp = [0; BPP];
-                        let mut c_bpp = [0; BPP];
+                }
+                BytesPerPixel::Eight => {
+                    const BPP: usize = 8;
+                    let mut a_bpp = [0; BPP];
+                    let mut c_bpp = [0; BPP];
 
-                        for (c, p) in current
-                            .chunks_exact_mut(BPP)
-                            .zip(previous.chunks_exact(BPP))
-                        {
-                            for i in 0..BPP {
-                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                    a_bpp[i],
-                                    p[i] as i16,
-                                    c_bpp[i],
-                                ));
-                            }
-
-                            a_bpp = [
-                                c[0] as i16,
-                                c[1] as i16,
-                                c[2] as i16,
-                                c[3] as i16,
-                                c[4] as i16,
-                                c[5] as i16,
-                            ];
-                            c_bpp = [
-                                p[0] as i16,
-                                p[1] as i16,
-                                p[2] as i16,
-                                p[3] as i16,
-                                p[4] as i16,
-                                p[5] as i16,
-                            ];
+                    for (c, p) in current
+                        .chunks_exact_mut(BPP)
+                        .zip(previous.chunks_exact(BPP))
+                    {
+                        for i in 0..BPP {
+                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                a_bpp[i],
+                                p[i] as i16,
+                                c_bpp[i],
+                            ));
                         }
-                    }
-                    BytesPerPixel::Eight => {
-                        const BPP: usize = 8;
-                        let mut a_bpp = [0; BPP];
-                        let mut c_bpp = [0; BPP];
 
-                        for (c, p) in current
-                            .chunks_exact_mut(BPP)
-                            .zip(previous.chunks_exact(BPP))
-                        {
-                            for i in 0..BPP {
-                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                    a_bpp[i],
-                                    p[i] as i16,
-                                    c_bpp[i],
-                                ));
-                            }
-
-                            a_bpp = [
-                                c[0] as i16,
-                                c[1] as i16,
-                                c[2] as i16,
-                                c[3] as i16,
-                                c[4] as i16,
-                                c[5] as i16,
-                                c[6] as i16,
-                                c[7] as i16,
-                            ];
-                            c_bpp = [
-                                p[0] as i16,
-                                p[1] as i16,
-                                p[2] as i16,
-                                p[3] as i16,
-                                p[4] as i16,
-                                p[5] as i16,
-                                p[6] as i16,
-                                p[7] as i16,
-                            ];
-                        }
+                        a_bpp = [
+                            c[0] as i16,
+                            c[1] as i16,
+                            c[2] as i16,
+                            c[3] as i16,
+                            c[4] as i16,
+                            c[5] as i16,
+                            c[6] as i16,
+                            c[7] as i16,
+                        ];
+                        c_bpp = [
+                            p[0] as i16,
+                            p[1] as i16,
+                            p[2] as i16,
+                            p[3] as i16,
+                            p[4] as i16,
+                            p[5] as i16,
+                            p[6] as i16,
+                            p[7] as i16,
+                        ];
                     }
                 }
             }
@@ -1090,6 +935,34 @@ mod test {
     #[test]
     #[ignore] // takes ~20s without optimizations
     fn paeth_impls_are_equivalent() {
+        // This is an optimized version of the algorithm found in the PNG spec,
+        // derived by rearranging the following terms:
+        //   p  = a + b - c
+        //   pa = abs(p - a)
+        //   pb = abs(p - b)
+        //   pc = abs(p - c)
+        // See `fn filter_paeth_fpnge` for details on the derivation.
+        //
+        // We previously used this on all non-x86 platforms before adapting stb.
+        fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
+            let pa = (i16::from(b) - i16::from(c)).abs();
+            let pb = (i16::from(a) - i16::from(c)).abs();
+            let pc = ((i16::from(a) - i16::from(c)) + (i16::from(b) - i16::from(c))).abs();
+
+            let mut out = a;
+            let mut min = pa;
+
+            if pb < min {
+                min = pb;
+                out = b;
+            }
+            if pc < min {
+                out = c;
+            }
+
+            out
+        }
+
         for a in 0..=255 {
             for b in 0..=255 {
                 for c in 0..=255 {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -93,6 +93,9 @@ impl RowFilter {
     }
 }
 
+// This code path is used on non-x86_64 architectures but we allow dead code
+// for the test module to be able to access it.
+#[allow(dead_code)]
 fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
     // On ARM this algorithm performs much better than the one above adapted from stb,
     // and this is the better-studied algorithm we've always used here,
@@ -115,7 +118,7 @@ fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
     out
 }
 
-fn filter_paeth_stbi(a: u8, b: u8, c: u8) -> u8 {
+fn filter_paeth_stbi(a: i16, b: i16, c: i16) -> u8 {
     // Decoding optimizes better with this algorithm than with `filter_paeth`
     //
     // This formulation looks very different from the reference in the PNG spec, but is
@@ -124,12 +127,12 @@ fn filter_paeth_stbi(a: u8, b: u8, c: u8) -> u8 {
     //
     // Adapted from public domain PNG implementation:
     // https://github.com/nothings/stb/blob/5c205738c191bcb0abc65c4febfa9bd25ff35234/stb_image.h#L4657-L4668
-    let thresh = i16::from(c) * 3 - (i16::from(a) + i16::from(b));
+    let thresh = c * 3 - (a + b);
     let lo = a.min(b);
     let hi = a.max(b);
-    let t0 = if hi as i16 <= thresh { lo } else { c };
-    let t1 = if thresh <= lo as i16 { hi } else { t0 };
-    t1
+    let t0 = if hi <= thresh { lo } else { c };
+    let t1 = if thresh <= lo { hi } else { t0 };
+    t1 as u8
 }
 
 fn filter_paeth_fpnge(a: u8, b: u8, c: u8) -> u8 {
@@ -534,144 +537,302 @@ pub(crate) fn unfilter(
         },
         #[allow(unreachable_code)]
         Paeth => {
-            // Select the fastest Paeth filter implementation based on the target architecture.
-            let filter_paeth_decode = if cfg!(target_arch = "x86_64") {
-                filter_paeth_stbi
-            } else {
-                filter_paeth
-            };
+            #[cfg(not(target_arch = "x86_64"))]
+            {
+                // Paeth filter pixels:
+                // C B D
+                // A X
+                match tbpp {
+                    BytesPerPixel::One => {
+                        let mut a_bpp = [0; 1];
+                        let mut c_bpp = [0; 1];
+                        for (chunk, b_bpp) in
+                            current.chunks_exact_mut(1).zip(previous.chunks_exact(1))
+                        {
+                            let new_chunk = [
+                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0]))
+                            ];
+                            *TryInto::<&mut [u8; 1]>::try_into(chunk).unwrap() = new_chunk;
+                            a_bpp = new_chunk;
+                            c_bpp = b_bpp.try_into().unwrap();
+                        }
+                    }
+                    BytesPerPixel::Two => {
+                        let mut a_bpp = [0; 2];
+                        let mut c_bpp = [0; 2];
+                        for (chunk, b_bpp) in
+                            current.chunks_exact_mut(2).zip(previous.chunks_exact(2))
+                        {
+                            let new_chunk = [
+                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
+                                chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            ];
+                            *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                            a_bpp = new_chunk;
+                            c_bpp = b_bpp.try_into().unwrap();
+                        }
+                    }
+                    BytesPerPixel::Three => {
+                        let mut a_bpp = [0; 3];
+                        let mut c_bpp = [0; 3];
 
-            // Paeth filter pixels:
-            // C B D
-            // A X
-            match tbpp {
-                BytesPerPixel::One => {
-                    let mut a_bpp = [0; 1];
-                    let mut c_bpp = [0; 1];
-                    for (chunk, b_bpp) in current.chunks_exact_mut(1).zip(previous.chunks_exact(1))
-                    {
-                        let new_chunk = [chunk[0]
-                            .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0]))];
-                        *TryInto::<&mut [u8; 1]>::try_into(chunk).unwrap() = new_chunk;
-                        a_bpp = new_chunk;
-                        c_bpp = b_bpp.try_into().unwrap();
+                        let mut previous = &previous[..previous.len() / 3 * 3];
+                        let current_len = current.len();
+                        let mut current = &mut current[..current_len / 3 * 3];
+
+                        while let ([c0, c1, c2, c_rest @ ..], [p0, p1, p2, p_rest @ ..]) =
+                            (current, previous)
+                        {
+                            current = c_rest;
+                            previous = p_rest;
+
+                            *c0 = c0.wrapping_add(filter_paeth(a_bpp[0], *p0, c_bpp[0]));
+                            *c1 = c1.wrapping_add(filter_paeth(a_bpp[1], *p1, c_bpp[1]));
+                            *c2 = c2.wrapping_add(filter_paeth(a_bpp[2], *p2, c_bpp[2]));
+
+                            a_bpp = [*c0, *c1, *c2];
+                            c_bpp = [*p0, *p1, *p2];
+                        }
+                    }
+                    BytesPerPixel::Four => {
+                        // Using the `simd` module here has no effect on Linux
+                        // and appears to regress performance on Windows, so we don't use it here.
+                        // See https://github.com/image-rs/image-png/issues/567
+
+                        let mut a_bpp = [0; 4];
+                        let mut c_bpp = [0; 4];
+
+                        let mut previous = &previous[..previous.len() & !3];
+                        let current_len = current.len();
+                        let mut current = &mut current[..current_len & !3];
+
+                        while let ([c0, c1, c2, c3, c_rest @ ..], [p0, p1, p2, p3, p_rest @ ..]) =
+                            (current, previous)
+                        {
+                            current = c_rest;
+                            previous = p_rest;
+
+                            *c0 = c0.wrapping_add(filter_paeth(a_bpp[0], *p0, c_bpp[0]));
+                            *c1 = c1.wrapping_add(filter_paeth(a_bpp[1], *p1, c_bpp[1]));
+                            *c2 = c2.wrapping_add(filter_paeth(a_bpp[2], *p2, c_bpp[2]));
+                            *c3 = c3.wrapping_add(filter_paeth(a_bpp[3], *p3, c_bpp[3]));
+
+                            a_bpp = [*c0, *c1, *c2, *c3];
+                            c_bpp = [*p0, *p1, *p2, *p3];
+                        }
+                    }
+                    BytesPerPixel::Six => {
+                        let mut a_bpp = [0; 6];
+                        let mut c_bpp = [0; 6];
+                        for (chunk, b_bpp) in
+                            current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
+                        {
+                            let new_chunk = [
+                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
+                                chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
+                                chunk[2].wrapping_add(filter_paeth(a_bpp[2], b_bpp[2], c_bpp[2])),
+                                chunk[3].wrapping_add(filter_paeth(a_bpp[3], b_bpp[3], c_bpp[3])),
+                                chunk[4].wrapping_add(filter_paeth(a_bpp[4], b_bpp[4], c_bpp[4])),
+                                chunk[5].wrapping_add(filter_paeth(a_bpp[5], b_bpp[5], c_bpp[5])),
+                            ];
+                            *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                            a_bpp = new_chunk;
+                            c_bpp = b_bpp.try_into().unwrap();
+                        }
+                    }
+                    BytesPerPixel::Eight => {
+                        let mut a_bpp = [0; 8];
+                        let mut c_bpp = [0; 8];
+                        for (chunk, b_bpp) in
+                            current.chunks_exact_mut(8).zip(previous.chunks_exact(8))
+                        {
+                            let new_chunk = [
+                                chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
+                                chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
+                                chunk[2].wrapping_add(filter_paeth(a_bpp[2], b_bpp[2], c_bpp[2])),
+                                chunk[3].wrapping_add(filter_paeth(a_bpp[3], b_bpp[3], c_bpp[3])),
+                                chunk[4].wrapping_add(filter_paeth(a_bpp[4], b_bpp[4], c_bpp[4])),
+                                chunk[5].wrapping_add(filter_paeth(a_bpp[5], b_bpp[5], c_bpp[5])),
+                                chunk[6].wrapping_add(filter_paeth(a_bpp[6], b_bpp[6], c_bpp[6])),
+                                chunk[7].wrapping_add(filter_paeth(a_bpp[7], b_bpp[7], c_bpp[7])),
+                            ];
+                            *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                            a_bpp = new_chunk;
+                            c_bpp = b_bpp.try_into().unwrap();
+                        }
                     }
                 }
-                BytesPerPixel::Two => {
-                    let mut a_bpp = [0; 2];
-                    let mut c_bpp = [0; 2];
-                    for (chunk, b_bpp) in current.chunks_exact_mut(2).zip(previous.chunks_exact(2))
-                    {
-                        let new_chunk = [
-                            chunk[0]
-                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
-                            chunk[1]
-                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
-                        ];
-                        *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
-                        a_bpp = new_chunk;
-                        c_bpp = b_bpp.try_into().unwrap();
+            }
+
+            // The x86_64 functions avoid casting between u8xN and i16xN SIMD
+            // representations when possible by maintaining [i16; BPP] arrays
+            // between iterations instead of [u8; BPP].
+            #[cfg(target_arch = "x86_64")]
+            {
+                // Paeth filter pixels:
+                // C B D
+                // A X
+                match tbpp {
+                    BytesPerPixel::One => {
+                        const BPP: usize = 1;
+                        let mut a_bpp = [0; BPP];
+                        let mut c_bpp = [0; BPP];
+
+                        for (c, p) in current
+                            .chunks_exact_mut(BPP)
+                            .zip(previous.chunks_exact(BPP))
+                        {
+                            for i in 0..BPP {
+                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                    a_bpp[i],
+                                    p[i] as i16,
+                                    c_bpp[i],
+                                ));
+                            }
+
+                            a_bpp = [c[0] as i16];
+                            c_bpp = [p[0] as i16];
+                        }
                     }
-                }
-                BytesPerPixel::Three => {
-                    let mut a_bpp = [0; 3];
-                    let mut c_bpp = [0; 3];
+                    BytesPerPixel::Two => {
+                        const BPP: usize = 2;
+                        let mut a_bpp = [0; BPP];
+                        let mut c_bpp = [0; BPP];
 
-                    let mut previous = &previous[..previous.len() / 3 * 3];
-                    let current_len = current.len();
-                    let mut current = &mut current[..current_len / 3 * 3];
+                        for (c, p) in current
+                            .chunks_exact_mut(BPP)
+                            .zip(previous.chunks_exact(BPP))
+                        {
+                            for i in 0..BPP {
+                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                    a_bpp[i],
+                                    p[i] as i16,
+                                    c_bpp[i],
+                                ));
+                            }
 
-                    while let ([c0, c1, c2, c_rest @ ..], [p0, p1, p2, p_rest @ ..]) =
-                        (current, previous)
-                    {
-                        current = c_rest;
-                        previous = p_rest;
-
-                        *c0 = c0.wrapping_add(filter_paeth_decode(a_bpp[0], *p0, c_bpp[0]));
-                        *c1 = c1.wrapping_add(filter_paeth_decode(a_bpp[1], *p1, c_bpp[1]));
-                        *c2 = c2.wrapping_add(filter_paeth_decode(a_bpp[2], *p2, c_bpp[2]));
-
-                        a_bpp = [*c0, *c1, *c2];
-                        c_bpp = [*p0, *p1, *p2];
+                            a_bpp = [c[0] as i16, c[1] as i16];
+                            c_bpp = [p[0] as i16, p[1] as i16];
+                        }
                     }
-                }
-                BytesPerPixel::Four => {
-                    // Using the `simd` module here has no effect on Linux
-                    // and appears to regress performance on Windows, so we don't use it here.
-                    // See https://github.com/image-rs/image-png/issues/567
+                    BytesPerPixel::Three => {
+                        const BPP: usize = 3;
+                        let mut a_bpp = [0; BPP];
+                        let mut c_bpp = [0; BPP];
 
-                    let mut a_bpp = [0; 4];
-                    let mut c_bpp = [0; 4];
+                        for (c, p) in current
+                            .chunks_exact_mut(BPP)
+                            .zip(previous.chunks_exact(BPP))
+                        {
+                            for i in 0..BPP {
+                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                    a_bpp[i],
+                                    p[i] as i16,
+                                    c_bpp[i],
+                                ));
+                            }
 
-                    let mut previous = &previous[..previous.len() & !3];
-                    let current_len = current.len();
-                    let mut current = &mut current[..current_len & !3];
-
-                    while let ([c0, c1, c2, c3, c_rest @ ..], [p0, p1, p2, p3, p_rest @ ..]) =
-                        (current, previous)
-                    {
-                        current = c_rest;
-                        previous = p_rest;
-
-                        *c0 = c0.wrapping_add(filter_paeth_decode(a_bpp[0], *p0, c_bpp[0]));
-                        *c1 = c1.wrapping_add(filter_paeth_decode(a_bpp[1], *p1, c_bpp[1]));
-                        *c2 = c2.wrapping_add(filter_paeth_decode(a_bpp[2], *p2, c_bpp[2]));
-                        *c3 = c3.wrapping_add(filter_paeth_decode(a_bpp[3], *p3, c_bpp[3]));
-
-                        a_bpp = [*c0, *c1, *c2, *c3];
-                        c_bpp = [*p0, *p1, *p2, *p3];
+                            a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16];
+                            c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16];
+                        }
                     }
-                }
-                BytesPerPixel::Six => {
-                    let mut a_bpp = [0; 6];
-                    let mut c_bpp = [0; 6];
-                    for (chunk, b_bpp) in current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
-                    {
-                        let new_chunk = [
-                            chunk[0]
-                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
-                            chunk[1]
-                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
-                            chunk[2]
-                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
-                            chunk[3]
-                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
-                            chunk[4]
-                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
-                            chunk[5]
-                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
-                        ];
-                        *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
-                        a_bpp = new_chunk;
-                        c_bpp = b_bpp.try_into().unwrap();
+                    BytesPerPixel::Four => {
+                        // Using the `simd` module here has no effect on Linux
+                        // and appears to regress performance on Windows, so we don't use it here.
+                        // See https://github.com/image-rs/image-png/issues/567
+                        const BPP: usize = 4;
+                        let mut a_bpp = [0; BPP];
+                        let mut c_bpp = [0; BPP];
+
+                        for (c, p) in current
+                            .chunks_exact_mut(BPP)
+                            .zip(previous.chunks_exact(BPP))
+                        {
+                            for i in 0..BPP {
+                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                    a_bpp[i],
+                                    p[i] as i16,
+                                    c_bpp[i],
+                                ));
+                            }
+
+                            a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16, c[3] as i16];
+                            c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16, p[3] as i16];
+                        }
                     }
-                }
-                BytesPerPixel::Eight => {
-                    let mut a_bpp = [0; 8];
-                    let mut c_bpp = [0; 8];
-                    for (chunk, b_bpp) in current.chunks_exact_mut(8).zip(previous.chunks_exact(8))
-                    {
-                        let new_chunk = [
-                            chunk[0]
-                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
-                            chunk[1]
-                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
-                            chunk[2]
-                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
-                            chunk[3]
-                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
-                            chunk[4]
-                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
-                            chunk[5]
-                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
-                            chunk[6]
-                                .wrapping_add(filter_paeth_decode(a_bpp[6], b_bpp[6], c_bpp[6])),
-                            chunk[7]
-                                .wrapping_add(filter_paeth_decode(a_bpp[7], b_bpp[7], c_bpp[7])),
-                        ];
-                        *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
-                        a_bpp = new_chunk;
-                        c_bpp = b_bpp.try_into().unwrap();
+                    BytesPerPixel::Six => {
+                        const BPP: usize = 6;
+                        let mut a_bpp = [0; BPP];
+                        let mut c_bpp = [0; BPP];
+
+                        for (c, p) in current
+                            .chunks_exact_mut(BPP)
+                            .zip(previous.chunks_exact(BPP))
+                        {
+                            for i in 0..BPP {
+                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                    a_bpp[i],
+                                    p[i] as i16,
+                                    c_bpp[i],
+                                ));
+                            }
+
+                            a_bpp = [
+                                c[0] as i16,
+                                c[1] as i16,
+                                c[2] as i16,
+                                c[3] as i16,
+                                c[4] as i16,
+                                c[5] as i16,
+                            ];
+                            c_bpp = [
+                                p[0] as i16,
+                                p[1] as i16,
+                                p[2] as i16,
+                                p[3] as i16,
+                                p[4] as i16,
+                                p[5] as i16,
+                            ];
+                        }
+                    }
+                    BytesPerPixel::Eight => {
+                        const BPP: usize = 8;
+                        let mut a_bpp = [0; BPP];
+                        let mut c_bpp = [0; BPP];
+
+                        for (c, p) in current
+                            .chunks_exact_mut(BPP)
+                            .zip(previous.chunks_exact(BPP))
+                        {
+                            for i in 0..BPP {
+                                c[i] = c[i].wrapping_add(filter_paeth_stbi(
+                                    a_bpp[i],
+                                    p[i] as i16,
+                                    c_bpp[i],
+                                ));
+                            }
+
+                            a_bpp = [
+                                c[0] as i16,
+                                c[1] as i16,
+                                c[2] as i16,
+                                c[3] as i16,
+                                c[4] as i16,
+                                c[5] as i16,
+                                c[6] as i16,
+                                c[7] as i16,
+                            ];
+                            c_bpp = [
+                                p[0] as i16,
+                                p[1] as i16,
+                                p[2] as i16,
+                                p[3] as i16,
+                                p[4] as i16,
+                                p[5] as i16,
+                                p[6] as i16,
+                                p[7] as i16,
+                            ];
+                        }
                     }
                 }
             }
@@ -934,7 +1095,7 @@ mod test {
                 for c in 0..=255 {
                     let baseline = filter_paeth(a, b, c);
                     let fpnge = filter_paeth_fpnge(a, b, c);
-                    let stbi = filter_paeth_stbi(a, b, c);
+                    let stbi = filter_paeth_stbi(a as i16, b as i16, c as i16);
 
                     assert_eq!(baseline, fpnge);
                     assert_eq!(baseline, stbi);


### PR DESCRIPTION
- Change the stbi filter function to take `i16` instead of `u8`
- Use `[i16; BPP]` instead of `[u8; BPP]` arrays to avoid unnecessary casting between `u8` and `i16`

First commit adds this as a parallel implementation for x86_64 only.
Second commit makes it the only implementation.

No huge wins for 3 or 4, but this shows slight improvements for each BPP.

<details><summary>Bench stats for Paeth</summary>

With the nightly compiler, baseline target cpu
```bash
$ cargo bench --features=benchmarks -- filter=Paeth
// master
unfilter/filter=Paeth/bpp=1
                        time:   [9.1529 µs 9.1770 µs 9.1956 µs]
                        thrpt:  [424.80 MiB/s 425.66 MiB/s 426.78 MiB/s]
unfilter/filter=Paeth/bpp=2
                        time:   [15.315 µs 15.336 µs 15.352 µs]
                        thrpt:  [508.89 MiB/s 509.44 MiB/s 510.12 MiB/s]
unfilter/filter=Paeth/bpp=3
                        time:   [15.871 µs 15.907 µs 15.948 µs]
                        thrpt:  [734.80 MiB/s 736.70 MiB/s 738.37 MiB/s]
unfilter/filter=Paeth/bpp=4
                        time:   [13.368 µs 13.423 µs 13.488 µs]
                        thrpt:  [1.1313 GiB/s 1.1367 GiB/s 1.1414 GiB/s]
unfilter/filter=Paeth/bpp=6
                        time:   [24.002 µs 24.266 µs 24.575 µs]
                        thrpt:  [953.71 MiB/s 965.84 MiB/s 976.50 MiB/s]
unfilter/filter=Paeth/bpp=8
                        time:   [17.065 µs 17.203 µs 17.351 µs]
                        thrpt:  [1.7588 GiB/s 1.7740 GiB/s 1.7884 GiB/s]
// this PR
unfilter/filter=Paeth/bpp=1
                        time:   [7.7879 µs 7.8124 µs 7.8342 µs]
                        thrpt:  [498.61 MiB/s 500.01 MiB/s 501.58 MiB/s]
unfilter/filter=Paeth/bpp=2
                        time:   [13.995 µs 14.133 µs 14.291 µs]
                        thrpt:  [546.69 MiB/s 552.78 MiB/s 558.23 MiB/s]
unfilter/filter=Paeth/bpp=3
                        time:   [14.936 µs 14.975 µs 15.010 µs]
                        thrpt:  [780.73 MiB/s 782.58 MiB/s 784.60 MiB/s]
unfilter/filter=Paeth/bpp=4
                        time:   [12.566 µs 12.669 µs 12.783 µs]
                        thrpt:  [1.1937 GiB/s 1.2045 GiB/s 1.2143 GiB/s]
unfilter/filter=Paeth/bpp=6
                        time:   [17.578 µs 17.823 µs 18.078 µs]
                        thrpt:  [1.2661 GiB/s 1.2842 GiB/s 1.3021 GiB/s]
unfilter/filter=Paeth/bpp=8
                        time:   [13.038 µs 13.177 µs 13.332 µs]
                        thrpt:  [2.2890 GiB/s 2.3159 GiB/s 2.3407 GiB/s]
```

</details>

---

I wrote an `sse2` intrinsic version of the stb filter to compare assembly and see where we were falling short.

I saw that we could improve beyond pre-1.87 performance by using arrays of `i16` instead of `u8` to maintain state between iterations. These changes should have fewer instructions than the 1.86 version and be more robust against LLVM tripping up on optimization like the upstream-reported issues.

#### unfilter 3 and 4, x86_64 - https://godbolt.org/z/5TGd8ojGM

In the pr_625 loop bodies, note the 5 `punpcklbw` instructions compared to the 2 in this PR. We only need to unpack the current pixel and the pixel above it to `i16`, so the other 3 are wasted instructions, along with the extra `packsswb` of which only 1 should be needed (`packuswb` in this PR) to convert back to `u8` for storing.

#### unfilter 4, aarch64 - https://godbolt.org/z/jf1e1554f

The instruction count for arm64 is lower as well, so I assume it's faster there but don't have hardware to confirm. I included the second commit to make that easier for others to test.
