### PR TITLE
Set chunk action for IDAT and fdAT

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -915,6 +915,7 @@ impl StreamingDecoder {
                                 FormatErrorInner::FdatShorterThanFourBytes.into(),
                             ));
                         }
+                        self.current_chunk.action = ChunkAction::Process;
                         Some(State::new_u32(U32ValueKind::ApngSequenceNumber))
                     }
                     IDAT => {
@@ -927,6 +928,7 @@ impl StreamingDecoder {
                             ));
                         }
                         self.have_idat = true;
+                        self.current_chunk.action = ChunkAction::Process;
                         Some(State::ImageData(type_str))
                     }
                     _ => Some(self.start_chunk(type_str, length)?),


### PR DESCRIPTION
Fixes a regression caused by #657. When processing the CRC associated with an IDAT or fdAT chunk, we should use the previous logic of calling `process_chunk` rather than dispatching based on whatever previous chunk action was used.