### PR TITLE
perf: Neon Paeth unfiltering (3bpp)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@
 //! ```
 //!
 
-#![forbid(unsafe_code)]
 // Silence certain clippy warnings until our MSRV is higher.
 //
 // The #[default] attribute was stabilized in Rust 1.62.0.


### PR DESCRIPTION
As a counter-point to #632, this PR ports over the Neon code [from libpng](https://github.com/pnggroup/libpng/blame/be81ebe1a45c2da3c5788485cd55408fe2e328df/arm/filter_neon_intrinsics.c#L260)

Theoretical results from the micro-architecture simulator indicate an improvement in cycles (n.b. that cache hierarchy is not modelled):

Filter | Arm Cortex A520 | Arm Cortex X4
-- | -- | --
Paeth (3bpp) | 24.44% | 37.63%

Results from a Pixel 10:
Filter | Arm Cortex A520 | Arm Cortex X4 | Baseline Cortex A520 | Baseline Cortex X4 | Neon on Cortex A520 | Neon on Cortex-X4
-- | -- | -- | -- | -- | -- | --
Paeth (3bpp) | 48.40% | 2.54% | 171.4 MiB/s | 703.2 MiB/s | 254.4 MiB/s | 721.0 MiB/s

This is not really intended to merge, but offers another data point for `portable_simd`: some of the gain, but less than what's possible with per-architecture intrinsics.

