### PR TITLE
Add early exit for adaptive filter selection

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1210,12 +1210,16 @@ pub(crate) fn filter(
         Filter::Adaptive => {
             let mut min_sum: u64 = u64::MAX;
             let mut filter_choice = RowFilter::NoFilter;
-            for &filter in [Sub, Up, Avg, Paeth].iter() {
+            for &filter in [Up, Sub, Avg, Paeth].iter() {
                 filter_internal(filter, bpp, len, previous, current, output);
                 let sum = sum_buffer(output);
                 if sum <= min_sum {
                     min_sum = sum;
                     filter_choice = filter;
+
+                    if sum == 0 {
+                        return filter_choice;
+                    }
                 }
             }
 


### PR DESCRIPTION
If we find a filter that produces all zeros, there's little point in checking the rest of the possible filters.

Also reorder the list of filters so that `Up` is checked first. That's both the cheapest filter, and probably the most likely to result in all zeros (which happens in the case where two consecutive rows of the image are the same).

Inspired by https://github.com/oxipng/oxipng/pull/648