### PR TITLE
Add `encoder` and `decoder` features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust: ["1.73.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        features: [""]
+        features: ["", "decoder", "encoder", "decoder,encoder"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
   feature_check:
     strategy:
       matrix:
-        features: ["", "unstable", "benchmarks"]
+        features: ["", "decoder", "encoder", "decoder,encoder", "decoder,encoder,unstable", "decoder,encoder,benchmarks"]
         os: [ubuntu-latest, macos-latest] # macos-latest is ARM
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ rand = "0.9.2"
 criterion = "0.7.0"
 
 [features]
-default = ["encoder"]
+default = ["decoder", "encoder"]
+decoder = []
 encoder = ["flate2"]
 # Use nightly-only features for a minor performance boost in PNG decoding
 unstable = ["crc32fast/nightly"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ bitflags = "2.0"
 crc32fast = "1.2.0"
 fdeflate = "0.3.3"
 flate2 = { version = "1.0.35", optional = true }
-miniz_oxide = { version = "0.8", features = ["simd"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ include = [
 ]
 
 [dependencies]
-bitflags = "2.0"
-crc32fast = "1.2.0"
-fdeflate = "0.3.3"
+bitflags = { version = "2.0", optional = true }
+crc32fast = { version = "1.2.0", optional = true }
+fdeflate = { version = "0.3.3", optional = true }
 flate2 = { version = "1.0.35", optional = true }
 
 [dev-dependencies]
@@ -38,8 +38,8 @@ criterion = "0.7.0"
 
 [features]
 default = ["decoder", "encoder"]
-decoder = []
-encoder = ["flate2"]
+decoder = ["bitflags", "crc32fast", "fdeflate"]
+encoder = ["bitflags", "crc32fast", "fdeflate", "flate2"]
 # Use nightly-only features for a minor performance boost in PNG decoding
 unstable = ["crc32fast/nightly"]
 # Use zlib-rs for faster PNG encoding at the cost of some `unsafe` code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 bitflags = "2.0"
 crc32fast = "1.2.0"
 fdeflate = "0.3.3"
-flate2 = "1.0.35"
+flate2 = { version = "1.0.35", optional = true }
 miniz_oxide = { version = "0.8", features = ["simd"] }
 
 [dev-dependencies]
@@ -38,6 +38,8 @@ rand = "0.9.2"
 criterion = "0.7.0"
 
 [features]
+default = ["encoder"]
+encoder = ["flate2"]
 # Use nightly-only features for a minor performance boost in PNG decoding
 unstable = ["crc32fast/nightly"]
 # Use zlib-rs for faster PNG encoding at the cost of some `unsafe` code.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,27 @@ path = "benches/expand_paletted.rs"
 name = "expand_paletted"
 harness = false
 required-features = ["benchmarks"]
+
+[[test]]
+name = "bugfixes"
+required-features = ["decoder", "encoder"]
+
+[[test]]
+name = "check_testimages"
+required-features = ["decoder", "encoder"]
+
+[[example]]
+name = "change-png-info"
+required-features = ["decoder", "encoder"]
+
+[[example]]
+name = "corpus-bench"
+required-features = ["decoder", "encoder"]
+
+[[example]]
+name = "pngcheck"
+required-features = ["decoder"]
+
+[[example]]
+name = "png-generate"
+required-features = ["encoder"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,8 +6,6 @@ use crate::Filter;
 use crate::{chunk, encoder};
 #[cfg(feature = "encoder")]
 use io::Write;
-#[cfg(feature = "decoder")]
-use std::convert::TryFrom;
 #[cfg(feature = "encoder")]
 use std::io;
 use std::{borrow::Cow, fmt};

--- a/src/decoder/interlace_info.rs
+++ b/src/decoder/interlace_info.rs
@@ -121,7 +121,7 @@ mod test {
         assert_eq!(
             InterlaceInfoIter::empty()
                 .map(|info| info.line_number())
-                .collect::<Vec<_>>(),
+                .collect::<Vec<u32>>(),
             vec![],
         );
     }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -2288,6 +2288,7 @@ mod tests {
         assert_eq!(4070462061, crc32fast::hash(&icc_profile));
     }
 
+    #[cfg(feature = "encoder")]
     #[test]
     fn test_iccp_roundtrip() {
         let dummy_icc = b"I'm a profile";
@@ -2305,6 +2306,7 @@ mod tests {
         assert_eq!(dummy_icc, &**dec.info().icc_profile.as_ref().unwrap());
     }
 
+    #[cfg(feature = "encoder")]
     #[test]
     fn test_phys_roundtrip() {
         let mut info = crate::Info::with_size(1, 1);
@@ -2327,6 +2329,7 @@ mod tests {
         assert_eq!(phys.unit, Unit::Meter);
     }
 
+    #[cfg(feature = "encoder")]
     #[test]
     fn test_srgb_roundtrip() {
         let mut info = crate::Info::with_size(1, 1);

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::error;
 use std::fmt;
 use std::io;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1775,6 +1775,7 @@ impl<W: Write> Drop for StreamWriter<'_, W> {
     }
 }
 
+#[cfg(feature = "decoder")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -657,8 +657,6 @@ impl<W: Write> Writer<W> {
     /// the length of `data` can't be parsed as a `u32` though the length of the chunk data should
     /// not exceed `i32::MAX` or 2,147,483,647.
     pub fn write_chunk(&mut self, name: ChunkType, data: &[u8]) -> Result<()> {
-        use std::convert::TryFrom;
-
         if u32::try_from(data.len()).map_or(true, |length| length > i32::MAX as u32) {
             let kind = FormatErrorKind::WrittenTooMuch(data.len() - i32::MAX as usize);
             return Err(EncodingError::Format(kind.into()));

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,6 +1,8 @@
 use core::convert::TryInto;
 
-use crate::{common::BytesPerPixel, Compression};
+use crate::common::BytesPerPixel;
+#[cfg(feature = "encoder")]
+use crate::Compression;
 
 mod paeth;
 
@@ -46,6 +48,7 @@ impl From<RowFilter> for Filter {
     }
 }
 
+#[cfg(feature = "encoder")]
 impl Filter {
     pub(crate) fn from_simple(compression: Compression) -> Self {
         match compression {
@@ -87,6 +90,7 @@ impl RowFilter {
         }
     }
 
+    #[cfg(feature = "encoder")]
     pub fn from_method(strat: Filter) -> Option<Self> {
         match strat {
             Filter::NoFilter => Some(Self::NoFilter),
@@ -358,6 +362,7 @@ pub(crate) fn unfilter(
     }
 }
 
+#[cfg(feature = "encoder")]
 fn filter_internal(
     method: RowFilter,
     bpp: usize,
@@ -497,6 +502,7 @@ fn filter_internal(
     }
 }
 
+#[cfg(feature = "encoder")]
 fn adaptive_filter(
     f: impl Fn(&[u8]) -> u64,
     bpp: usize,
@@ -527,6 +533,7 @@ fn adaptive_filter(
     filter_choice
 }
 
+#[cfg(feature = "encoder")]
 pub(crate) fn filter(
     method: Filter,
     bpp: BytesPerPixel,
@@ -549,11 +556,13 @@ pub(crate) fn filter(
 
 /// Estimate the value of i * log2(i) without using floating point operations,
 /// implementation originally from oxipng.
+#[cfg(feature = "encoder")]
 fn ilog2i(i: u32) -> u32 {
     let log = 32 - i.leading_zeros() - 1;
     i * log + ((i - (1 << log)) << 1)
 }
 
+#[cfg(feature = "encoder")]
 fn entropy(buf: &[u8]) -> u64 {
     let mut counts = [[0_u32; 256]; 4];
     let mut total = 0;
@@ -602,6 +611,7 @@ fn entropy(buf: &[u8]) -> u64 {
 }
 
 // Helper function for Adaptive filter buffer summation
+#[cfg(feature = "encoder")]
 fn sum_buffer(buf: &[u8]) -> u64 {
     const CHUNK_SIZE: usize = 32;
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "decoder")]
-use core::convert::TryInto;
-
 use crate::common::BytesPerPixel;
 #[cfg(feature = "encoder")]
 use crate::Compression;

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -640,6 +640,7 @@ mod test {
     use super::*;
     use core::iter;
 
+    #[cfg(all(feature = "decoder", feature = "encoder"))]
     #[test]
     fn roundtrip() {
         // A multiple of 8, 6, 4, 3, 2, 1
@@ -683,6 +684,7 @@ mod test {
         }
     }
 
+    #[cfg(all(feature = "decoder", feature = "encoder"))]
     #[test]
     fn roundtrip_ascending_previous_line() {
         // A multiple of 8, 6, 4, 3, 2, 1
@@ -726,6 +728,7 @@ mod test {
         }
     }
 
+    #[cfg(feature = "encoder")]
     #[test]
     // This tests that converting u8 to i8 doesn't overflow when taking the
     // absolute value for adaptive filtering: -128_i8.abs() will panic in debug

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "decoder")]
 use core::convert::TryInto;
 
 use crate::common::BytesPerPixel;
@@ -79,6 +80,7 @@ impl Default for RowFilter {
 }
 
 impl RowFilter {
+    #[cfg(feature = "decoder")]
     pub fn from_u8(n: u8) -> Option<Self> {
         match n {
             0 => Some(Self::NoFilter),
@@ -103,6 +105,7 @@ impl RowFilter {
     }
 }
 
+#[cfg(feature = "decoder")]
 pub(crate) fn unfilter(
     mut filter: RowFilter,
     tbpp: BytesPerPixel,

--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -385,6 +385,8 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
 mod tests {
     use super::*;
 
+    #[cfg(all(feature = "decoder", feature = "encoder"))]
+    #[cfg(target_arch = "x86_64")]
     #[test]
     #[ignore] // takes ~20s without optimizations
     fn paeth_impls_are_equivalent() {

--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "decoder")]
 use crate::BytesPerPixel;
 
 // This code path is used on non-x86_64 architectures but we allow dead code
@@ -25,6 +26,8 @@ pub(super) fn filter_paeth(a: u8, b: u8, c: u8) -> u8 {
     out
 }
 
+#[cfg(feature = "decoder")]
+#[cfg(target_arch = "x86_64")]
 pub(super) fn filter_paeth_stbi(a: i16, b: i16, c: i16) -> u8 {
     // Decoding optimizes better with this algorithm than with `filter_paeth`
     //
@@ -84,6 +87,7 @@ pub(super) fn filter_paeth_fpnge(a: u8, b: u8, c: u8) -> u8 {
     }
 }
 
+#[cfg(feature = "decoder")]
 #[allow(unreachable_code)]
 #[cfg(not(target_arch = "x86_64"))]
 pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8]) {
@@ -217,6 +221,7 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
 /// The x86_64 functions avoid casting between u8xN and i16xN SIMD
 /// representations when possible by maintaining [i16; BPP] arrays
 /// between iterations instead of [u8; BPP].
+#[cfg(feature = "decoder")]
 #[allow(unreachable_code)]
 #[cfg(target_arch = "x86_64")]
 pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8]) {

--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -42,6 +42,7 @@ pub(super) fn filter_paeth_stbi(a: i16, b: i16, c: i16) -> u8 {
     t1 as u8
 }
 
+#[cfg(feature = "encoder")]
 pub(super) fn filter_paeth_fpnge(a: u8, b: u8, c: u8) -> u8 {
     // This is an optimized version of the paeth filter from the PNG specification, proposed by
     // Luca Versari for [FPNGE](https://www.lucaversari.it/FJXL_and_FPNGE.pdf). It operates

--- a/src/filter/simd.rs
+++ b/src/filter/simd.rs
@@ -1,6 +1,5 @@
 ///! Optional module containing `portable_simd` versions of the most
 ///! important unfiltering algorithms. Enable using the `unstable` feature.
-use core::convert::TryInto;
 use core::simd::cmp::{SimdOrd, SimdPartialOrd};
 use core::simd::num::{SimdInt, SimdUint};
 use core::simd::{LaneCount, Simd, SupportedLaneCount};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,15 +70,21 @@
 
 #[cfg(feature = "decoder")]
 mod adam7;
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 pub mod chunk;
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 mod common;
 #[cfg(feature = "decoder")]
 mod decoder;
 #[cfg(feature = "encoder")]
 mod encoder;
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 mod filter;
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 mod srgb;
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 pub mod text_metadata;
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 mod traits;
 
 #[cfg(feature = "decoder")]
@@ -88,6 +94,7 @@ pub use crate::adam7::{
 
 #[cfg(feature = "decoder")]
 pub use crate::adam7::{Adam7Info, Adam7Variant};
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 pub use crate::common::*;
 #[cfg(feature = "decoder")]
 pub use crate::decoder::stream::{DecodeOptions, Decoded, DecodingError, StreamingDecoder};
@@ -97,10 +104,13 @@ pub use crate::decoder::{Decoder, InterlaceInfo, InterlacedRow, Limits, OutputIn
 pub use crate::decoder::{UnfilterBuf, UnfilterRegion};
 #[cfg(feature = "encoder")]
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 pub use crate::filter::Filter;
 
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+#[cfg(any(feature = "decoder", feature = "encoder"))]
 #[cfg(feature = "benchmarks")]
 pub mod benchable_apis;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ mod adam7;
 pub mod chunk;
 mod common;
 mod decoder;
+#[cfg(feature = "encoder")]
 mod encoder;
 mod filter;
 mod srgb;
@@ -87,6 +88,7 @@ pub use crate::common::*;
 pub use crate::decoder::stream::{DecodeOptions, Decoded, DecodingError, StreamingDecoder};
 pub use crate::decoder::{Decoder, InterlaceInfo, InterlacedRow, Limits, OutputInfo, Reader};
 pub use crate::decoder::{UnfilterBuf, UnfilterRegion};
+#[cfg(feature = "encoder")]
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
 pub use crate::filter::Filter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
 //! image data is reached.
 //!
 //! ### Using the decoder
-//! ```
+#![cfg_attr(feature = "decoder", doc = "```")]
+#![cfg_attr(not(feature = "decoder"), doc = "```ignore")]
 //! use std::fs::File;
 //! use std::io::BufReader;
 //! // The decoder is a build for reader and can be used to set various decoding options
@@ -30,7 +31,8 @@
 //! ## Encoder
 //! ### Using the encoder
 //!
-//! ```no_run
+#![cfg_attr(feature = "encoder", doc = "```no_run")]
+#![cfg_attr(not(feature = "encoder"), doc = " ```no_run,ignore")]
 //! // For reading and opening files
 //! use std::path::Path;
 //! use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,11 @@
 #![allow(clippy::uninlined_format_args)]
 #![cfg_attr(feature = "unstable", feature(portable_simd))]
 
+#[cfg(feature = "decoder")]
 mod adam7;
 pub mod chunk;
 mod common;
+#[cfg(feature = "decoder")]
 mod decoder;
 #[cfg(feature = "encoder")]
 mod encoder;
@@ -79,14 +81,19 @@ mod srgb;
 pub mod text_metadata;
 mod traits;
 
+#[cfg(feature = "decoder")]
 pub use crate::adam7::{
     expand_pass as expand_interlaced_row, expand_pass_splat as splat_interlaced_row,
 };
 
+#[cfg(feature = "decoder")]
 pub use crate::adam7::{Adam7Info, Adam7Variant};
 pub use crate::common::*;
+#[cfg(feature = "decoder")]
 pub use crate::decoder::stream::{DecodeOptions, Decoded, DecodingError, StreamingDecoder};
+#[cfg(feature = "decoder")]
 pub use crate::decoder::{Decoder, InterlaceInfo, InterlacedRow, Limits, OutputInfo, Reader};
+#[cfg(feature = "decoder")]
 pub use crate::decoder::{UnfilterBuf, UnfilterRegion};
 #[cfg(feature = "encoder")]
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -98,9 +98,11 @@
 
 #![warn(missing_docs)]
 
+#[cfg(feature = "decoder")]
 use crate::DecodingError;
 #[cfg(feature = "encoder")]
 use crate::{chunk, encoder, EncodingError};
+#[cfg(feature = "decoder")]
 use fdeflate::BoundedDecompressionError;
 #[cfg(feature = "encoder")]
 use flate2::write::ZlibEncoder;
@@ -125,6 +127,7 @@ pub(crate) enum TextEncodingError {
 }
 
 /// Text decoding error that is wrapped by the standard DecodingError type
+#[cfg(feature = "decoder")]
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum TextDecodingError {
     /// Unrepresentable characters in string
@@ -161,6 +164,7 @@ pub struct TEXtChunk {
     pub text: String,
 }
 
+#[cfg(feature = "decoder")]
 fn decode_iso_8859_1(text: &[u8]) -> String {
     text.iter().map(|&b| b as char).collect()
 }
@@ -184,6 +188,7 @@ fn encode_iso_8859_1_iter(text: &str) -> impl Iterator<Item = Result<u8, TextEnc
         .map(|c| u8::try_from(c as u32).map_err(|_| TextEncodingError::Unrepresentable))
 }
 
+#[cfg(feature = "decoder")]
 fn decode_ascii(text: &[u8]) -> Result<&str, TextDecodingError> {
     if text.is_ascii() {
         // `from_utf8` cannot panic because we're already checked that `text` is ASCII-7.
@@ -206,6 +211,7 @@ impl TEXtChunk {
 
     /// Decodes a slice of bytes to a String using Latin-1 decoding.
     /// The decoder runs in strict mode, and any decoding errors are passed along to the caller.
+    #[cfg(feature = "decoder")]
     pub(crate) fn decode(
         keyword_slice: &[u8],
         text_slice: &[u8],
@@ -266,6 +272,7 @@ impl ZTXtChunk {
         }
     }
 
+    #[cfg(feature = "decoder")]
     pub(crate) fn decode(
         keyword_slice: &[u8],
         compression_method: u8,
@@ -286,11 +293,13 @@ impl ZTXtChunk {
     }
 
     /// Decompresses the inner text, mutating its own state. Can only handle decompressed text up to `DECOMPRESSION_LIMIT` bytes.
+    #[cfg(feature = "decoder")]
     pub fn decompress_text(&mut self) -> Result<(), DecodingError> {
         self.decompress_text_with_limit(DECOMPRESSION_LIMIT)
     }
 
     /// Decompresses the inner text, mutating its own state. Can only handle decompressed text up to `limit` bytes.
+    #[cfg(feature = "decoder")]
     pub fn decompress_text_with_limit(&mut self, limit: usize) -> Result<(), DecodingError> {
         match &self.text {
             OptCompressed::Compressed(v) => {
@@ -314,6 +323,7 @@ impl ZTXtChunk {
 
     /// Decompresses the inner text, and returns it as a `String`.
     /// If decompression uses more the 2MiB, first call decompress with limit, and then this method.
+    #[cfg(feature = "decoder")]
     pub fn get_text(&self) -> Result<String, DecodingError> {
         match &self.text {
             OptCompressed::Compressed(v) => {
@@ -411,6 +421,7 @@ impl ITXtChunk {
         }
     }
 
+    #[cfg(feature = "decoder")]
     pub(crate) fn decode(
         keyword_slice: &[u8],
         compression_flag: u8,
@@ -458,11 +469,13 @@ impl ITXtChunk {
     }
 
     /// Decompresses the inner text, mutating its own state. Can only handle decompressed text up to `DECOMPRESSION_LIMIT` bytes.
+    #[cfg(feature = "decoder")]
     pub fn decompress_text(&mut self) -> Result<(), DecodingError> {
         self.decompress_text_with_limit(DECOMPRESSION_LIMIT)
     }
 
     /// Decompresses the inner text, mutating its own state. Can only handle decompressed text up to `limit` bytes.
+    #[cfg(feature = "decoder")]
     pub fn decompress_text_with_limit(&mut self, limit: usize) -> Result<(), DecodingError> {
         match &self.text {
             OptCompressed::Compressed(v) => {
@@ -489,6 +502,7 @@ impl ITXtChunk {
 
     /// Decompresses the inner text, and returns it as a `String`.
     /// If decompression takes more than 2 MiB, try `decompress_text_with_limit` followed by this method.
+    #[cfg(feature = "decoder")]
     pub fn get_text(&self) -> Result<String, DecodingError> {
         match &self.text {
             OptCompressed::Compressed(v) => {

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -22,7 +22,8 @@
 //!  `compressed_latin1_text`, and the `utf8_text` fields depending on whether the encountered
 //!  chunk is `tEXt`, `zTXt`, or `iTXt`.
 //!
-//!  ```
+#![cfg_attr(feature = "decoder", doc = " ```")]
+#![cfg_attr(not(feature = "decoder"), doc = " ```ignore")]
 //!  use std::fs::File;
 //!  use std::io::BufReader;
 //!  use std::path::PathBuf;
@@ -46,7 +47,8 @@
 //!  There are two ways to write text chunks: the first is to add the appropriate text structs directly to the encoder header before the header is written to file.
 //!  To add a text chunk at any point in the stream, use the `write_text_chunk` method.
 //!
-//!  ```
+#![cfg_attr(feature = "encoder", doc = " ```")]
+#![cfg_attr(not(feature = "encoder"), doc = " ```ignore")]
 //!  # use png::text_metadata::{ITXtChunk, ZTXtChunk};
 //!  # use std::env;
 //!  # use std::fs::File;

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -25,7 +25,6 @@
 //!  ```
 //!  use std::fs::File;
 //!  use std::io::BufReader;
-//!  use std::iter::FromIterator;
 //!  use std::path::PathBuf;
 //!
 //!  // Opening a png file that has a zTXt chunk
@@ -52,7 +51,6 @@
 //!  # use std::env;
 //!  # use std::fs::File;
 //!  # use std::io::BufWriter;
-//!  # use std::iter::FromIterator;
 //!  # use std::path::PathBuf;
 //!  # let file = File::create(PathBuf::from_iter(["target", "text_chunk.png"])).unwrap();
 //!  # let ref mut w = BufWriter::new(file);
@@ -109,7 +107,7 @@ use flate2::write::ZlibEncoder;
 #[cfg(feature = "encoder")]
 use flate2::Compression;
 #[cfg(feature = "encoder")]
-use std::{convert::TryFrom, io::Write};
+use std::io::Write;
 
 /// Default decompression limit for compressed text chunks.
 pub const DECOMPRESSION_LIMIT: usize = 2097152; // 2 MiB

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -13,6 +13,7 @@ macro_rules! read_bytes_ext {
     };
 }
 
+#[cfg(feature = "encoder")]
 macro_rules! write_bytes_ext {
     ($input_type:ty) => {
         impl<W: io::Write + ?Sized> WriteBytesExt<$input_type> for W {
@@ -31,6 +32,7 @@ pub trait ReadBytesExt<T>: io::Read {
 }
 
 /// Write extension to write big endian data
+#[cfg(feature = "encoder")]
 pub trait WriteBytesExt<T>: io::Write {
     /// Writes `T` to a bytes stream. Most significant byte first.
     fn write_be(&mut self, _: T) -> io::Result<()>;
@@ -40,4 +42,5 @@ read_bytes_ext!(u8);
 read_bytes_ext!(u16);
 read_bytes_ext!(u32);
 
+#[cfg(feature = "encoder")]
 write_bytes_ext!(u32);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,6 @@
 use std::io;
 
+#[cfg(feature = "decoder")]
 macro_rules! read_bytes_ext {
     ($output_type:ty) => {
         impl<W: io::Read + ?Sized> ReadBytesExt<$output_type> for W {
@@ -26,6 +27,7 @@ macro_rules! write_bytes_ext {
 }
 
 /// Read extension to read big endian data
+#[cfg(feature = "decoder")]
 pub trait ReadBytesExt<T>: io::Read {
     /// Read `T` from a bytes stream. Most significant byte first.
     fn read_be(&mut self) -> io::Result<T>;
@@ -38,8 +40,11 @@ pub trait WriteBytesExt<T>: io::Write {
     fn write_be(&mut self, _: T) -> io::Result<()>;
 }
 
+#[cfg(feature = "decoder")]
 read_bytes_ext!(u8);
+#[cfg(feature = "decoder")]
 read_bytes_ext!(u16);
+#[cfg(feature = "decoder")]
 read_bytes_ext!(u32);
 
 #[cfg(feature = "encoder")]


### PR DESCRIPTION
This allows applications which only want to decode PNGs, or to encode PNGs, to not embed code for the direction they don’t need, with a compile-time error if neither are enabled.

On my i5-8350U, in release mode, current master builds in 1.55s, with only the `decoder` feature it builds in 1.13s, and with only the `encoder` feature in 0.68s.

On my iBook G4, still in release mode, the improvements are much more dramatic, a full build of `png` that would previously take 2:13 and 11 units, goes down to 1:16 and 8 units with only the `decoder` feature enabled, since it doesn’t build the `flate2` crate and its dependencies.  With just the `encoder` feature it takes 1:40, which is also much better on this slow CPU. :)

I’ve also cleaned up extra imports already present in the prelude since edition 2021, and removed the now-indirect `miniz_oxide` dependency.

This PR is best reviewed commit-per-commit.

Edit: I still need help to get the docstring tests to only run if the relevant feature is enabled, I couldn’t figure out how to do that so far.

Edit 2: Do we want to also test for only-encoder and only-decoder configurations now, and disable no-default-features checks as that means nothing?