### PR TITLE
Stop using hand-written simd unfiltering on x86_64

### DIFF
--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -258,14 +258,6 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             }
         }
         BytesPerPixel::Three => {
-            #[cfg(feature = "unstable")]
-            {
-                // Results in PR: https://github.com/image-rs/image-png/pull/632
-                // 23% better on an Epyc 7B13, 10% on a Zen 3 part.
-                // ~30% when targeting x86-64-v2.
-                super::simd::paeth_unfilter_3bpp(current, previous);
-                return;
-            }
             const BPP: usize = 3;
             let mut a_bpp = [0; BPP];
             let mut c_bpp = [0; BPP];
@@ -283,13 +275,6 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             }
         }
         BytesPerPixel::Four => {
-            #[cfg(feature = "unstable")]
-            {
-                // Results in PR: https://github.com/image-rs/image-png/pull/633
-                // May be slightly faster on AMD EPYC 7B13.
-                super::simd::paeth_unfilter_4bpp(current, previous);
-                return;
-            }
             const BPP: usize = 4;
             let mut a_bpp = [0; BPP];
             let mut c_bpp = [0; BPP];


### PR DESCRIPTION
[As I've pointed out before](https://github.com/image-rs/image-png/pull/632#issuecomment-3239470800), the current pattern that we've gone through is having someone propose a specialized SIMD implementation of unfiltering, getting a whole bunch of people in the thread to benchmark it, merging it, then discovering a year or two later that codegen changes / optimizations to the scalar unfiltering has invalidated the prior measurements. We've now done this whole cycle _twice_.
 
The manual SIMD codepath may still be faster on some x86 processors. I haven't even tried figuring out an ARM device to benchmark on. But on my Zen 5 CPU the regression is pretty clear...

Scalar implementation (this PR):
```
image-png:              355.3 MP/s (average)   298.5 MP/s (geomean)
image-png [x86-64-v2]:  368.4 MP/s (average)   310.5 MP/s (geomean)
```

SIMD implementation (current main):
```
image-png:              338.2 MP/s (average)   279.0 MP/s (geomean)
image-png [x86-64-v2]:  341.9 MP/s (average)   285.7 MP/s (geomean)
```

(These are _end-to-end_ decoding times measured using [`corpus-bench`](https://codeberg.org/fintelia/corpus-bench) and rustc nightly 2026-06-20)

---

Fixes #688 