### PR TITLE
Fix panic with malformed palette chunk

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1275,6 +1275,10 @@ impl StreamingDecoder {
             Err(DecodingError::Format(
                 FormatErrorInner::DuplicateChunk { kind: chunk::PLTE }.into(),
             ))
+        } else if self.current_chunk.raw_bytes.len() % 3 != 0 {
+            Err(DecodingError::Format(
+                FormatErrorInner::ChunkLengthWrong { kind: chunk::PLTE }.into(),
+            ))
         } else {
             info.palette = Some(Cow::Owned(self.current_chunk.raw_bytes.clone()));
             Ok(())

--- a/src/decoder/transform/palette.rs
+++ b/src/decoder/transform/palette.rs
@@ -71,6 +71,7 @@ fn create_rgba_palette(info: &Info) -> [[u8; 4]; 256] {
             rgba_iter = &mut rgba_iter[1..];
         }
         if !palette_iter.is_empty() {
+            assert_eq!(palette_iter.len(), 3, "chunk is checked in parse_plte");
             rgba_iter[0][0..3].copy_from_slice(&palette_iter[0..3]);
         }
     }


### PR DESCRIPTION
Hi,

I ran into a panic a malformed PNG file:

```console
$ xxd invalid_palette.png
00000000: 8950 4e47 0d0a 1a0a 0000 000d 4948 4452  .PNG........IHDR
00000010: 0000 0001 0000 000d 0103 0000 0052 1996  .............R..
00000020: b100 0000 0061 5d55 4c7e 1c56 3300 0000  .....a]UL~.V3...
00000030: 0450 4c54 4578 9c03 ffe8 0edb d3ff 0100  .PLTEx..........
00000040: d949 4441 5478 0163 2100 08              .IDATx.c!..
$ cargo run --example corpus-bench ./
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/examples/corpus-bench ./`
Directory                                     Ratio             Encode                    Decode
---------                                    -------     --------------------      --------------------

thread 'main' (1110803) panicked at src/decoder/transform/palette.rs:74:61:
range end index 3 out of range for slice of length 1
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/14196dbfa3eb7c30195251eac092b1b86c8a2d84/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/14196dbfa3eb7c30195251eac092b1b86c8a2d84/library/core/src/panicking.rs:80:14
   2: core::slice::index::slice_index_fail
             at /rustc/14196dbfa3eb7c30195251eac092b1b86c8a2d84/library/core/src/panic.rs:177:9
   3: <core::ops::range::Range<usize> as core::slice::index::SliceIndex<[u8]>>::index
             at /home/user/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:443:13
   4: <[u8] as core::ops::index::Index<core::ops::range::Range<usize>>>::index
             at /home/user/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/slice/index.rs:19:15
   5: png::decoder::transform::palette::create_rgba_palette
             at ./src/decoder/transform/palette.rs:74:61
   6: png::decoder::transform::palette::create_expansion_into_rgb8
             at ./src/decoder/transform/palette.rs:23:24
   7: png::decoder::transform::create_transform_fn
             at ./src/decoder/transform.rs:49:21
   8: <png::decoder::Reader<std::io::cursor::Cursor<&[u8]>>>::next_interlaced_row_impl
             at ./src/decoder/mod.rs:617:42
   9: <png::decoder::Reader<std::io::cursor::Cursor<&[u8]>>>::next_frame
             at ./src/decoder/mod.rs:480:22
  10: corpus_bench::main
             at ./examples/corpus-bench.rs:123:37
  11: <fn() as core::ops::function::FnOnce<()>>::call_once
             at /home/user/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This PR fixes the panic by ignoring leftover palette entries that don't have enough bytes to fill the RGB slice.
Notably, I'm just ignoring the one or two trailing bytes here, but if that'd be useful I could also add a check that rejects these malformed PLTE chunks.

Thanks!