### PR TITLE
feat: Add option to keep unknown chunks during decoding

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,7 @@
 use crate::text_metadata::{ITXtChunk, TEXtChunk, ZTXtChunk};
 #[allow(unused_imports)] // used by doc comments only
 use crate::Filter;
-use crate::{chunk, encoder};
+use crate::{chunk, chunk::ChunkType, encoder};
 use io::Write;
 use std::{borrow::Cow, convert::TryFrom, fmt, io};
 
@@ -645,6 +645,13 @@ pub struct ContentLightLevelInfo {
     pub max_frame_average_light_level: u32,
 }
 
+/// A chunk that was not parsed by the decoder.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnknownChunk {
+    pub name: ChunkType,
+    pub data: Vec<u8>,
+}
+
 /// PNG info struct
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -701,6 +708,8 @@ pub struct Info<'a> {
     pub compressed_latin1_text: Vec<ZTXtChunk>,
     /// iTXt field
     pub utf8_text: Vec<ITXtChunk>,
+    /// Unknown chunks
+    pub unknown_chunks: Vec<UnknownChunk>,
 }
 
 impl Default for Info<'_> {
@@ -732,6 +741,7 @@ impl Default for Info<'_> {
             uncompressed_latin1_text: Vec::new(),
             compressed_latin1_text: Vec::new(),
             utf8_text: Vec::new(),
+            unknown_chunks: Vec::new(),
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -645,9 +645,9 @@ pub struct ContentLightLevelInfo {
     pub max_frame_average_light_level: u32,
 }
 
-/// A chunk that was not parsed by the decoder.
+/// A chunk that was captured (and not parsed) by the decoder.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct UnknownChunk {
+pub struct CapturedChunk {
     pub name: ChunkType,
     pub data: Vec<u8>,
 }
@@ -708,8 +708,8 @@ pub struct Info<'a> {
     pub compressed_latin1_text: Vec<ZTXtChunk>,
     /// iTXt field
     pub utf8_text: Vec<ITXtChunk>,
-    /// Unknown chunks
-    pub unknown_chunks: Vec<UnknownChunk>,
+    /// Captured chunks
+    pub captured_chunks: Vec<CapturedChunk>,
 }
 
 impl Default for Info<'_> {
@@ -741,7 +741,7 @@ impl Default for Info<'_> {
             uncompressed_latin1_text: Vec::new(),
             compressed_latin1_text: Vec::new(),
             utf8_text: Vec::new(),
-            unknown_chunks: Vec::new(),
+            captured_chunks: Vec::new(),
         }
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -645,7 +645,7 @@ pub struct ContentLightLevelInfo {
     pub max_frame_average_light_level: u32,
 }
 
-/// A chunk that was captured (and not parsed) by the decoder.
+/// A chunk that was captured by the decoder.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CapturedChunk {
     pub name: ChunkType,
@@ -960,6 +960,8 @@ pub(crate) enum ParameterErrorKind {
     /// [`DecodingError::Format`]).  The only case when it is possible to resume after an error
     /// is an `UnexpectedEof` scenario - see [`DecodingError::IoError`].
     PolledAfterFatalError,
+    /// Critical chunks cannot be captured when decoding.
+    CannotCaptureCriticalChunk,
 }
 
 impl From<ParameterErrorKind> for ParameterError {
@@ -978,6 +980,9 @@ impl fmt::Display for ParameterError {
             PolledAfterEndOfImage => write!(fmt, "End of image has been reached"),
             PolledAfterFatalError => {
                 write!(fmt, "A fatal decoding error has been encounted earlier")
+            }
+            CannotCaptureCriticalChunk => {
+                write!(fmt, "Critical chunks cannot be captured")
             }
         }
     }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -13,7 +13,7 @@ use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
 use crate::common::{
     AnimationControl, BitDepth, BlendOp, ColorType, ContentLightLevelInfo, DisposeOp, FrameControl,
     Info, MasteringDisplayColorVolume, ParameterError, ParameterErrorKind, PixelDimensions,
-    ScaledFloat, SourceChromaticities, Unit,
+    ScaledFloat, SourceChromaticities, Unit, UnknownChunk,
 };
 use crate::text_metadata::{decode_iso_8859_1, ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk};
 use crate::traits::ReadBytesExt;
@@ -469,6 +469,7 @@ pub struct DecodeOptions {
     ignore_text_chunk: bool,
     ignore_iccp_chunk: bool,
     skip_ancillary_crc_failures: bool,
+    keep_unknown_chunks: bool,
 }
 
 impl Default for DecodeOptions {
@@ -479,6 +480,7 @@ impl Default for DecodeOptions {
             ignore_text_chunk: false,
             ignore_iccp_chunk: false,
             skip_ancillary_crc_failures: true,
+            keep_unknown_chunks: false,
         }
     }
 }
@@ -524,6 +526,13 @@ impl DecodeOptions {
     /// Defaults to `true`
     pub fn set_skip_ancillary_crc_failures(&mut self, skip_ancillary_crc_failures: bool) {
         self.skip_ancillary_crc_failures = skip_ancillary_crc_failures;
+    }
+
+    /// When set, the decoder will keep unknown chunks in the `Info` struct.
+    ///
+    /// Defaults to `false`.
+    pub fn set_keep_unknown_chunks(&mut self, keep_unknown_chunks: bool) {
+        self.keep_unknown_chunks = keep_unknown_chunks;
     }
 }
 
@@ -1068,7 +1077,11 @@ impl StreamingDecoder {
                 ));
             }
             _ => {
-                self.current_chunk.action = ChunkAction::Skip;
+                if self.decode_options.keep_unknown_chunks {
+                    self.current_chunk.action = ChunkAction::Process;
+                } else {
+                    self.current_chunk.action = ChunkAction::Skip;
+                }
                 return Ok(State::ReadChunkData(type_str));
             }
         };
@@ -1126,6 +1139,7 @@ impl StreamingDecoder {
             chunk::iTXt => self.parse_itxt(),
 
             // Unrecognized chunks.
+            _ if self.decode_options.keep_unknown_chunks => self.parse_unknown(type_str),
             _ => unreachable!(
                 "Unrecognized chunk {type_str:?} should have been caught in start_chunk"
             ),
@@ -1921,6 +1935,20 @@ impl StreamingDecoder {
         Ok(())
     }
 
+    fn parse_unknown(&mut self, type_str: ChunkType) -> Result<(), DecodingError> {
+        self.limits
+            .reserve_bytes(self.current_chunk.raw_bytes.len())?;
+        self.info
+            .as_mut()
+            .unwrap()
+            .unknown_chunks
+            .push(UnknownChunk {
+                name: type_str,
+                data: self.current_chunk.raw_bytes.clone(),
+            });
+        Ok(())
+    }
+
     fn parse_bkgd(&mut self) -> Result<(), DecodingError> {
         let info = self.info.as_mut().unwrap();
         if info.bkgd.is_some() {
@@ -2013,8 +2041,12 @@ impl Default for StreamingDecoder {
 mod tests {
     use super::ScaledFloat;
     use super::SourceChromaticities;
+    use crate::chunk::ChunkType;
     use crate::test_utils::*;
-    use crate::{Decoder, DecodingError, Reader, SrgbRenderingIntent, Unit};
+    use crate::{
+        DecodeOptions, Decoder, DecodingError, Limits, Reader, SrgbRenderingIntent, Unit,
+        UnknownChunk,
+    };
     use approx::assert_relative_eq;
     use byteorder::WriteBytesExt;
     use std::borrow::Cow;
@@ -3394,5 +3426,105 @@ mod tests {
         };
         assert_eq!(actl.num_frames, 2);
         assert_eq!(actl.num_plays, 123);
+    }
+
+    #[test]
+    fn test_unknown_chunks_disabled() {
+        let width = 16;
+        let mut png = Vec::new();
+        write_png_sig(&mut png);
+        write_rgba8_ihdr_with_width(&mut png, width);
+        write_chunk(&mut png, b"uNKn", b"hello world");
+        write_chunk(
+            &mut png,
+            b"IDAT",
+            &generate_rgba8_with_width_and_height(width, width),
+        );
+        write_iend(&mut png);
+
+        let reader = Decoder::new(Cursor::new(png)).read_info().unwrap();
+        assert_eq!(reader.info().unknown_chunks.len(), 0);
+    }
+
+    #[test]
+    fn test_unknown_chunks_preserved() {
+        let width = 16;
+        let mut png = Vec::new();
+        write_png_sig(&mut png);
+        write_rgba8_ihdr_with_width(&mut png, width);
+        write_chunk(&mut png, b"uNK1", b"data1");
+        write_chunk(&mut png, b"uNK2", b"data2");
+        write_chunk(
+            &mut png,
+            b"IDAT",
+            &generate_rgba8_with_width_and_height(width, width),
+        );
+        write_iend(&mut png);
+
+        let mut options = DecodeOptions::default();
+        options.set_keep_unknown_chunks(true);
+        let reader = Decoder::new_with_options(Cursor::new(png), options)
+            .read_info()
+            .unwrap();
+        assert_eq!(
+            reader.info().unknown_chunks,
+            vec![
+                UnknownChunk {
+                    name: ChunkType(*b"uNK1"),
+                    data: b"data1".to_vec()
+                },
+                UnknownChunk {
+                    name: ChunkType(*b"uNK2"),
+                    data: b"data2".to_vec()
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn test_unknown_chunks_limits_exceeded() {
+        let width = 16;
+        let mut png = Vec::new();
+        write_png_sig(&mut png);
+        write_rgba8_ihdr_with_width(&mut png, width);
+        write_chunk(&mut png, b"uNKn", b"long data that exceeds limits");
+        write_chunk(
+            &mut png,
+            b"IDAT",
+            &generate_rgba8_with_width_and_height(width, width),
+        );
+        write_iend(&mut png);
+
+        let mut options = DecodeOptions::default();
+        options.set_keep_unknown_chunks(true);
+        let mut decoder = Decoder::new_with_options(Cursor::new(png), options);
+        // Set a limit lower than the unknown chunk data size (29 bytes)
+        decoder.set_limits(Limits { bytes: 10 });
+        let result = decoder.read_info();
+        assert!(matches!(result, Err(DecodingError::LimitsExceeded)));
+    }
+
+    #[test]
+    fn test_critical_unknown_chunk() {
+        let width = 16;
+        let mut png = Vec::new();
+        write_png_sig(&mut png);
+        write_rgba8_ihdr_with_width(&mut png, width);
+        // The first letter is uppercase, making it a critical chunk.
+        write_chunk(&mut png, b"UNKn", b"critical data");
+        write_chunk(
+            &mut png,
+            b"IDAT",
+            &generate_rgba8_with_width_and_height(width, width),
+        );
+        write_iend(&mut png);
+
+        let mut options = DecodeOptions::default();
+        options.set_keep_unknown_chunks(true);
+        let result = Decoder::new_with_options(Cursor::new(png), options).read_info();
+        assert!(matches!(result, Err(DecodingError::Format(_))));
+        let err = result.err().unwrap().to_string();
+        assert!(err.contains("Unrecognized critical chunk"));
+        assert!(err.contains("UNKn"));
     }
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -11,9 +11,9 @@ use super::zlib::ZlibStream;
 use crate::chunk::is_critical;
 use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
 use crate::common::{
-    AnimationControl, BitDepth, BlendOp, ColorType, ContentLightLevelInfo, DisposeOp, FrameControl,
-    Info, MasteringDisplayColorVolume, ParameterError, ParameterErrorKind, PixelDimensions,
-    ScaledFloat, SourceChromaticities, Unit, UnknownChunk,
+    AnimationControl, BitDepth, BlendOp, CapturedChunk, ColorType, ContentLightLevelInfo,
+    DisposeOp, FrameControl, Info, MasteringDisplayColorVolume, ParameterError, ParameterErrorKind,
+    PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
 };
 use crate::text_metadata::{decode_iso_8859_1, ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk};
 use crate::traits::ReadBytesExt;
@@ -469,7 +469,7 @@ pub struct DecodeOptions {
     ignore_text_chunk: bool,
     ignore_iccp_chunk: bool,
     skip_ancillary_crc_failures: bool,
-    keep_unknown_chunks: bool,
+    captured_chunks: Vec<ChunkType>,
 }
 
 impl Default for DecodeOptions {
@@ -480,7 +480,7 @@ impl Default for DecodeOptions {
             ignore_text_chunk: false,
             ignore_iccp_chunk: false,
             skip_ancillary_crc_failures: true,
-            keep_unknown_chunks: false,
+            captured_chunks: Vec::new(),
         }
     }
 }
@@ -528,11 +528,18 @@ impl DecodeOptions {
         self.skip_ancillary_crc_failures = skip_ancillary_crc_failures;
     }
 
-    /// When set, the decoder will keep unknown chunks in the `Info` struct.
+    /// Sets the list of chunks to be captured.
     ///
-    /// Defaults to `false`.
-    pub fn set_keep_unknown_chunks(&mut self, keep_unknown_chunks: bool) {
-        self.keep_unknown_chunks = keep_unknown_chunks;
+    /// Captured chunks will be skipped by the decoder and their raw data will be stored in the
+    /// `captured_chunks` field of the `Info` struct.
+    ///
+    /// This applies even to chunks that are recognized by the decoder and critical chunks.
+    /// Doing so may cause the decoding to fail if the chunk is strictly required by the PNG
+    /// specification.
+    ///
+    /// Defaults to `&[]`.
+    pub fn set_captured_chunks(&mut self, names: &[ChunkType]) {
+        self.captured_chunks = names.to_vec();
     }
 }
 
@@ -1045,6 +1052,11 @@ impl StreamingDecoder {
     }
 
     fn start_chunk(&mut self, type_str: ChunkType, length: u32) -> Result<State, DecodingError> {
+        if self.decode_options.captured_chunks.contains(&type_str) {
+            self.current_chunk.action = ChunkAction::Process;
+            return Ok(State::ReadChunkData(type_str));
+        }
+
         let target_length = match type_str {
             IHDR => 13..=13,
             chunk::PLTE => 3..=768,
@@ -1077,11 +1089,7 @@ impl StreamingDecoder {
                 ));
             }
             _ => {
-                if self.decode_options.keep_unknown_chunks {
-                    self.current_chunk.action = ChunkAction::Process;
-                } else {
-                    self.current_chunk.action = ChunkAction::Skip;
-                }
+                self.current_chunk.action = ChunkAction::Skip;
                 return Ok(State::ReadChunkData(type_str));
             }
         };
@@ -1108,6 +1116,9 @@ impl StreamingDecoder {
 
     fn parse_chunk(&mut self, type_str: ChunkType) -> Result<Decoded, DecodingError> {
         let mut parse_result = match type_str {
+            type_str if self.decode_options.captured_chunks.contains(&type_str) => {
+                self.parse_captured(type_str)
+            }
             // Critical non-data chunks.
             IHDR => self.parse_ihdr(),
             chunk::PLTE => self.parse_plte(),
@@ -1139,7 +1150,6 @@ impl StreamingDecoder {
             chunk::iTXt => self.parse_itxt(),
 
             // Unrecognized chunks.
-            _ if self.decode_options.keep_unknown_chunks => self.parse_unknown(type_str),
             _ => unreachable!(
                 "Unrecognized chunk {type_str:?} should have been caught in start_chunk"
             ),
@@ -1755,6 +1765,20 @@ impl StreamingDecoder {
         Ok(())
     }
 
+    fn parse_captured(&mut self, type_str: ChunkType) -> Result<(), DecodingError> {
+        self.limits
+            .reserve_bytes(self.current_chunk.raw_bytes.len())?;
+        self.info
+            .as_mut()
+            .unwrap()
+            .captured_chunks
+            .push(CapturedChunk {
+                name: type_str,
+                data: self.current_chunk.raw_bytes.clone(),
+            });
+        Ok(())
+    }
+
     fn parse_ihdr(&mut self) -> Result<(), DecodingError> {
         if self.info.is_some() {
             return Err(DecodingError::Format(
@@ -1935,20 +1959,6 @@ impl StreamingDecoder {
         Ok(())
     }
 
-    fn parse_unknown(&mut self, type_str: ChunkType) -> Result<(), DecodingError> {
-        self.limits
-            .reserve_bytes(self.current_chunk.raw_bytes.len())?;
-        self.info
-            .as_mut()
-            .unwrap()
-            .unknown_chunks
-            .push(UnknownChunk {
-                name: type_str,
-                data: self.current_chunk.raw_bytes.clone(),
-            });
-        Ok(())
-    }
-
     fn parse_bkgd(&mut self) -> Result<(), DecodingError> {
         let info = self.info.as_mut().unwrap();
         if info.bkgd.is_some() {
@@ -2044,8 +2054,8 @@ mod tests {
     use crate::chunk::ChunkType;
     use crate::test_utils::*;
     use crate::{
-        DecodeOptions, Decoder, DecodingError, Limits, Reader, SrgbRenderingIntent, Unit,
-        UnknownChunk,
+        CapturedChunk, DecodeOptions, Decoder, DecodingError, Limits, Reader, SrgbRenderingIntent,
+        Unit,
     };
     use approx::assert_relative_eq;
     use byteorder::WriteBytesExt;
@@ -3429,7 +3439,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_chunks_disabled() {
+    fn test_no_captured_chunks() {
         let width = 16;
         let mut png = Vec::new();
         write_png_sig(&mut png);
@@ -3443,11 +3453,11 @@ mod tests {
         write_iend(&mut png);
 
         let reader = Decoder::new(Cursor::new(png)).read_info().unwrap();
-        assert_eq!(reader.info().unknown_chunks.len(), 0);
+        assert_eq!(reader.info().captured_chunks.len(), 0);
     }
 
     #[test]
-    fn test_unknown_chunks_preserved() {
+    fn test_captured_chunks_unknown() {
         let width = 16;
         let mut png = Vec::new();
         write_png_sig(&mut png);
@@ -3462,18 +3472,18 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_keep_unknown_chunks(true);
+        options.set_captured_chunks(&[ChunkType(*b"uNK1"), ChunkType(*b"uNK2")]);
         let reader = Decoder::new_with_options(Cursor::new(png), options)
             .read_info()
             .unwrap();
         assert_eq!(
-            reader.info().unknown_chunks,
+            reader.info().captured_chunks,
             vec![
-                UnknownChunk {
+                CapturedChunk {
                     name: ChunkType(*b"uNK1"),
                     data: b"data1".to_vec()
                 },
-                UnknownChunk {
+                CapturedChunk {
                     name: ChunkType(*b"uNK2"),
                     data: b"data2".to_vec()
                 }
@@ -3482,12 +3492,13 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_chunks_limits_exceeded() {
+    fn test_captured_chunks_known() {
         let width = 16;
         let mut png = Vec::new();
         write_png_sig(&mut png);
         write_rgba8_ihdr_with_width(&mut png, width);
-        write_chunk(&mut png, b"uNKn", b"long data that exceeds limits");
+        // Write a bKGD chunk (a known ancillary chunk)
+        write_chunk(&mut png, b"bKGD", &[0, 255]);
         write_chunk(
             &mut png,
             b"IDAT",
@@ -3496,16 +3507,25 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_keep_unknown_chunks(true);
-        let mut decoder = Decoder::new_with_options(Cursor::new(png), options);
-        // Set a limit lower than the unknown chunk data size (29 bytes)
-        decoder.set_limits(Limits { bytes: 10 });
-        let result = decoder.read_info();
-        assert!(matches!(result, Err(DecodingError::LimitsExceeded)));
+        options.set_captured_chunks(&[ChunkType(*b"bKGD")]);
+        let reader = Decoder::new_with_options(Cursor::new(png), options)
+            .read_info()
+            .unwrap();
+
+        // Assert that the chunk is captured
+        assert_eq!(
+            reader.info().captured_chunks,
+            vec![CapturedChunk {
+                name: ChunkType(*b"bKGD"),
+                data: vec![0, 255],
+            }]
+        );
+        // Assert that it was not parsed natively
+        assert_eq!(reader.info().bkgd, None);
     }
 
     #[test]
-    fn test_critical_unknown_chunk() {
+    fn test_captured_chunks_critical() {
         let width = 16;
         let mut png = Vec::new();
         write_png_sig(&mut png);
@@ -3520,11 +3540,39 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_keep_unknown_chunks(true);
-        let result = Decoder::new_with_options(Cursor::new(png), options).read_info();
-        assert!(matches!(result, Err(DecodingError::Format(_))));
-        let err = result.err().unwrap().to_string();
-        assert!(err.contains("Unrecognized critical chunk"));
-        assert!(err.contains("UNKn"));
+        options.set_captured_chunks(&[ChunkType(*b"UNKn")]);
+        let reader = Decoder::new_with_options(Cursor::new(png), options)
+            .read_info()
+            .unwrap();
+        assert_eq!(
+            reader.info().captured_chunks,
+            vec![CapturedChunk {
+                name: ChunkType(*b"UNKn"),
+                data: b"critical data".to_vec()
+            }]
+        );
+    }
+
+    #[test]
+    fn test_captured_chunks_limits_exceeded() {
+        let width = 16;
+        let mut png = Vec::new();
+        write_png_sig(&mut png);
+        write_rgba8_ihdr_with_width(&mut png, width);
+        write_chunk(&mut png, b"uNKn", b"long data that exceeds limits");
+        write_chunk(
+            &mut png,
+            b"IDAT",
+            &generate_rgba8_with_width_and_height(width, width),
+        );
+        write_iend(&mut png);
+
+        let mut options = DecodeOptions::default();
+        options.set_captured_chunks(&[ChunkType(*b"uNKn")]);
+        let mut decoder = Decoder::new_with_options(Cursor::new(png), options);
+        // Set a limit lower than the unknown chunk data size (29 bytes)
+        decoder.set_limits(Limits { bytes: 10 });
+        let result = decoder.read_info();
+        assert!(matches!(result, Err(DecodingError::LimitsExceeded)));
     }
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::error;
 use std::fmt;
@@ -469,7 +470,7 @@ pub struct DecodeOptions {
     ignore_text_chunk: bool,
     ignore_iccp_chunk: bool,
     skip_ancillary_crc_failures: bool,
-    captured_chunks: Vec<ChunkType>,
+    captured_chunks: HashSet<ChunkType>,
 }
 
 impl Default for DecodeOptions {
@@ -480,7 +481,7 @@ impl Default for DecodeOptions {
             ignore_text_chunk: false,
             ignore_iccp_chunk: false,
             skip_ancillary_crc_failures: true,
-            captured_chunks: Vec::new(),
+            captured_chunks: HashSet::new(),
         }
     }
 }
@@ -546,7 +547,7 @@ impl DecodeOptions {
                 return Err(ParameterErrorKind::CannotCaptureCriticalChunk.into());
             }
         }
-        self.captured_chunks = names.to_vec();
+        self.captured_chunks = names.iter().cloned().collect();
         Ok(())
     }
 
@@ -1064,8 +1065,6 @@ impl StreamingDecoder {
     }
 
     fn start_chunk(&mut self, type_str: ChunkType, length: u32) -> Result<State, DecodingError> {
-        let is_captured = self.decode_options.is_captured(type_str);
-
         let target_length = match type_str {
             IHDR => 13..=13,
             chunk::PLTE => 3..=768,
@@ -1098,7 +1097,7 @@ impl StreamingDecoder {
                 ));
             }
             _ => {
-                if is_captured {
+                if self.decode_options.is_captured(type_str) {
                     self.current_chunk.action = ChunkAction::Process;
                 } else {
                     self.current_chunk.action = ChunkAction::Skip;
@@ -3518,7 +3517,6 @@ mod tests {
 
         let text_data = b"Title\0Test string";
         write_chunk(&mut png, b"tEXt", text_data);
-
         write_chunk(
             &mut png,
             b"IDAT",

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -530,16 +530,28 @@ impl DecodeOptions {
 
     /// Sets the list of chunks to be captured.
     ///
-    /// Captured chunks will be skipped by the decoder and their raw data will be stored in the
-    /// `captured_chunks` field of the `Info` struct.
+    /// The raw data of captured chunks will be stored in the `captured_chunks`
+    /// field of the `Info` struct and will contribute towards the set `Limits`.
     ///
-    /// This applies even to chunks that are recognized by the decoder and critical chunks.
-    /// Doing so may cause the decoding to fail if the chunk is strictly required by the PNG
-    /// specification.
+    /// If a chunk is recognized by the decoder, it will still be parsed normally
+    /// alongside the capture.
+    ///
+    /// Note that critical chunks cannot be captured. Attempting to capture a critical chunk will
+    /// return a `ParameterError`.
     ///
     /// Defaults to `&[]`.
-    pub fn set_captured_chunks(&mut self, names: &[ChunkType]) {
+    pub fn set_captured_chunks(&mut self, names: &[ChunkType]) -> Result<(), ParameterError> {
+        for &name in names {
+            if chunk::is_critical(name) {
+                return Err(ParameterErrorKind::CannotCaptureCriticalChunk.into());
+            }
+        }
         self.captured_chunks = names.to_vec();
+        Ok(())
+    }
+
+    pub(crate) fn is_captured(&self, type_str: ChunkType) -> bool {
+        self.captured_chunks.contains(&type_str)
     }
 }
 
@@ -1052,10 +1064,7 @@ impl StreamingDecoder {
     }
 
     fn start_chunk(&mut self, type_str: ChunkType, length: u32) -> Result<State, DecodingError> {
-        if self.decode_options.captured_chunks.contains(&type_str) {
-            self.current_chunk.action = ChunkAction::Process;
-            return Ok(State::ReadChunkData(type_str));
-        }
+        let is_captured = self.decode_options.is_captured(type_str);
 
         let target_length = match type_str {
             IHDR => 13..=13,
@@ -1089,7 +1098,11 @@ impl StreamingDecoder {
                 ));
             }
             _ => {
-                self.current_chunk.action = ChunkAction::Skip;
+                if is_captured {
+                    self.current_chunk.action = ChunkAction::Process;
+                } else {
+                    self.current_chunk.action = ChunkAction::Skip;
+                }
                 return Ok(State::ReadChunkData(type_str));
             }
         };
@@ -1115,10 +1128,12 @@ impl StreamingDecoder {
     }
 
     fn parse_chunk(&mut self, type_str: ChunkType) -> Result<Decoded, DecodingError> {
+        let is_captured = self.decode_options.is_captured(type_str);
+        if is_captured {
+            self.parse_captured(type_str)?;
+        }
+
         let mut parse_result = match type_str {
-            type_str if self.decode_options.captured_chunks.contains(&type_str) => {
-                self.parse_captured(type_str)
-            }
             // Critical non-data chunks.
             IHDR => self.parse_ihdr(),
             chunk::PLTE => self.parse_plte(),
@@ -1150,6 +1165,7 @@ impl StreamingDecoder {
             chunk::iTXt => self.parse_itxt(),
 
             // Unrecognized chunks.
+            _ if is_captured => Ok(()),
             _ => unreachable!(
                 "Unrecognized chunk {type_str:?} should have been caught in start_chunk"
             ),
@@ -3472,7 +3488,9 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_captured_chunks(&[ChunkType(*b"uNK1"), ChunkType(*b"uNK2")]);
+        options
+            .set_captured_chunks(&[ChunkType(*b"uNK1"), ChunkType(*b"uNK2")])
+            .unwrap();
         let reader = Decoder::new_with_options(Cursor::new(png), options)
             .read_info()
             .unwrap();
@@ -3497,8 +3515,10 @@ mod tests {
         let mut png = Vec::new();
         write_png_sig(&mut png);
         write_rgba8_ihdr_with_width(&mut png, width);
-        // Write a bKGD chunk (a known ancillary chunk)
-        write_chunk(&mut png, b"bKGD", &[0, 255]);
+
+        let text_data = b"Title\0Test string";
+        write_chunk(&mut png, b"tEXt", text_data);
+
         write_chunk(
             &mut png,
             b"IDAT",
@@ -3507,21 +3527,25 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_captured_chunks(&[ChunkType(*b"bKGD")]);
+        options.set_captured_chunks(&[ChunkType(*b"tEXt")]).unwrap();
         let reader = Decoder::new_with_options(Cursor::new(png), options)
             .read_info()
             .unwrap();
-
         // Assert that the chunk is captured
         assert_eq!(
             reader.info().captured_chunks,
             vec![CapturedChunk {
-                name: ChunkType(*b"bKGD"),
-                data: vec![0, 255],
+                name: ChunkType(*b"tEXt"),
+                data: text_data.to_vec(),
             }]
         );
-        // Assert that it was not parsed natively
-        assert_eq!(reader.info().bkgd, None);
+        // Assert that it was also parsed
+        assert_eq!(reader.info().uncompressed_latin1_text.len(), 1);
+        assert_eq!(reader.info().uncompressed_latin1_text[0].keyword, "Title");
+        assert_eq!(
+            reader.info().uncompressed_latin1_text[0].text,
+            "Test string"
+        );
     }
 
     #[test]
@@ -3540,17 +3564,10 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_captured_chunks(&[ChunkType(*b"UNKn")]);
-        let reader = Decoder::new_with_options(Cursor::new(png), options)
-            .read_info()
-            .unwrap();
-        assert_eq!(
-            reader.info().captured_chunks,
-            vec![CapturedChunk {
-                name: ChunkType(*b"UNKn"),
-                data: b"critical data".to_vec()
-            }]
-        );
+        let result = options.set_captured_chunks(&[ChunkType(*b"UNKn")]);
+        assert!(matches!(result, Err(_)));
+        let err = result.unwrap_err();
+        assert_eq!("Critical chunks cannot be captured", format!("{err}"));
     }
 
     #[test]
@@ -3568,7 +3585,7 @@ mod tests {
         write_iend(&mut png);
 
         let mut options = DecodeOptions::default();
-        options.set_captured_chunks(&[ChunkType(*b"uNKn")]);
+        options.set_captured_chunks(&[ChunkType(*b"uNKn")]).unwrap();
         let mut decoder = Decoder::new_with_options(Cursor::new(png), options);
         // Set a limit lower than the unknown chunk data size (29 bytes)
         decoder.set_limits(Limits { bytes: 10 });


### PR DESCRIPTION
#### Context
This change is motivated by the integration of the png crate into the Android Skia graphics framework. Android needs to access chunks that are not explicitly handled by the decoder to maintain feature parity with libpng.

#### Feature Parity with libpng
This implementation provides functionality similar to libpng's unknown chunk handling (see [png_set_keep_unknown_chunks](https://linux.die.net/man/3/libpng) and [png_get_unknown_chunks](http://www.libpng.org/pub/png/libpng-manual.txt)).

#### Changes
- Added UnknownChunk struct and unknown_chunks: Vec<UnknownChunk> to Info.
- Added keep_unknown_chunks to DecodeOptions (defaults to false).
- Updated StreamingDecoder to capture and store unrecognized chunks when enabled.
- Added unit tests for preservation logic, memory limits, and critical chunk handling.