### PR TITLE
Only passing `available..` bytes of `UnfilterBuf` to `fdeflate`.

### DIFF
--- a/src/decoder/zlib.rs
+++ b/src/decoder/zlib.rs
@@ -211,6 +211,11 @@ impl UnfilterBuf<'_> {
         if decompressor.is_done() {
             *self.available = *self.filled;
         } else if let Some(new_available) = self.filled.checked_sub(Self::LOOKBACK_SIZE) {
+            // The decompressed data may have started in the middle of the buffer,
+            // so ensure that `self.available` never goes backward.  This is needed
+            // to avoid miscommunicating the size of the "look-back" window when calling
+            // `fdeflate::Decompressor::read` a bit earlier and passing
+            // `&mut self.buffer[*self.available..output_limit]`.
             if new_available > *self.available {
                 *self.available = new_available;
             }


### PR DESCRIPTION
PTAL?

This PR tries to support the work from https://github.com/image-rs/image-png/pull/640 (/cc @fintelia, @197g).  I wonder if the changes in this PR may help to avoid fuzzing failures reported in https://github.com/image-rs/image-png/pull/640#issuecomment-3253727444 (since passing an incorrect look-back buffer to fdeflate may be one hypothetical difference seen when reading byte-by-byte vs whole-content).

--------------------------

I am not sure if rebasing https://github.com/image-rs/image-png/pull/640 on top of this PR would address remaining concerns about that other PR.  I hope so?  :-)  At any rate, I think that merging this PR should still be desirable and be a step in the right direction.

If there are other remaining issues with https://github.com/image-rs/image-png/pull/640 (limited time available for continuing working on it?  functional or performance concerns?), then I may try to continue this work later.  At the same time, I find it a bit hard to fit all of the complexity of `UnfilteringBuffer` and `UnfilterBuf` into my brain all at once.  At the same time, I don't have any solid/constructive ideas, so maybe I just need to try harder.

One half-baked idea that I had was to:

* Rename `UnfilterBuf` into `DecompressorBufferMutRef`
    - Public API can remain unchanged by renaming in `lib.rs` via `pub use DecompressorBufferMutRef as UnfilterBuf` (I think this is ok, because `zlib` module is not public)
    - Alternatively we could also rename in the public API and introduce a `#[deprecated]` type alias to keep the old name available until 0.19
* Rename `UnfilterRegion` into `DecompressorBufferRegion` (same notes as above)
* Introduce an `DecompressorBuffer` struct with owned (i.e. non-ref) `buffer`, `available`, `filled`
* Somehow (/me waves hands) encapsulate managing the buffers into `DecompressorBuffer...`.  Maybe:
    - Replace `data_stream`, `filled`, and `available` fields of `UnfilteringBuffer` with a single `buf: DecompressorBuffer`
    - Move shifting code from `UnfilteringBuffer` into `DecompressorBuffer` (while also letting `UnfilteringBuffer` appropriately shift/managed `prev_start` and `current_start`).
    - Make the fields of `DecompressorBuffer` and `DecompressorBufferMutRef` private (exposing accessors if needed - e.g. maybe `fn available_bytes_mut(&mut self) -> &mut [u8]`)

But I am not sure if the above would really help, or if I would just be shuffling the chairs around.  (And in the process making the code more familiar and therefore maybe easier to understand for me [I am not even sure about that part :-)], but not necessarily for others.)