### PR TITLE
Revert "perf: Improve Paeth unfilter auto-vectorization by changing how loop state is maintained"

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -93,7 +93,29 @@ impl RowFilter {
     }
 }
 
-fn filter_paeth_stbi(a: i16, b: i16, c: i16) -> u8 {
+fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
+    // On ARM this algorithm performs much better than the one above adapted from stb,
+    // and this is the better-studied algorithm we've always used here,
+    // so we default to it on all non-x86 platforms.
+    let pa = (i16::from(b) - i16::from(c)).abs();
+    let pb = (i16::from(a) - i16::from(c)).abs();
+    let pc = ((i16::from(a) - i16::from(c)) + (i16::from(b) - i16::from(c))).abs();
+
+    let mut out = a;
+    let mut min = pa;
+
+    if pb < min {
+        min = pb;
+        out = b;
+    }
+    if pc < min {
+        out = c;
+    }
+
+    out
+}
+
+fn filter_paeth_stbi(a: u8, b: u8, c: u8) -> u8 {
     // Decoding optimizes better with this algorithm than with `filter_paeth`
     //
     // This formulation looks very different from the reference in the PNG spec, but is
@@ -102,12 +124,12 @@ fn filter_paeth_stbi(a: i16, b: i16, c: i16) -> u8 {
     //
     // Adapted from public domain PNG implementation:
     // https://github.com/nothings/stb/blob/5c205738c191bcb0abc65c4febfa9bd25ff35234/stb_image.h#L4657-L4668
-    let thresh = c * 3 - (a + b);
+    let thresh = i16::from(c) * 3 - (i16::from(a) + i16::from(b));
     let lo = a.min(b);
     let hi = a.max(b);
-    let t0 = if hi <= thresh { lo } else { c };
-    let t1 = if thresh <= lo { hi } else { t0 };
-    t1 as u8
+    let t0 = if hi as i16 <= thresh { lo } else { c };
+    let t1 = if thresh <= lo as i16 { hi } else { t0 };
+    t1
 }
 
 fn filter_paeth_fpnge(a: u8, b: u8, c: u8) -> u8 {
@@ -510,174 +532,146 @@ pub(crate) fn unfilter(
                 }
             }
         },
+        #[allow(unreachable_code)]
         Paeth => {
-            // These functions are designed to avoid casting between
-            // u8xN and i16xN SIMD representations when possible by maintaining
-            // [i16; BPP] arrays between iterations instead of [u8; BPP].
+            // Select the fastest Paeth filter implementation based on the target architecture.
+            let filter_paeth_decode = if cfg!(target_arch = "x86_64") {
+                filter_paeth_stbi
+            } else {
+                filter_paeth
+            };
 
             // Paeth filter pixels:
             // C B D
             // A X
             match tbpp {
                 BytesPerPixel::One => {
-                    const BPP: usize = 1;
-                    let mut a_bpp = [0; BPP];
-                    let mut c_bpp = [0; BPP];
-
-                    for (c, p) in current
-                        .chunks_exact_mut(BPP)
-                        .zip(previous.chunks_exact(BPP))
+                    let mut a_bpp = [0; 1];
+                    let mut c_bpp = [0; 1];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(1).zip(previous.chunks_exact(1))
                     {
-                        for i in 0..BPP {
-                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                a_bpp[i],
-                                p[i] as i16,
-                                c_bpp[i],
-                            ));
-                        }
-
-                        a_bpp = [c[0] as i16];
-                        c_bpp = [p[0] as i16];
+                        let new_chunk = [chunk[0]
+                            .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0]))];
+                        *TryInto::<&mut [u8; 1]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
                     }
                 }
                 BytesPerPixel::Two => {
-                    const BPP: usize = 2;
-                    let mut a_bpp = [0; BPP];
-                    let mut c_bpp = [0; BPP];
-
-                    for (c, p) in current
-                        .chunks_exact_mut(BPP)
-                        .zip(previous.chunks_exact(BPP))
+                    let mut a_bpp = [0; 2];
+                    let mut c_bpp = [0; 2];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(2).zip(previous.chunks_exact(2))
                     {
-                        for i in 0..BPP {
-                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                a_bpp[i],
-                                p[i] as i16,
-                                c_bpp[i],
-                            ));
-                        }
-
-                        a_bpp = [c[0] as i16, c[1] as i16];
-                        c_bpp = [p[0] as i16, p[1] as i16];
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                        ];
+                        *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
                     }
                 }
                 BytesPerPixel::Three => {
-                    const BPP: usize = 3;
-                    let mut a_bpp = [0; BPP];
-                    let mut c_bpp = [0; BPP];
+                    let mut a_bpp = [0; 3];
+                    let mut c_bpp = [0; 3];
 
-                    for (c, p) in current
-                        .chunks_exact_mut(BPP)
-                        .zip(previous.chunks_exact(BPP))
+                    let mut previous = &previous[..previous.len() / 3 * 3];
+                    let current_len = current.len();
+                    let mut current = &mut current[..current_len / 3 * 3];
+
+                    while let ([c0, c1, c2, c_rest @ ..], [p0, p1, p2, p_rest @ ..]) =
+                        (current, previous)
                     {
-                        for i in 0..BPP {
-                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                a_bpp[i],
-                                p[i] as i16,
-                                c_bpp[i],
-                            ));
-                        }
+                        current = c_rest;
+                        previous = p_rest;
 
-                        a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16];
-                        c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16];
+                        *c0 = c0.wrapping_add(filter_paeth_decode(a_bpp[0], *p0, c_bpp[0]));
+                        *c1 = c1.wrapping_add(filter_paeth_decode(a_bpp[1], *p1, c_bpp[1]));
+                        *c2 = c2.wrapping_add(filter_paeth_decode(a_bpp[2], *p2, c_bpp[2]));
+
+                        a_bpp = [*c0, *c1, *c2];
+                        c_bpp = [*p0, *p1, *p2];
                     }
                 }
                 BytesPerPixel::Four => {
                     // Using the `simd` module here has no effect on Linux
                     // and appears to regress performance on Windows, so we don't use it here.
                     // See https://github.com/image-rs/image-png/issues/567
-                    const BPP: usize = 4;
-                    let mut a_bpp = [0; BPP];
-                    let mut c_bpp = [0; BPP];
 
-                    for (c, p) in current
-                        .chunks_exact_mut(BPP)
-                        .zip(previous.chunks_exact(BPP))
+                    let mut a_bpp = [0; 4];
+                    let mut c_bpp = [0; 4];
+
+                    let mut previous = &previous[..previous.len() & !3];
+                    let current_len = current.len();
+                    let mut current = &mut current[..current_len & !3];
+
+                    while let ([c0, c1, c2, c3, c_rest @ ..], [p0, p1, p2, p3, p_rest @ ..]) =
+                        (current, previous)
                     {
-                        for i in 0..BPP {
-                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                a_bpp[i],
-                                p[i] as i16,
-                                c_bpp[i],
-                            ));
-                        }
+                        current = c_rest;
+                        previous = p_rest;
 
-                        a_bpp = [c[0] as i16, c[1] as i16, c[2] as i16, c[3] as i16];
-                        c_bpp = [p[0] as i16, p[1] as i16, p[2] as i16, p[3] as i16];
+                        *c0 = c0.wrapping_add(filter_paeth_decode(a_bpp[0], *p0, c_bpp[0]));
+                        *c1 = c1.wrapping_add(filter_paeth_decode(a_bpp[1], *p1, c_bpp[1]));
+                        *c2 = c2.wrapping_add(filter_paeth_decode(a_bpp[2], *p2, c_bpp[2]));
+                        *c3 = c3.wrapping_add(filter_paeth_decode(a_bpp[3], *p3, c_bpp[3]));
+
+                        a_bpp = [*c0, *c1, *c2, *c3];
+                        c_bpp = [*p0, *p1, *p2, *p3];
                     }
                 }
                 BytesPerPixel::Six => {
-                    const BPP: usize = 6;
-                    let mut a_bpp = [0; BPP];
-                    let mut c_bpp = [0; BPP];
-
-                    for (c, p) in current
-                        .chunks_exact_mut(BPP)
-                        .zip(previous.chunks_exact(BPP))
+                    let mut a_bpp = [0; 6];
+                    let mut c_bpp = [0; 6];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(6).zip(previous.chunks_exact(6))
                     {
-                        for i in 0..BPP {
-                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                a_bpp[i],
-                                p[i] as i16,
-                                c_bpp[i],
-                            ));
-                        }
-
-                        a_bpp = [
-                            c[0] as i16,
-                            c[1] as i16,
-                            c[2] as i16,
-                            c[3] as i16,
-                            c[4] as i16,
-                            c[5] as i16,
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            chunk[2]
+                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
+                            chunk[3]
+                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
+                            chunk[4]
+                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
+                            chunk[5]
+                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
                         ];
-                        c_bpp = [
-                            p[0] as i16,
-                            p[1] as i16,
-                            p[2] as i16,
-                            p[3] as i16,
-                            p[4] as i16,
-                            p[5] as i16,
-                        ];
+                        *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
                     }
                 }
                 BytesPerPixel::Eight => {
-                    const BPP: usize = 8;
-                    let mut a_bpp = [0; BPP];
-                    let mut c_bpp = [0; BPP];
-
-                    for (c, p) in current
-                        .chunks_exact_mut(BPP)
-                        .zip(previous.chunks_exact(BPP))
+                    let mut a_bpp = [0; 8];
+                    let mut c_bpp = [0; 8];
+                    for (chunk, b_bpp) in current.chunks_exact_mut(8).zip(previous.chunks_exact(8))
                     {
-                        for i in 0..BPP {
-                            c[i] = c[i].wrapping_add(filter_paeth_stbi(
-                                a_bpp[i],
-                                p[i] as i16,
-                                c_bpp[i],
-                            ));
-                        }
-
-                        a_bpp = [
-                            c[0] as i16,
-                            c[1] as i16,
-                            c[2] as i16,
-                            c[3] as i16,
-                            c[4] as i16,
-                            c[5] as i16,
-                            c[6] as i16,
-                            c[7] as i16,
+                        let new_chunk = [
+                            chunk[0]
+                                .wrapping_add(filter_paeth_decode(a_bpp[0], b_bpp[0], c_bpp[0])),
+                            chunk[1]
+                                .wrapping_add(filter_paeth_decode(a_bpp[1], b_bpp[1], c_bpp[1])),
+                            chunk[2]
+                                .wrapping_add(filter_paeth_decode(a_bpp[2], b_bpp[2], c_bpp[2])),
+                            chunk[3]
+                                .wrapping_add(filter_paeth_decode(a_bpp[3], b_bpp[3], c_bpp[3])),
+                            chunk[4]
+                                .wrapping_add(filter_paeth_decode(a_bpp[4], b_bpp[4], c_bpp[4])),
+                            chunk[5]
+                                .wrapping_add(filter_paeth_decode(a_bpp[5], b_bpp[5], c_bpp[5])),
+                            chunk[6]
+                                .wrapping_add(filter_paeth_decode(a_bpp[6], b_bpp[6], c_bpp[6])),
+                            chunk[7]
+                                .wrapping_add(filter_paeth_decode(a_bpp[7], b_bpp[7], c_bpp[7])),
                         ];
-                        c_bpp = [
-                            p[0] as i16,
-                            p[1] as i16,
-                            p[2] as i16,
-                            p[3] as i16,
-                            p[4] as i16,
-                            p[5] as i16,
-                            p[6] as i16,
-                            p[7] as i16,
-                        ];
+                        *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                        a_bpp = new_chunk;
+                        c_bpp = b_bpp.try_into().unwrap();
                     }
                 }
             }
@@ -935,40 +929,12 @@ mod test {
     #[test]
     #[ignore] // takes ~20s without optimizations
     fn paeth_impls_are_equivalent() {
-        // This is an optimized version of the algorithm found in the PNG spec,
-        // derived by rearranging the following terms:
-        //   p  = a + b - c
-        //   pa = abs(p - a)
-        //   pb = abs(p - b)
-        //   pc = abs(p - c)
-        // See `fn filter_paeth_fpnge` for details on the derivation.
-        //
-        // We previously used this on all non-x86 platforms before adapting stb.
-        fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
-            let pa = (i16::from(b) - i16::from(c)).abs();
-            let pb = (i16::from(a) - i16::from(c)).abs();
-            let pc = ((i16::from(a) - i16::from(c)) + (i16::from(b) - i16::from(c))).abs();
-
-            let mut out = a;
-            let mut min = pa;
-
-            if pb < min {
-                min = pb;
-                out = b;
-            }
-            if pc < min {
-                out = c;
-            }
-
-            out
-        }
-
         for a in 0..=255 {
             for b in 0..=255 {
                 for c in 0..=255 {
                     let baseline = filter_paeth(a, b, c);
                     let fpnge = filter_paeth_fpnge(a, b, c);
-                    let stbi = filter_paeth_stbi(a as i16, b as i16, c as i16);
+                    let stbi = filter_paeth_stbi(a, b, c);
 
                     assert_eq!(baseline, fpnge);
                     assert_eq!(baseline, stbi);


### PR DESCRIPTION
Reverts image-rs/image-png#635 because it regressed ARM and I failed to notice the flipped sign :face_exhaling: 

It still looks absolutely worth it for x86.