### PR TITLE
Implement PartialEq for EncodingError

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -923,12 +923,12 @@ impl Default for Transformations {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ParameterError {
     inner: ParameterErrorKind,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum ParameterErrorKind {
     /// A provided buffer must be have the exact size to hold the image data. Where the buffer can
     /// be allocated by the caller, they must ensure that it has a minimum size as hinted previously.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -28,12 +28,23 @@ pub enum EncodingError {
     LimitsExceeded,
 }
 
-#[derive(Debug)]
+impl PartialEq for EncodingError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Format(l0), Self::Format(r0)) => l0 == r0,
+            (Self::Parameter(l0), Self::Parameter(r0)) => l0 == r0,
+            (Self::IoError(_), _) | (_, Self::IoError(_)) => false,
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub struct FormatError {
     inner: FormatErrorKind,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum FormatErrorKind {
     ZeroWidth,
     ZeroHeight,

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -108,7 +108,7 @@ use std::{convert::TryFrom, io::Write};
 pub const DECOMPRESSION_LIMIT: usize = 2097152; // 2 MiB
 
 /// Text encoding errors that is wrapped by the standard EncodingError type
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum TextEncodingError {
     /// Unrepresentable characters in string
     Unrepresentable,


### PR DESCRIPTION
- I have a library where I would like to test the errors with expect_eq and deriving PartialEq would be convenient
- Did a manual implementation because the trait is not derivable due to IoError not having straightforward eq semantics.
- Feel free to reject the PR, there is some discussion at https://users.rust-lang.org/t/help-understanding-io-error-and-lack-of-partialeq/13212 for why io error equality doesn't make sense. In this PR, I just made it always false.