### PR TITLE
Call `finish` to consistently detect errors in `buf_independent`.

### DIFF
--- a/fuzz/fuzz_targets/buf_independent.rs
+++ b/fuzz/fuzz_targets/buf_independent.rs
@@ -240,6 +240,7 @@ fn test_data<'a>(data: &'a [u8]) -> Result<(), ()> {
                 };
                 retry_after_eofs(eof_controller, || {
                     png_reader.next_frame(buffer.as_mut_slice())
+                        .and_then(|_| png_reader.finish())
                 })
             })
             .assert_all_results_are_consistent()


### PR DESCRIPTION
Fixes https://github.com/image-rs/image-png/issues/666

Thank you @fintelia for pointing out the fix in https://github.com/image-rs/image-png/issues/666#issuecomment-3731712775