### PR TITLE
Allow full unfiltering for partial data (`enum`-based approach)

### DIFF
--- a/src/decoder/unfiltering_buffer.rs
+++ b/src/decoder/unfiltering_buffer.rs
@@ -8,12 +8,7 @@ use crate::Info;
 pub(crate) struct UnfilteringBuffer {
     /// Vec containing the uncompressed image data currently being processed.
     data_stream: Vec<u8>,
-    /// Index in `data_stream` where the previous row starts.
-    /// This excludes the filter type byte - it points at the first byte of actual pixel data.
-    /// The pixel data is already-`unfilter`-ed.
-    ///
-    /// If `prev_start == current_start` then it means that there is no previous row.
-    prev_start: usize,
+    prev_row: PrevRow,
     /// Index in `data_stream` where the current row starts.
     /// This points at the filter type byte of the current row (i.e. the actual pixel data starts at `current_start + 1`)
     /// The pixel data is not-yet-`unfilter`-ed.
@@ -28,6 +23,8 @@ pub(crate) struct UnfilteringBuffer {
     shift_back_limit: usize,
     /// How many bytes are left to decompress into this buffer for the current frame.
     remaining_bytes: u64,
+    /// To avoid always allocating a new vector in `fn unfilter_curr_row_using_scratch_buffer`.
+    scratch_buffer: Vec<u8>,
 }
 
 impl UnfilteringBuffer {
@@ -36,9 +33,14 @@ impl UnfilteringBuffer {
     /// Asserts in debug builds that all the invariants hold.  No-op in release
     /// builds.  Intended to be called after creating or mutating `self` to
     /// ensure that the final state preserves the invariants.
+    #[cfg(not(debug_assertions))]
+    fn debug_assert_invariants(&self) {}
+    #[cfg(debug_assertions)]
     fn debug_assert_invariants(&self) {
-        debug_assert!(self.prev_start <= self.current_start);
-        debug_assert!(self.current_start <= self.available);
+        if let PrevRow::InPlace(prev_start) = &self.prev_row {
+            debug_assert!(*prev_start <= self.current_start);
+        }
+        debug_assert!(self.current_start <= self.filled);
         debug_assert!(self.available <= self.filled);
         debug_assert!(self.filled <= self.data_stream.len());
     }
@@ -89,12 +91,13 @@ impl UnfilteringBuffer {
 
         let result = Self {
             data_stream: Vec::with_capacity(data_stream_capacity),
-            prev_start: 0,
+            prev_row: PrevRow::None,
             current_start: 0,
             filled: 0,
             available: 0,
             shift_back_limit,
             remaining_bytes: u64::MAX,
+            scratch_buffer: Vec::new(),
         };
 
         result.debug_assert_invariants();
@@ -104,13 +107,19 @@ impl UnfilteringBuffer {
     /// Called to indicate that there is no previous row (e.g. when the current
     /// row is the first scanline of a given Adam7 pass).
     pub fn reset_prev_row(&mut self) {
-        self.prev_start = self.current_start;
+        // Stash a previously allocated buffer (for potential reuse later)
+        // rather than throwing it away when resetting `self.prev_row`.
+        if let PrevRow::Scratch(buf) = &mut self.prev_row {
+            self.scratch_buffer = std::mem::take(buf);
+        }
+
+        self.prev_row = PrevRow::None;
         self.debug_assert_invariants();
     }
 
     pub fn start_frame(&mut self, frame_bytes: u64) {
         self.data_stream.clear();
-        self.prev_start = 0;
+        self.prev_row = PrevRow::None;
         self.current_start = 0;
         self.filled = 0;
         self.available = 0;
@@ -123,12 +132,28 @@ impl UnfilteringBuffer {
 
     /// Returns the previous (already `unfilter`-ed) row.
     pub fn prev_row(&self) -> &[u8] {
-        &self.data_stream[self.prev_start..self.current_start]
+        self.prev_row
+            .as_slice(&self.data_stream[..self.current_start])
     }
 
-    /// Returns how many bytes of the current row are present in the buffer.
-    pub fn curr_row_len(&self) -> usize {
-        self.available - self.current_start
+    /// Returns how many bytes of the current row are present in the mutable
+    /// part of the buffer (32kB most recently decompressed bytes are read-only
+    /// to retain the "lookback" window as needed for inflate algorithm).  If a
+    /// full row is mutable, then it may be unfiltered using
+    /// `unfilter_curr_row_in_place`.
+    ///
+    /// See also `readable_len_of_curr_row`.
+    pub fn mutable_len_of_curr_row(&self) -> usize {
+        self.available.saturating_sub(self.current_start)
+    }
+
+    /// Returns how many bytes of the current row have been already
+    /// decompressed.  If a full row is available, then it may be unfiltered
+    /// using `unfilter_curr_row_using_scratch_buffer`.
+    ///
+    /// See also `mutable_len_of_curr_row`.
+    pub fn readable_len_of_curr_row(&self) -> usize {
+        self.filled - self.current_start
     }
 
     /// Runs `f` on the underlying buffer.
@@ -143,7 +168,11 @@ impl UnfilteringBuffer {
         F: FnOnce(&mut UnfilterBuf<'_>) -> T,
     {
         // Potentially shift the buffer left to avoid unbounded growth.
-        if self.prev_start >= self.shift_back_limit
+        let discard_size = self.available.min(match &self.prev_row {
+            PrevRow::None | PrevRow::Scratch(_) => self.current_start,
+            PrevRow::InPlace(prev_start) => *prev_start,
+        });
+        if discard_size >= self.shift_back_limit
             // Avoid the shift back if the buffer is still very empty. Consider how we got here: a
             // previous decompression filled the buffer, then we unfiltered, we're now refilling
             // the buffer again. The condition implies, the previous decompression filled at most
@@ -151,7 +180,7 @@ impl UnfilteringBuffer {
             // attempt will not yet be limited by the buffer length.
             && self.filled >= self.data_stream.len() / 2
         {
-            self.shift_buffer_left(self.prev_start);
+            self.shift_buffer_left(discard_size);
         }
 
         if self.filled + Self::GROWTH_BYTES > self.data_stream.len() {
@@ -206,7 +235,10 @@ impl UnfilteringBuffer {
         self.current_start -= discard_size;
         self.available -= discard_size;
         self.filled -= discard_size;
-        self.prev_start -= discard_size;
+        match &mut self.prev_row {
+            PrevRow::None | PrevRow::Scratch(_) => (),
+            PrevRow::InPlace(prev_start) => *prev_start -= discard_size,
+        }
     }
 
     fn curr_row_filter(&self) -> Result<RowFilter, DecodingError> {
@@ -216,29 +248,116 @@ impl UnfilteringBuffer {
         ))
     }
 
-    /// Runs `unfilter` on the current row, and then shifts rows so that the current row becomes the previous row.
+    /// Runs `unfilter` on the current row, and then shifts rows so that the
+    /// current row becomes the previous row.
     ///
-    /// Will panic if `self.curr_row_len() < rowlen`.
-    pub fn unfilter_curr_row(
+    /// `unfilter` will mutate the current row in-place, and therefore the
+    /// caller should first consult `mutable_len_of_curr_row` to check if all
+    /// bytes of the current row are indeed mutable.
+    pub fn unfilter_curr_row_in_place(
         &mut self,
         rowlen: usize,
         bpp: BytesPerPixel,
     ) -> Result<(), DecodingError> {
         debug_assert!(rowlen >= 2); // 1 byte for `RowFilter` and at least 1 byte of pixel data.
 
+        // Violating the assertion below would clobber the bytes in the
+        // "lookback" window.
+        debug_assert!(self.mutable_len_of_curr_row() >= rowlen);
+
         let filter = self.curr_row_filter()?;
         let (prev, row) = self.data_stream.split_at_mut(self.current_start);
-        let prev: &[u8] = &prev[self.prev_start..];
+        let prev: &[u8] = self.prev_row.as_slice(prev);
         let row = &mut row[1..rowlen]; // Skip the `RowFilter` byte.
         debug_assert!(prev.is_empty() || prev.len() == row.len());
 
         unfilter(filter, bpp, prev, row);
 
-        self.prev_start = self.current_start + 1;
+        self.reset_prev_row();
+        self.prev_row = PrevRow::InPlace(self.current_start + 1);
         self.current_start += rowlen;
         self.debug_assert_invariants();
 
         Ok(())
+    }
+
+    /// Runs `unfilter` on the current row, and then shifts rows so that the
+    /// current row becomes the previous row.
+    ///
+    /// Before running `unfilter`, the contents of the current row will be
+    /// copied into a scratch buffer.  This allows unfiltering to happen even
+    /// if `mutable_len_of_curr_row < rowlen` (e.g. when handling partial
+    /// or not-yet-complete input streams).
+    pub fn unfilter_curr_row_using_scratch_buffer(
+        &mut self,
+        rowlen: usize,
+        bpp: BytesPerPixel,
+    ) -> Result<(), DecodingError> {
+        debug_assert!(rowlen >= 2); // 1 byte for `RowFilter` and at least 1 byte of pixel data.
+        debug_assert!(self.readable_len_of_curr_row() >= rowlen);
+
+        // If `mutable_len_of_curr_row >= rowlen`, then `unfilter_curr_row_in_place`
+        // should have been called instead (to avoid the cost of `copy_from_slice` below).
+        debug_assert!(self.mutable_len_of_curr_row() < rowlen);
+
+        let filter = self.curr_row_filter()?;
+
+        let mut row = std::mem::take(&mut self.scratch_buffer);
+        row.resize(rowlen - 1, 0);
+        row.as_mut_slice()
+            .copy_from_slice(&self.data_stream[self.current_start + 1..][..rowlen - 1]);
+
+        let prev = self.prev_row();
+        debug_assert!(prev.is_empty() || prev.len() == (rowlen - 1));
+
+        unfilter(filter, bpp, prev, &mut row);
+
+        self.reset_prev_row();
+        self.prev_row = PrevRow::Scratch(row);
+        self.current_start += rowlen;
+
+        self.debug_assert_invariants();
+
+        Ok(())
+    }
+}
+
+/// An already `unfilter`-ed, previous row.
+///
+/// The data excludes the `RowFilter` byte - it only includes the actual pixel data.
+enum PrevRow {
+    /// No unfiltered row.
+    ///
+    /// `None` is the value of `UnfilteringBuffer::prev_row` before any row has
+    /// been unfiltered (or at the start of a new interlace pass).
+    None,
+
+    /// Offset of `UnfilteringBuffer::data_stream` where the unfiltered row
+    /// starts.
+    ///
+    /// `UnfilteringBuffer::InPlace(_)` is used by `unfilter_curr_row_in_place`
+    /// when setting `UnfilteringBuffer::prev_row`.
+    InPlace(usize),
+
+    /// Separate scratch buffer containing the unfiltered row data.
+    ///
+    /// `UnfilteringBuffer::Scratch(_)` is used by
+    /// `unfilter_curr_row_using_scratch_buffer`
+    /// when setting `UnfilteringBuffer::prev_row`.
+    Scratch(Vec<u8>),
+}
+
+impl PrevRow {
+    /// Returns the previous unfiltered row as a slice of bytes.
+    ///
+    /// `buf` should refer to the `..current_start` portion of
+    /// `UnfilteringBuffer::data_stream`.
+    fn as_slice<'a>(&'a self, buf: &'a [u8]) -> &'a [u8] {
+        match self {
+            PrevRow::None => &[],
+            PrevRow::InPlace(prev_start) => &buf[*prev_start..],
+            PrevRow::Scratch(scratch) => scratch.as_slice(),
+        }
     }
 }
 

--- a/tests/partial_decode.rs
+++ b/tests/partial_decode.rs
@@ -1,0 +1,179 @@
+use png::{Decoder, DecodingError};
+use std::io::Write;
+
+mod pipe {
+    use std::cell::RefCell;
+    use std::io::{BufRead, Cursor, Read, Result, Seek, SeekFrom, Write};
+    use std::rc::Rc;
+
+    pub fn create() -> (impl BufRead + Seek, impl Write) {
+        let write_end = Pipe {
+            buf: Rc::new(RefCell::new(Cursor::new(Vec::new()))),
+            long_lived_fill_buf: Vec::new(),
+        };
+        let read_end = write_end.clone();
+        (read_end, write_end)
+    }
+
+    #[derive(Clone)]
+    struct Pipe {
+        buf: Rc<RefCell<Cursor<Vec<u8>>>>,
+        long_lived_fill_buf: Vec<u8>,
+    }
+
+    impl Read for Pipe {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+            self.buf.borrow_mut().read(buf)
+        }
+    }
+
+    impl BufRead for Pipe {
+        fn fill_buf(&mut self) -> Result<&[u8]> {
+            let mut buf = self.buf.borrow_mut();
+
+            // `short_lived_fill_buf` lives as long as the `buf` borrow.
+            let short_lived_fill_buf = buf.fill_buf()?;
+
+            // Copy `short_lived_fill_buf` into a longer-lived buffer.
+            self.long_lived_fill_buf.clear();
+            self.long_lived_fill_buf
+                .extend_from_slice(short_lived_fill_buf);
+            Ok(&self.long_lived_fill_buf)
+        }
+
+        fn consume(&mut self, amount: usize) {
+            self.buf.borrow_mut().consume(amount)
+        }
+    }
+
+    impl Seek for Pipe {
+        fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+            self.buf.borrow_mut().seek(pos)
+        }
+    }
+
+    impl Write for Pipe {
+        fn write(&mut self, buf: &[u8]) -> Result<usize> {
+            self.buf.borrow_mut().get_mut().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> Result<()> {
+            self.buf.borrow_mut().flush()
+        }
+    }
+
+    #[test]
+    fn test_pipe() {
+        let (input, mut output) = create();
+        write!(&mut output, "foobar").unwrap();
+
+        let input = std::io::read_to_string(input).unwrap();
+        assert_eq!(input, "foobar");
+    }
+}
+
+/// Regression test for a scenario that was:
+///
+/// * Discovered:
+///     - When testing via `cargo fuzz run buf_independent` and discussed at
+///       https://github.com/image-rs/image-png/pull/640#discussion_r2602412407
+///     - In the wild: https://github.com/image-rs/image-png/issues/605
+/// * Fixed by https://github.com/image-rs/image-png/pull/662
+///
+/// In this scenario:
+///
+/// * Decoding the full PNG (see `baseline_reader` or `byte_by_byte_reader`
+///   in `fuzz/fuzz_targets/buf_independent.rs`) would
+///       - Result in
+///         `Err(Format(FormatError { inner: CorruptFlateStream { err: InsufficientInput } }))`
+///         before https://github.com/image-rs/image-png/pull/662
+///       - Result in `Ok(_)` afterwards
+/// * Decoding streaming/partial input (see `intermittent_eofs_reader` in
+///   `fuzz/fuzz_targets/buf_independent.rs`) would miss the `FormatError`
+///   and return `Ok(_)`.
+///
+/// The input file here has an IDAT payload that covers all image rows, but
+/// is truncated without properly terminating the zlib stream.
+#[test]
+fn test_partial_decode_with_unterminated_redundant_zlib_tail() {
+    static CONTENT: &[u8] = &[
+        // PNG header
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        // IHDR chunk (width=34, height=3, bits=8, color=6, interlaced)
+        0x00, 0x00, 0x00, 0x0d, // length
+        0x49, 0x48, 0x44, 0x52, // IHDR
+        0x00, 0x00, 0x00, 0x22, 0x00, 0x00, 0x00, 0x03, 0x08, 0x06, 0x00, 0x00, 0x01, // data
+        0x81, 0xb0, 0xed, 0xc7, // crc
+        // IDAT chunk (truncated/incomplete zlib stream)
+        0x00, 0x00, 0x00, 0x23, // length
+        0x49, 0x44, 0x41, 0x54, // IHDR
+        0x78, 0x5e, 0x63, 0x64, 0x06, 0x82, 0x01, 0x00, 0x83, 0x8b, // data
+        0x21, 0xcc, 0x47, 0x0d, 0x0a, 0x64, 0x06, 0x89, 0x50, 0x4e, // data
+        0x82, 0x8b, 0x21, 0x47, 0x0d, 0x0a, 0x41, 0x54, 0x78, 0x5e, // data
+        0x63, 0x64, 0x06, 0x89, 0x50, // data
+        0x08, 0x42, 0x67, 0x27, // crc
+        // IEND chunk (to signal end of IDAT/zlib stream)
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+
+    // Initially only the first 80 bytes are available
+    // (after the whole IDAT chunk, but before IEND chunk,
+    // so not far enough to detect the end of IDAT/zlib stream).
+    let (input, mut output) = pipe::create();
+    let (prefix, suffix) = CONTENT.split_at(80);
+    output.write_all(prefix).unwrap();
+
+    // Decoding partial input should result in `UnexpectedEof`.
+    let mut reader = Decoder::new(input).read_info().unwrap();
+    let mut image = vec![0; reader.output_buffer_size().unwrap()];
+    let prefix_result = reader.next_frame(&mut image);
+    let DecodingError::IoError(prefix_err) = prefix_result.unwrap_err() else {
+        panic!("Unexpected error variant");
+    };
+    assert_eq!(prefix_err.kind(), std::io::ErrorKind::UnexpectedEof);
+
+    // Write the remaining input bytes and verify that no error is reported
+    // (i.e. that the remaining `IDAT` payload is ignored).
+    output.write_all(suffix).unwrap();
+    let suffix_result = reader.next_frame(&mut image);
+    assert!(suffix_result.is_ok());
+}
+
+/// Regression test for https://github.com/image-rs/image-png/issues/639
+#[test]
+fn test_partial_decode_success() {
+    // The first 0x8D bytes from the following test image from Skia:
+    // resources/images/apng-test-suite--dispose-ops--none-basic.png
+    let partial_png: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x40, 0x08, 0x06, 0x00, 0x00, 0x00, 0xd2,
+        0xd6, 0x7f, 0x7f, 0x00, 0x00, 0x00, 0x08, 0x61, 0x63, 0x54, 0x4c, 0x00, 0x00, 0x00, 0x03,
+        0x00, 0x00, 0x00, 0x01, 0xb9, 0xea, 0x8a, 0x56, 0x00, 0x00, 0x00, 0x1a, 0x66, 0x63, 0x54,
+        0x4c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x64, 0x00, 0x01, 0x26, 0x12, 0x2f,
+        0xe0, 0x00, 0x00, 0x00, 0x93, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0xed, 0xd2, 0xa1, 0x01,
+        0x00, 0x30, 0x10, 0x84, 0xb0, 0xdb, 0x7f, 0xe9, 0xef, 0x18, 0x15, 0x44, 0xc4, 0x23, 0xd8,
+        0x6d, 0x47, 0xd7, 0x7e, 0x07, 0x60, 0x00, 0x0c, 0x80, 0x01, 0x30, 0x00, 0x06, 0xc0, 0x00,
+        0x18, 0x00, 0x03, 0x60, 0x00, 0x0c,
+    ];
+
+    let mut reader = Decoder::new(std::io::Cursor::new(partial_png))
+        .read_info()
+        .unwrap();
+    let mut row = vec![0; reader.output_buffer_size().unwrap()];
+
+    // The first 10 rows should decode successfully
+    // (even though we only have the first 0x8D bytes of the full PNG).
+    for i in 0..10 {
+        let result = reader.read_row(&mut row);
+        assert!(matches!(result, Ok(_)), "{result:?} at {i}");
+    }
+
+    // Attempting to decode the 11th row should return `UnexpectedEof` error.
+    let result = reader.read_row(&mut row);
+    let DecodingError::IoError(err) = result.unwrap_err() else {
+        panic!("Unexpected error variant");
+    };
+    assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+}


### PR DESCRIPTION
Hello!

This PR fixes https://github.com/image-rs/image-png/issues/639.   This is an alternative approach to @197g's https://github.com/image-rs/image-png/pull/640 - the two main differences are:

* `prev_start: usize` is replaced with `prev_row: PrevRow` where `PrevRow` is an `enum` with separate `None`, `InPlace`, and `Scratch` variants.  I think this results in easier to read code then imposing a special meaning on certain values of offsets (e.g. `self.prev_start == self.curr_start` => no previous row;  or having `self.prev_start` sometimes trail `self.curr_start` by `rowlen-1` and sometimes point to mutable scratch space in the same buffer as `curr_start`).
* There is a test and a fix for consistently detecting errors in the tail portion of zlib stream (see the discussion at https://github.com/image-rs/image-png/pull/640#discussion_r2594273419).  This part may conflict with https://github.com/image-rs/image-png/pull/662 where @fintelia proposes to always ignore the tail zlib bytes (rather than as in this PR, to always decode them to detect errors).  I think I should wait until @fintelia's PR lands, and then rebase on top of it (removing changes in _this_ PR that won't be necessary afterwards).

PTAL?