### PR TITLE
Fix buffer size dependency for no-end zlib

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 [dependencies.png]
 path = ".."
 [dependencies.libfuzzer-sys]
-git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+version = "0.4.10"
 
 # Prevent this from interfering with workspaces
 [workspace]


### PR DESCRIPTION
Draft to be benchmarked.

Ensure that the buffer is fully flushed before checking for an end-of-file marker via the bool-flag in `fdeflate`. We first pass an empty input without setting the flag and repeat the whole flush cycle if that still yielded data. That same data could previously be masked by the missing end-of-file error.

See: https://github.com/image-rs/fdeflate/issues/58#issuecomment-3263261866