### PR TITLE
Allow seeking back to read skipped chunks

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -186,6 +186,11 @@ impl<R: BufRead + Seek> Decoder<R> {
         self.read_decoder.read_header_info()
     }
 
+    pub fn read_headers(&mut self) -> Result<&Info<'static>, DecodingError> {
+        self.read_decoder.read_until_image_data()?;
+        Ok(self.read_decoder.info().unwrap())
+    }
+
     /// Reads all meta data until the first IDAT chunk
     pub fn read_info(mut self) -> Result<Reader<R>, DecodingError> {
         let info = self.read_header_info()?;
@@ -260,6 +265,10 @@ impl<R: BufRead + Seek> Decoder<R> {
     /// ```
     pub fn set_ignore_text_chunk(&mut self, ignore_text_chunk: bool) {
         self.read_decoder.set_ignore_text_chunk(ignore_text_chunk);
+    }
+
+    pub fn set_ignore_exif_chunk(&mut self, ignore_exif_chunk: bool) {
+        self.read_decoder.set_ignore_exif_chunk(ignore_exif_chunk);
     }
 
     /// Set the decoder to ignore iccp chunks while parsing.
@@ -694,6 +703,13 @@ impl<R: BufRead + Seek> Reader<R> {
         }
 
         self.unfiltering_buffer.unfilter_curr_row(rowlen, self.bpp)
+    }
+
+    pub fn read_exif(&mut self) -> Result<Option<Vec<u8>>, DecodingError> {
+        if let Some(ref exif) = self.decoder.info().unwrap().exif_metadata {
+            return Ok(Some(exif.to_vec()));
+        }
+        self.decoder.read_exif()
     }
 }
 


### PR DESCRIPTION
With #630 in place, we now have most of the pieces to load PNG metadata without consuming an unbounded amount of space.

The key here is that we track just the start position of each unbounded-size chunk we might care about. Which means that we can track thousands of text chunks with even a tiny space limit. When it comes time to read the chunks, we can seek back to them and provide the desired info. But if the chunk info is never requested then we don't pay the overhead of storing them. When in recording-mode, I believe that the only non-constant memory usage should be recording text chunk positions and reserving two rows of space for the unfiltering buffer.

This is particularly useful for the `image` crate which needs to know whether there's a tRNS chunk (to determine whether the color type is RGB or RGBA) before it knows whether the EXIF or ICC profile will be requested. By doing things this way, it neatly sidesteps the question of setting decoding limits before reading metadata. The main thing decoding limits were being used for was prevent zip-bombs in the compressed iCCP chunks and to a lesser degree preventing unreasonably sized EXIF or text chunks.
