### PR TITLE
Provide a way to prevent overshooting past `IEND` (fixes #531)

### DIFF
--- a/src/decoder/input.rs
+++ b/src/decoder/input.rs
@@ -1,0 +1,78 @@
+use std::io::{BufRead, BufReader, Read, Take};
+
+/// Buffered input for the PNG decoder, with optional boundary-limited refills.
+///
+/// This trait is similar to [`BufRead`], but `fill_buf_limited` receives the maximum number of
+/// bytes the decoder currently expects to consume before reaching the next PNG parser boundary.
+///
+/// To avoid reading beyond PNG boundaries, see [`LimitBufReader`] for an implementation that
+/// honors the provided `limit`.
+pub trait LimitBufRead {
+    /// Same as [`BufRead::fill_buf`], but with a hint to cap reads to at most `limit` bytes.
+    ///
+    /// The `limit` boundary serves as a hint to avoid overshooting past `IEND`. Implementors
+    /// are free to discard this value: [`BufRead`] implements this trait discarding `limit`
+    /// entirely.
+    ///
+    /// Implementations that can enforce the `limit` should use it to cap the number of reads, i.e.
+    /// it is valid to return a slice bigger than `limit` if there are more than `limit` unconsumed
+    /// bytes.
+    fn fill_buf_limited(&mut self, limit: usize) -> std::io::Result<&[u8]>;
+
+    /// Same as [`BufRead::consume`].
+    fn consume(&mut self, amt: usize);
+}
+
+/// Blanket implementation for all [`BufRead`] types.
+///
+/// [`LimitBufRead`] replaces the [`BufRead`] trait bound historically required by
+/// [`Decoder`](crate::Decoder) and [`Reader`](crate::Reader) in a backwards-compatible manner.
+///
+/// This implementation deliberately ignores the `limit` dynamic boundary contract, aggressively
+/// pre-fetching data into standard memory buffers to maximize standard I/O caching performance.
+/// However, it does not prevent the underlying reader from being advanced past PNG boundaries.
+impl<T: BufRead> LimitBufRead for T {
+    fn fill_buf_limited(&mut self, _limit: usize) -> std::io::Result<&[u8]> {
+        self.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        BufRead::consume(self, amt);
+    }
+}
+
+/// A wrapper for [`Read`] streams that implements controlled buffering to prevent reading past
+/// `IEND` chunk boundaries.
+///
+/// # Performance note
+///
+/// Because this wrapper caps reads strictly to what the state machine expects, it can trigger more
+/// frequent operating system read syscalls in files characterized by many small chunks. This can
+/// cause context-switching regressions compared to standard large-block pre-fetching (e.g.
+/// `std::io::BufReader`). [`LimitBufReader`] should only be used when boundary safety is required.
+pub struct LimitBufReader<R>(BufReader<Take<R>>);
+
+impl<R: Read> LimitBufReader<R> {
+    /// Creates a new [`LimitBufReader`] wrapping the given [`Read`] stream with the default
+    /// [`BufReader`] capacity.
+    pub fn new(inner: R) -> Self {
+        Self(BufReader::new(inner.take(u64::MAX)))
+    }
+
+    /// Creates a new [`LimitBufReader`] wrapping the given [`Read`] stream with a specified
+    /// `capacity` limit.
+    pub fn with_capacity(capacity: usize, inner: R) -> Self {
+        Self(BufReader::with_capacity(capacity, inner.take(u64::MAX)))
+    }
+}
+
+impl<R: Read> LimitBufRead for LimitBufReader<R> {
+    fn fill_buf_limited(&mut self, limit: usize) -> std::io::Result<&[u8]> {
+        self.0.get_mut().set_limit(limit as u64);
+        self.0.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        BufRead::consume(&mut self.0, amt);
+    }
+}

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod input;
 mod interlace_info;
 mod read_decoder;
 pub(crate) mod stream;
@@ -10,9 +11,9 @@ use self::stream::{DecodeOptions, DecodingError, FormatErrorInner};
 use self::transform::{create_transform_fn, TransformFn};
 use self::unfiltering_buffer::UnfilteringBuffer;
 
-use std::io::BufRead;
 use std::mem;
 
+pub use self::input::{LimitBufRead, LimitBufReader};
 use crate::adam7::Adam7Info;
 use crate::common::{
     BitDepth, BytesPerPixel, ColorType, Info, ParameterErrorKind, Transformations,
@@ -87,7 +88,7 @@ impl Default for Limits {
 }
 
 /// PNG Decoder
-pub struct Decoder<R: BufRead> {
+pub struct Decoder<R: LimitBufRead> {
     read_decoder: ReadDecoder<R>,
     /// Output transformations
     transform: Transformations,
@@ -122,7 +123,7 @@ impl<'data> Row<'data> {
     }
 }
 
-impl<R: BufRead> Decoder<R> {
+impl<R: LimitBufRead> Decoder<R> {
     /// Create a new decoder configuration with default limits.
     pub fn new(r: R) -> Decoder<R> {
         Decoder::new_with_limits(r, Limits::default())
@@ -291,7 +292,7 @@ impl<R: BufRead> Decoder<R> {
 /// PNG reader (mostly high-level interface)
 ///
 /// Provides a high level that iterates over lines or whole images.
-pub struct Reader<R: BufRead> {
+pub struct Reader<R: LimitBufRead> {
     decoder: ReadDecoder<R>,
     bpp: BytesPerPixel,
     subframe: SubframeInfo,
@@ -327,7 +328,7 @@ struct SubframeInfo {
     consumed_and_flushed: bool,
 }
 
-impl<R: BufRead> Reader<R> {
+impl<R: LimitBufRead> Reader<R> {
     /// Advances to the start of the next animation frame and
     /// returns a reference to the [`FrameControl`] info that describes it.
     /// Skips and discards the image data of the previous frame if necessary.

--- a/src/decoder/read_decoder.rs
+++ b/src/decoder/read_decoder.rs
@@ -1,8 +1,9 @@
 use super::stream::{DecodeOptions, Decoded, DecodingError, FormatErrorInner, StreamingDecoder};
 use super::zlib::UnfilterBuf;
+use super::LimitBufRead;
 use super::Limits;
 
-use std::io::{BufRead, ErrorKind, Read};
+use std::io::ErrorKind;
 
 use crate::chunk;
 use crate::common::Info;
@@ -16,12 +17,12 @@ use crate::common::Info;
 /// * `decode_image_data` - reading from `IDAT` / `fdAT` sequence into `Vec<u8>`
 /// * `finish_decoding_image_data()` - discarding remaining data from `IDAT` / `fdAT` sequence
 /// * `read_until_end_of_input()` - reading until `IEND` chunk
-pub(crate) struct ReadDecoder<R: Read> {
+pub(crate) struct ReadDecoder<R: LimitBufRead> {
     reader: R,
     decoder: StreamingDecoder,
 }
 
-impl<R: BufRead> ReadDecoder<R> {
+impl<R: LimitBufRead> ReadDecoder<R> {
     pub fn new(r: R) -> Self {
         Self {
             reader: r,
@@ -64,8 +65,9 @@ impl<R: BufRead> ReadDecoder<R> {
         image_data: Option<&mut UnfilterBuf<'_>>,
     ) -> Result<Decoded, DecodingError> {
         let (consumed, result) = {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
+            let limit = self.decoder.expected_read_limit()?;
+            let buf = self.reader.fill_buf_limited(limit)?;
+            if limit > 0 && buf.is_empty() {
                 return Err(DecodingError::IoError(ErrorKind::UnexpectedEof.into()));
             }
             self.decoder.update(buf, image_data)?

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -661,6 +661,32 @@ impl StreamingDecoder {
         self.info.as_ref()
     }
 
+    /// Calculates the maximum number of bytes the streaming decoder expects to consume in its
+    /// current state before transitioning to the next state.
+    ///
+    /// This value is used by [`LimitBufReader`](crate::decoder::LimitBufReader) to limit buffer
+    /// refills, avoiding aggressive pre-fetching beyond the current chunk boundary to prevent
+    /// overshoot past the `IEND` chunk.
+    pub(crate) fn expected_read_limit(&self) -> Result<usize, DecodingError> {
+        self.state
+            .as_ref()
+            .map(|state| match state {
+                State::U32 {
+                    accumulated_count, ..
+                } => 4 - *accumulated_count,
+                State::ReadChunkData(_) | State::ImageData(_) => {
+                    if self.current_chunk.remaining == 0 {
+                        4 // For the CRC that we will transition to
+                    } else {
+                        self.current_chunk.remaining as usize
+                    }
+                }
+            })
+            .ok_or_else(|| {
+                DecodingError::Parameter(ParameterErrorKind::PolledAfterFatalError.into())
+            })
+    }
+
     pub fn set_ignore_text_chunk(&mut self, ignore_text_chunk: bool) {
         self.decode_options.set_ignore_text_chunk(ignore_text_chunk);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,9 @@ pub use crate::adam7::{
 pub use crate::adam7::{Adam7Info, Adam7Variant};
 pub use crate::common::*;
 pub use crate::decoder::stream::{DecodeOptions, Decoded, DecodingError, StreamingDecoder};
-pub use crate::decoder::{Decoder, InterlaceInfo, InterlacedRow, Limits, OutputInfo, Reader};
+pub use crate::decoder::{
+    Decoder, InterlaceInfo, InterlacedRow, LimitBufRead, LimitBufReader, Limits, OutputInfo, Reader,
+};
 pub use crate::decoder::{UnfilterBuf, UnfilterRegion};
 pub use crate::encoder::{Encoder, EncodingError, StreamWriter, Writer};
 pub use crate::filter::Filter;

--- a/tests/limit_buf_read.rs
+++ b/tests/limit_buf_read.rs
@@ -1,0 +1,103 @@
+use std::fs;
+use std::io::{self, BufReader, Cursor, Error, ErrorKind, Read};
+
+use png::{Decoder, LimitBufRead, LimitBufReader};
+
+/// A mock [`Read`] stream that rejects reads over the given `limit`.
+///
+/// This replicates integrations where a buffering layer above a blocking pipe attempts to satisfy
+/// the requested size instead of returning a short read.
+struct BlockOnLimit {
+    inner: Cursor<Vec<u8>>,
+    limit: usize,
+    read_bytes: usize,
+}
+
+impl BlockOnLimit {
+    fn new(data: Vec<u8>, limit: usize) -> Self {
+        Self {
+            inner: Cursor::new(data),
+            limit,
+            read_bytes: 0,
+        }
+    }
+}
+
+impl Read for BlockOnLimit {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let remaining = self.limit - self.read_bytes;
+        if buf.len() > remaining {
+            return Err(Error::new(
+                ErrorKind::WouldBlock,
+                "Blocked on eager overshoot request",
+            ));
+        }
+        let n = self.inner.read(buf)?;
+        self.read_bytes += n;
+        Ok(n)
+    }
+}
+
+fn decode_image<R: LimitBufRead>(reader: R) -> Result<(), png::DecodingError> {
+    let decoder = Decoder::new(reader);
+    let mut reader = decoder.read_info()?;
+    let mut buf = vec![0; reader.output_buffer_size().unwrap()];
+    reader.next_frame(&mut buf)?;
+    reader.finish()?;
+    Ok(())
+}
+
+#[test]
+fn test_buf_reader_overshoots() {
+    let png_data = fs::read("tests/pngsuite/basi0g01.png").unwrap();
+    let mut concat_data = Vec::new();
+    concat_data.extend_from_slice(&png_data);
+    concat_data.extend_from_slice(&png_data);
+
+    let mut cursor = Cursor::new(concat_data);
+    let buf_reader = BufReader::new(&mut cursor);
+    decode_image(buf_reader).expect("Standard BufReader decode failed");
+
+    assert_eq!(cursor.position(), (png_data.len() * 2) as u64);
+}
+
+#[test]
+fn test_buf_reader_blocks_on_blocking_source() {
+    let png_data = fs::read("tests/pngsuite/basi0g01.png").unwrap();
+    let png_len = png_data.len();
+    let blocking_source = BlockOnLimit::new(png_data, png_len);
+
+    let buf_reader = BufReader::new(blocking_source);
+    let res = decode_image(buf_reader);
+
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(
+        err,
+        png::DecodingError::IoError(ref io_err) if io_err.kind() == ErrorKind::WouldBlock
+    ));
+}
+
+#[test]
+fn test_limit_buf_reader_does_not_overshoot() {
+    let png_data = fs::read("tests/pngsuite/basi0g01.png").unwrap();
+    let mut concat_data = Vec::new();
+    concat_data.extend_from_slice(&png_data);
+    concat_data.extend_from_slice(&png_data);
+
+    let mut cursor = Cursor::new(concat_data);
+    let limited_reader = LimitBufReader::new(&mut cursor);
+    decode_image(limited_reader).expect("LimitBufReader decode failed");
+
+    assert_eq!(cursor.position(), png_data.len() as u64);
+}
+
+#[test]
+fn test_limit_buf_reader_does_not_block_on_blocking_source() {
+    let png_data = fs::read("tests/pngsuite/basi0g01.png").unwrap();
+    let png_len = png_data.len();
+    let blocking_source = BlockOnLimit::new(png_data, png_len);
+
+    let limited_reader = LimitBufReader::new(blocking_source);
+    decode_image(limited_reader).expect("LimitBufReader decode failed");
+}


### PR DESCRIPTION
## Buffering issues addressed
1. Overshoot (fixes #531): Standard `BufReader` can overshoot and read past the `IEND` chunk boundary. This fix is needed to support decoding concatenated images from a single stream (simulated in Skia's [Codec_end](https://source.chromium.org/chromium/chromium/src/+/main:third_party/skia/tests/CodecExactReadTest.cpp;l=50-94) test), where the stream must be left positioned exactly at the end of the first image's `IEND` chunk for subsequent decodes to work.
2. Blocking reads from pipe-like inputs: When decoding PNGs from blocking, non-seekable inputs (like pipes), standard buffering (e.g., standard `BufReader`'s 8KB refills) causes JNI/Skia layers to greedily request more bytes. Once the PNG data is fully consumed, the JNI loop calls `read()` again to satisfy the remaining buffer capacity, causing it to block indefinitely. This is highlighted by a timeout failure in AOSP CTS [testDecodePngFromPipe](https://android.googlesource.com/platform/cts/+/master/tests/tests/graphics/src/android/graphics/cts/BitmapFactoryTest.java#859) test.

## Seek vs limited reads approach
Although issue 1 (overshoot) could theoretically be resolved by seeking backward to the correct boundary after a read that's too wide, this approach does not seem adequate for issue 2 because pipes are not genuinely seekable. 

The AOSP CTS test deadlock occurs because the main test thread retains an open reference to the pipe's `writeFd` even after the `writeThread` closes the `FileOutputStream`, preventing the pipe from naturally closing and returning EOF. Theoretically, we could fix the test by closing `writeFd` in the main thread, but that would only hide a deeper production issue: if a standard decoder eagerly over-reads on an open, blocking stream (where the writer remains alive), the read blocks the entire decode thread indefinitely even after the image has been fully received.

To address both issues with a single solution, a limited buffering approach is implemented that limits reads at the dynamic state boundary, and the currently unused `Seek` bound is removed.

## How it's achieved
- Introduced a new public trait `LimitBufRead` that abstracts controlled buffering, replacing the generic `BufRead` bound on `Decoder` and `Reader` in a backwards-compatible manner. The trait is designed without sealed constraints to potentially be implementable by downstream callers (e.g., potentially a future `SkStream` integration).
- Exposes `LimitBufReader` wrapper which restricts buffer refills to the bytes expected by the decoder state machine.
- Added `expected_read_limit` to `StreamingDecoder` to calculate expected bytes dynamically.
- Added regression tests in `tests/limit_buf_read.rs` verifying concatenated stream decodes and eager-buffered blocking source handling (via `BlockOnLimit` simulating blocking buffering wrappers).

## Testing

To verify the correctness of the new `LimitBufRead` usage and `LimitBufReader` APIs, I have run all existing integration and unit tests by replacing the `BufReader`s with `LimitBufReader`, and wrapping the `Cursor`s in `LimitBufReader`. All tests passed successfully.

## Benchmarks

Additionally, I ran the decoder criterion benchmark suite across four distinct configurations to collect comparative metrics:

1. **Memory standard** (`Cursor<&[u8]>`)
2. **Memory limit** (`Cursor<&[u8]>` wrapped in a `LimitBufReader`)
3. **File standard** (`File` wrapped in a `BufReader`)
4. **File limit** (`File` wrapped in a `LimitBufReader`)

The raw benchmark metrics are compiled below:

<details><summary>Click to expand benchmark results table</summary>
(On my machine)

| Benchmark Image / Case | Memory Standard | Memory Limit | Memory Overhead | File Standard | File Limit | File Overhead |
| :--- | :---: | :---: | :---: | :---: | :---: | :---: |
| **1. Real-world files (`decode`)** | | | | | | |
| `Fantasy_Digital_Painting.png` | `23.75 ms` | `23.99 ms` | **+1.0%** | `24.51 ms` | `24.56 ms` | **+0.2%** |
| `Exoplanet_Phase_Curve_(Diagram).png` | `29.20 ms` | `28.86 ms` | **-1.1%** | `29.32 ms` | `29.48 ms` | **+0.5%** |
| `Lohengrin_Illustrated.png` | `23.96 ms` | `24.90 ms` | **+3.9%** | `26.96 ms` | `27.36 ms` | **+1.5%** |
| `paletted-zune.png` | `11.06 ms` | `11.16 ms` | **+1.0%** | `11.52 ms` | `11.68 ms` | **+1.3%** |
| `kodim02.png` | `3.68 ms` | `3.72 ms` | **+1.1%** | `3.86 ms` | `3.92 ms` | **+1.5%** |
| `kodim07.png` | `4.70 ms` | `4.71 ms` | **+0.4%** | `4.86 ms` | `4.91 ms` | **+1.0%** |
| `kodim17.png` | `3.91 ms` | `3.92 ms` | **+0.3%** | `4.06 ms` | `4.08 ms` | **+0.6%** |
| `kodim23.png` | `3.58 ms` | `3.63 ms` | **+1.4%** | `3.79 ms` | `3.90 ms` | **+2.8%** |
| `Exoplanet_indexed_gimp.png` | `8.89 ms` | `8.93 ms` | **+0.4%** | `9.28 ms` | `9.31 ms` | **+0.4%** |
| `lorem_ipsum_screenshot.png` | `1.22 ms` | `1.23 ms` | **+1.2%** | `1.29 ms` | `1.36 ms` | **+5.8%** |
| `lorem_ipsum_oxipng.png` | `800.91 µs` | `800.60 µs` | **0.0%** | `833.58 µs` | `850.02 µs` | **+2.0%** |
| `tango-icon-new-128.png` | `109.17 µs` | `109.57 µs` | **+0.4%** | `121.41 µs` | `137.98 µs` | **+13.7%** |
| `tango-icon-new-32.png` | `13.87 µs` | `14.16 µs` | **+2.1%** | `23.34 µs` | `37.21 µs` | **+59.4%** |
| `tango-icon-new-16.png` | `7.73 µs` | `8.04 µs` | **+4.1%** | `17.15 µs` | `41.73 µs` | **+143.4%** |
| `Transparency.png` | `87.30 µs` | `88.26 µs` | **+1.1%** | `97.66 µs` | `125.38 µs` | **+28.4%** |
| **2. 4K chunks (Fragmented)** | | | | | | |
| `8x8.png` | `972.78 ns` | `1.18 µs` | **+21.3%** | `10.07 µs` | `20.09 µs` | **+99.5%** |
| `128x128.png` | `13.02 µs` | `14.33 µs` | **+10.1%** | `32.41 µs` | `94.49 µs` | **+191.5%** |
| `2048x2048.png` | `3.99 ms` | `4.48 ms` | **+12.3%** | `8.42 ms` | `21.92 ms` | **+160.3%** |
| `12288x12288.png` | `195.50 ms` | `171.30 ms` | **-12.4%** | `316.29 ms` | `815.29 ms` | **+157.8%** |
| **3. 64K chunks (Stable)** | | | | | | |
| `128x128.png` | `11.27 µs` | `11.99 µs` | **+6.4%** | `29.19 µs` | `43.61 µs` | **+49.4%** |
| `2048x2048.png` | `3.34 ms` | `3.26 ms` | **-2.3%** | `6.89 ms` | `7.89 ms` | **+14.5%** |
| `12288x12288.png` | `133.93 ms` | `141.75 ms` | **+5.8%** | `243.02 ms` | `275.64 ms` | **+13.4%** |
| **4. 2G chunks (Massive-chunk)** | | | | | | |
| `2048x2048.png` | `2.79 ms` | `3.04 ms` | **+8.8%** | `6.51 ms` | `7.25 ms` | **+11.5%** |
| `12288x12288.png` | `131.59 ms` | `142.90 ms` | **+8.6%** | `242.90 ms` | `251.84 ms` | **+3.7%** |
| **5. Incremental row-by-row** | | | | | | |
| `128x128-4k-idat` | `13.81 µs` | `15.16 µs` | **+9.8%** | `33.42 µs` | `92.27 µs` | **+176.1%** |
</details>

Duplicating all the tests and benchmarks on CI felt redundant, and helps keep the PR diff clean and focused. Let me know if you think otherwise.

## Conclusions and BufReader by-default rationale

1. **Negligible memory CPU overhead**: In memory-to-memory decoding (`Cursor`), `LimitBufReader` introduces low overhead (+20% on the tiny fragmented `8x8.png`, otherwise negligible on most files), proving that the limit tracking has little CPU cost.
2. **OS system calls overhead**: Under File I/O, the overhead is dictated by context-switch costs. When chunk structures are highly fragmented (4K chunks), `LimitBufReader` must refill the buffer in smaller increments to respect boundaries safely, resulting in higher overhead (e.g., +160% to +190% regression in pathological cases).
3. **Low overhead on standard real-world files**: For normal real-world photos and diagrams which use larger, continuous `IDAT` chunks, the File I/O overhead of `LimitBufReader` remains low (mostly between 1% and 15%).

This data supports keeping standard `BufReader` as the default decoder baseline for general performance, while exposing `LimitBufReader` as an opt-in wrapper with relatively low overhead for most files.