### PR TITLE
Upgrade MSRV to 1.88 and to 2024 Edition 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.73.0", stable, beta, nightly]
+        rust: ["1.88.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [""]
     runs-on: ${{ matrix.os }}
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.73.0' }}
+      if: ${{ matrix.rust == '1.88.0' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.73.0' }}
+      if: ${{ matrix.rust == '1.88.0' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ categories = ["multimedia::images"]
 authors = ["The image-rs Developers"]
 repository = "https://github.com/image-rs/image-png"
 
-edition = "2021"
-rust-version = "1.73"
+edition = "2024"
+rust-version = "1.88"
 include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",

--- a/src/adam7.rs
+++ b/src/adam7.rs
@@ -400,7 +400,7 @@ pub fn expand_pass(
             }
         }
         _ => {
-            debug_assert!(bits_per_pixel % 8 == 0);
+            debug_assert!(bits_per_pixel.is_multiple_of(8));
             let bytes_pp = bits_per_pixel / 8;
             let byte_indices = expand_adam7_bytes(img_row_stride, interlace_info, bytes_pp);
 
@@ -553,7 +553,7 @@ pub fn expand_pass_splat(
             }
         }
         _ => {
-            debug_assert!(bits_per_pixel % 8 == 0);
+            debug_assert!(bits_per_pixel.is_multiple_of(8));
             let bytes = bits_per_pixel / 8;
             let chunk = usize::from(bytes);
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,7 +64,7 @@ impl ColorType {
             subbyte => {
                 let samples_per_byte = 8 / subbyte as usize;
                 let whole = samples / samples_per_byte;
-                let fract = usize::from(samples % samples_per_byte > 0);
+                let fract = usize::from(!samples.is_multiple_of(samples_per_byte));
                 whole + fract
             }
         }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -296,7 +296,7 @@ impl fmt::Display for DecodingError {
         use self::DecodingError::*;
         match self {
             IoError(err) => write!(fmt, "{}", err),
-            Parameter(desc) => write!(fmt, "{}", &desc),
+            Parameter(desc) => write!(fmt, "{}", desc),
             Format(desc) => write!(fmt, "{}", desc),
             LimitsExceeded => write!(fmt, "limits are exceeded"),
         }
@@ -449,7 +449,7 @@ impl From<DecodingError> for io::Error {
     fn from(err: DecodingError) -> io::Error {
         match err {
             DecodingError::IoError(err) => err,
-            err => io::Error::new(io::ErrorKind::Other, err.to_string()),
+            err => io::Error::other(err.to_string()),
         }
     }
 }
@@ -1314,7 +1314,7 @@ impl StreamingDecoder {
             Err(DecodingError::Format(
                 FormatErrorInner::DuplicateChunk { kind: chunk::PLTE }.into(),
             ))
-        } else if self.current_chunk.raw_bytes.len() % 3 != 0 {
+        } else if !self.current_chunk.raw_bytes.len().is_multiple_of(3) {
             Err(DecodingError::Format(
                 FormatErrorInner::ChunkLengthWrong { kind: chunk::PLTE }.into(),
             ))
@@ -1761,7 +1761,7 @@ impl StreamingDecoder {
             }
         };
 
-        match fdeflate::decompress_to_vec_bounded(&compressed_data, self.limits.bytes) {
+        match fdeflate::decompress_to_vec_bounded(compressed_data, self.limits.bytes) {
             Ok(profile) => {
                 self.limits.reserve_bytes(profile.len())?;
                 info.icc_profile_name = Some(decode_iso_8859_1(keyword_slice));

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -125,7 +125,7 @@ impl From<io::Error> for EncodingError {
 
 impl From<EncodingError> for io::Error {
     fn from(err: EncodingError) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, err.to_string())
+        io::Error::other(err.to_string())
     }
 }
 
@@ -180,10 +180,10 @@ impl<'a, W: Write> Encoder<'a, W> {
             return Err(EncodingError::Format(FormatErrorKind::NotAnimated.into()));
         }
 
-        if let Some(actl) = info.animation_control {
-            if actl.num_frames == 0 {
-                return Err(EncodingError::Format(FormatErrorKind::ZeroFrames.into()));
-            }
+        if let Some(actl) = info.animation_control
+            && actl.num_frames == 0
+        {
+            return Err(EncodingError::Format(FormatErrorKind::ZeroFrames.into()));
         }
 
         Ok(Encoder {
@@ -882,11 +882,11 @@ impl<W: Write> Writer<W> {
     fn increment_images_written(&mut self) {
         self.images_written = self.images_written.saturating_add(1);
 
-        if let Some(actl) = self.info.animation_control {
-            if actl.num_frames <= self.animation_written {
-                // If we've written all animation frames, all following will be normal image chunks.
-                self.info.frame_control = None;
-            }
+        if let Some(actl) = self.info.animation_control
+            && actl.num_frames <= self.animation_written
+        {
+            // If we've written all animation frames, all following will be normal image chunks.
+            self.info.frame_control = None;
         }
     }
 
@@ -1298,8 +1298,9 @@ impl<'a, W: Write> Write for ChunkWriter<'a, W> {
 
             // Prepare the next animated frame, if any.
             let no_fctl = wrt.should_skip_frame_control_on_default_image();
-            if wrt.info.frame_control.is_some() && !no_fctl {
-                let fctl = wrt.info.frame_control.as_mut().unwrap();
+            if let Some(fctl) = wrt.info.frame_control.as_mut()
+                && !no_fctl
+            {
                 self.buffer[0..4].copy_from_slice(&fctl.sequence_number.to_be_bytes());
                 fctl.sequence_number += 1;
                 self.index = 4;

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -413,21 +413,20 @@ fn filter_internal(
             NoFilter
         }
         Sub => {
-            let mut out_chunks = output[bpp..].chunks_exact_mut(CHUNK_SIZE);
-            let mut cur_chunks = current[bpp..].chunks_exact(CHUNK_SIZE);
-            let mut prev_chunks = current[..len - bpp].chunks_exact(CHUNK_SIZE);
+            let (out_chunks, out_chunks_rem) = output[bpp..].as_chunks_mut::<CHUNK_SIZE>();
+            let (cur_chunks, cur_chunks_rem) = current[bpp..].as_chunks::<CHUNK_SIZE>();
+            let (prev_chunks, prev_chunks_rem) = current[..len - bpp].as_chunks::<CHUNK_SIZE>();
 
-            for ((out, cur), prev) in (&mut out_chunks).zip(&mut cur_chunks).zip(&mut prev_chunks) {
+            for ((out, cur), prev) in out_chunks.iter_mut().zip(cur_chunks).zip(prev_chunks) {
                 for i in 0..CHUNK_SIZE {
                     out[i] = cur[i].wrapping_sub(prev[i]);
                 }
             }
 
-            for ((out, cur), &prev) in out_chunks
-                .into_remainder()
+            for ((out, cur), &prev) in out_chunks_rem
                 .iter_mut()
-                .zip(cur_chunks.remainder())
-                .zip(prev_chunks.remainder())
+                .zip(cur_chunks_rem)
+                .zip(prev_chunks_rem)
             {
                 *out = cur.wrapping_sub(prev);
             }
@@ -436,36 +435,37 @@ fn filter_internal(
             Sub
         }
         Up => {
-            let mut out_chunks = output.chunks_exact_mut(CHUNK_SIZE);
-            let mut cur_chunks = current.chunks_exact(CHUNK_SIZE);
-            let mut prev_chunks = previous.chunks_exact(CHUNK_SIZE);
+            let (out_chunks, out_chunks_rem) = output.as_chunks_mut::<CHUNK_SIZE>();
+            let (cur_chunks, cur_chunks_rem) = current.as_chunks::<CHUNK_SIZE>();
+            let (prev_chunks, prev_chunks_rem) = previous.as_chunks::<CHUNK_SIZE>();
 
-            for ((out, cur), prev) in (&mut out_chunks).zip(&mut cur_chunks).zip(&mut prev_chunks) {
+            for ((out, cur), prev) in out_chunks.iter_mut().zip(cur_chunks).zip(prev_chunks) {
                 for i in 0..CHUNK_SIZE {
                     out[i] = cur[i].wrapping_sub(prev[i]);
                 }
             }
 
-            for ((out, cur), &prev) in out_chunks
-                .into_remainder()
+            for ((out, cur), &prev) in out_chunks_rem
                 .iter_mut()
-                .zip(cur_chunks.remainder())
-                .zip(prev_chunks.remainder())
+                .zip(cur_chunks_rem)
+                .zip(prev_chunks_rem)
             {
                 *out = cur.wrapping_sub(prev);
             }
             Up
         }
         Avg => {
-            let mut out_chunks = output[bpp..].chunks_exact_mut(CHUNK_SIZE);
-            let mut cur_chunks = current[bpp..].chunks_exact(CHUNK_SIZE);
-            let mut cur_minus_bpp_chunks = current[..len - bpp].chunks_exact(CHUNK_SIZE);
-            let mut prev_chunks = previous[bpp..].chunks_exact(CHUNK_SIZE);
+            let (out_chunks, out_chunks_rem) = output[bpp..].as_chunks_mut::<CHUNK_SIZE>();
+            let (cur_chunks, cur_chunks_rem) = current[bpp..].as_chunks::<CHUNK_SIZE>();
+            let (cur_minus_bpp_chunks, cur_minus_bpp_chunks_rem) =
+                current[..len - bpp].as_chunks::<CHUNK_SIZE>();
+            let (prev_chunks, prev_chunks_rem) = previous[bpp..].as_chunks::<CHUNK_SIZE>();
 
-            for (((out, cur), cur_minus_bpp), prev) in (&mut out_chunks)
-                .zip(&mut cur_chunks)
-                .zip(&mut cur_minus_bpp_chunks)
-                .zip(&mut prev_chunks)
+            for (((out, cur), cur_minus_bpp), prev) in out_chunks
+                .iter_mut()
+                .zip(cur_chunks)
+                .zip(cur_minus_bpp_chunks)
+                .zip(prev_chunks)
             {
                 for i in 0..CHUNK_SIZE {
                     // Bitwise average of two integers without overflow and
@@ -479,12 +479,11 @@ fn filter_internal(
                 }
             }
 
-            for (((out, cur), &cur_minus_bpp), &prev) in out_chunks
-                .into_remainder()
+            for (((out, cur), &cur_minus_bpp), &prev) in out_chunks_rem
                 .iter_mut()
-                .zip(cur_chunks.remainder())
-                .zip(cur_minus_bpp_chunks.remainder())
-                .zip(prev_chunks.remainder())
+                .zip(cur_chunks_rem)
+                .zip(cur_minus_bpp_chunks_rem)
+                .zip(prev_chunks_rem)
             {
                 *out = cur.wrapping_sub((cur_minus_bpp & prev) + ((cur_minus_bpp ^ prev) >> 1));
             }
@@ -495,30 +494,30 @@ fn filter_internal(
             Avg
         }
         Paeth => {
-            let mut out_chunks = output[bpp..].chunks_exact_mut(CHUNK_SIZE);
-            let mut cur_chunks = current[bpp..].chunks_exact(CHUNK_SIZE);
-            let mut a_chunks = current[..len - bpp].chunks_exact(CHUNK_SIZE);
-            let mut b_chunks = previous[bpp..].chunks_exact(CHUNK_SIZE);
-            let mut c_chunks = previous[..len - bpp].chunks_exact(CHUNK_SIZE);
+            let (out_chunks, out_chunks_rem) = output[bpp..].as_chunks_mut::<CHUNK_SIZE>();
+            let (cur_chunks, cur_chunks_rem) = current[bpp..].as_chunks::<CHUNK_SIZE>();
+            let (a_chunks, a_chunks_rem) = current[..len - bpp].as_chunks::<CHUNK_SIZE>();
+            let (b_chunks, b_chunks_rem) = previous[bpp..].as_chunks::<CHUNK_SIZE>();
+            let (c_chunks, c_chunks_rem) = previous[..len - bpp].as_chunks::<CHUNK_SIZE>();
 
-            for ((((out, cur), a), b), c) in (&mut out_chunks)
-                .zip(&mut cur_chunks)
-                .zip(&mut a_chunks)
-                .zip(&mut b_chunks)
-                .zip(&mut c_chunks)
+            for ((((out, cur), a), b), c) in out_chunks
+                .iter_mut()
+                .zip(cur_chunks)
+                .zip(a_chunks)
+                .zip(b_chunks)
+                .zip(c_chunks)
             {
                 for i in 0..CHUNK_SIZE {
                     out[i] = cur[i].wrapping_sub(paeth::filter_paeth_fpnge(a[i], b[i], c[i]));
                 }
             }
 
-            for ((((out, cur), &a), &b), &c) in out_chunks
-                .into_remainder()
+            for ((((out, cur), &a), &b), &c) in out_chunks_rem
                 .iter_mut()
-                .zip(cur_chunks.remainder())
-                .zip(a_chunks.remainder())
-                .zip(b_chunks.remainder())
-                .zip(c_chunks.remainder())
+                .zip(cur_chunks_rem)
+                .zip(a_chunks_rem)
+                .zip(b_chunks_rem)
+                .zip(c_chunks_rem)
             {
                 *out = cur.wrapping_sub(paeth::filter_paeth_fpnge(a, b, c));
             }

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,5 +1,3 @@
-use core::convert::TryInto;
-
 use crate::{common::BytesPerPixel, Compression};
 
 mod paeth;
@@ -127,43 +125,43 @@ pub(crate) fn unfilter(
             }
             BytesPerPixel::Two => {
                 let mut prev = [0; 2];
-                for chunk in current.chunks_exact_mut(2) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0]),
                         chunk[1].wrapping_add(prev[1]),
                     ];
-                    *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Three => {
                 let mut prev = [0; 3];
-                for chunk in current.chunks_exact_mut(3) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0]),
                         chunk[1].wrapping_add(prev[1]),
                         chunk[2].wrapping_add(prev[2]),
                     ];
-                    *TryInto::<&mut [u8; 3]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Four => {
                 let mut prev = [0; 4];
-                for chunk in current.chunks_exact_mut(4) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0]),
                         chunk[1].wrapping_add(prev[1]),
                         chunk[2].wrapping_add(prev[2]),
                         chunk[3].wrapping_add(prev[3]),
                     ];
-                    *TryInto::<&mut [u8; 4]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Six => {
                 let mut prev = [0; 6];
-                for chunk in current.chunks_exact_mut(6) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0]),
                         chunk[1].wrapping_add(prev[1]),
@@ -172,13 +170,13 @@ pub(crate) fn unfilter(
                         chunk[4].wrapping_add(prev[4]),
                         chunk[5].wrapping_add(prev[5]),
                     ];
-                    *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Eight => {
                 let mut prev = [0; 8];
-                for chunk in current.chunks_exact_mut(8) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0]),
                         chunk[1].wrapping_add(prev[1]),
@@ -189,7 +187,7 @@ pub(crate) fn unfilter(
                         chunk[6].wrapping_add(prev[6]),
                         chunk[7].wrapping_add(prev[7]),
                     ];
-                    *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
@@ -208,43 +206,43 @@ pub(crate) fn unfilter(
             }
             BytesPerPixel::Two => {
                 let mut prev = [0; 2];
-                for chunk in current.chunks_exact_mut(2) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0] / 2),
                         chunk[1].wrapping_add(prev[1] / 2),
                     ];
-                    *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Three => {
                 let mut prev = [0; 3];
-                for chunk in current.chunks_exact_mut(3) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0] / 2),
                         chunk[1].wrapping_add(prev[1] / 2),
                         chunk[2].wrapping_add(prev[2] / 2),
                     ];
-                    *TryInto::<&mut [u8; 3]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Four => {
                 let mut prev = [0; 4];
-                for chunk in current.chunks_exact_mut(4) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0] / 2),
                         chunk[1].wrapping_add(prev[1] / 2),
                         chunk[2].wrapping_add(prev[2] / 2),
                         chunk[3].wrapping_add(prev[3] / 2),
                     ];
-                    *TryInto::<&mut [u8; 4]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Six => {
                 let mut prev = [0; 6];
-                for chunk in current.chunks_exact_mut(6) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0] / 2),
                         chunk[1].wrapping_add(prev[1] / 2),
@@ -253,13 +251,13 @@ pub(crate) fn unfilter(
                         chunk[4].wrapping_add(prev[4] / 2),
                         chunk[5].wrapping_add(prev[5] / 2),
                     ];
-                    *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
             BytesPerPixel::Eight => {
                 let mut prev = [0; 8];
-                for chunk in current.chunks_exact_mut(8) {
+                for chunk in current.as_chunks_mut().0.iter_mut() {
                     let new_chunk = [
                         chunk[0].wrapping_add(prev[0] / 2),
                         chunk[1].wrapping_add(prev[1] / 2),
@@ -270,60 +268,90 @@ pub(crate) fn unfilter(
                         chunk[6].wrapping_add(prev[6] / 2),
                         chunk[7].wrapping_add(prev[7] / 2),
                     ];
-                    *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     prev = new_chunk;
                 }
             }
         },
         Avg => match tbpp {
             BytesPerPixel::One => {
-                let mut lprev = [0; 1];
-                for (chunk, above) in current.chunks_exact_mut(1).zip(previous.chunks_exact(1)) {
+                const BPP: usize = 1;
+                let mut lprev = [0; BPP];
+                for (chunk, above) in current
+                    .as_chunks_mut()
+                    .0
+                    .iter_mut()
+                    .zip(previous.as_chunks::<BPP>().0.iter())
+                {
                     let new_chunk =
                         [chunk[0].wrapping_add(((above[0] as u16 + lprev[0] as u16) / 2) as u8)];
-                    *TryInto::<&mut [u8; 1]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     lprev = new_chunk;
                 }
             }
             BytesPerPixel::Two => {
-                let mut lprev = [0; 2];
-                for (chunk, above) in current.chunks_exact_mut(2).zip(previous.chunks_exact(2)) {
+                const BPP: usize = 2;
+                let mut lprev = [0; BPP];
+                for (chunk, above) in current
+                    .as_chunks_mut()
+                    .0
+                    .iter_mut()
+                    .zip(previous.as_chunks::<BPP>().0.iter())
+                {
                     let new_chunk = [
                         chunk[0].wrapping_add(((above[0] as u16 + lprev[0] as u16) / 2) as u8),
                         chunk[1].wrapping_add(((above[1] as u16 + lprev[1] as u16) / 2) as u8),
                     ];
-                    *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     lprev = new_chunk;
                 }
             }
             BytesPerPixel::Three => {
-                let mut lprev = [0; 3];
-                for (chunk, above) in current.chunks_exact_mut(3).zip(previous.chunks_exact(3)) {
+                const BPP: usize = 3;
+                let mut lprev = [0; BPP];
+                for (chunk, above) in current
+                    .as_chunks_mut()
+                    .0
+                    .iter_mut()
+                    .zip(previous.as_chunks::<BPP>().0.iter())
+                {
                     let new_chunk = [
                         chunk[0].wrapping_add(((above[0] as u16 + lprev[0] as u16) / 2) as u8),
                         chunk[1].wrapping_add(((above[1] as u16 + lprev[1] as u16) / 2) as u8),
                         chunk[2].wrapping_add(((above[2] as u16 + lprev[2] as u16) / 2) as u8),
                     ];
-                    *TryInto::<&mut [u8; 3]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     lprev = new_chunk;
                 }
             }
             BytesPerPixel::Four => {
-                let mut lprev = [0; 4];
-                for (chunk, above) in current.chunks_exact_mut(4).zip(previous.chunks_exact(4)) {
+                const BPP: usize = 4;
+                let mut lprev = [0; BPP];
+                for (chunk, above) in current
+                    .as_chunks_mut()
+                    .0
+                    .iter_mut()
+                    .zip(previous.as_chunks::<BPP>().0.iter())
+                {
                     let new_chunk = [
                         chunk[0].wrapping_add(((above[0] as u16 + lprev[0] as u16) / 2) as u8),
                         chunk[1].wrapping_add(((above[1] as u16 + lprev[1] as u16) / 2) as u8),
                         chunk[2].wrapping_add(((above[2] as u16 + lprev[2] as u16) / 2) as u8),
                         chunk[3].wrapping_add(((above[3] as u16 + lprev[3] as u16) / 2) as u8),
                     ];
-                    *TryInto::<&mut [u8; 4]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     lprev = new_chunk;
                 }
             }
             BytesPerPixel::Six => {
-                let mut lprev = [0; 6];
-                for (chunk, above) in current.chunks_exact_mut(6).zip(previous.chunks_exact(6)) {
+                const BPP: usize = 6;
+                let mut lprev = [0; BPP];
+                for (chunk, above) in current
+                    .as_chunks_mut()
+                    .0
+                    .iter_mut()
+                    .zip(previous.as_chunks::<BPP>().0.iter())
+                {
                     let new_chunk = [
                         chunk[0].wrapping_add(((above[0] as u16 + lprev[0] as u16) / 2) as u8),
                         chunk[1].wrapping_add(((above[1] as u16 + lprev[1] as u16) / 2) as u8),
@@ -332,13 +360,19 @@ pub(crate) fn unfilter(
                         chunk[4].wrapping_add(((above[4] as u16 + lprev[4] as u16) / 2) as u8),
                         chunk[5].wrapping_add(((above[5] as u16 + lprev[5] as u16) / 2) as u8),
                     ];
-                    *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     lprev = new_chunk;
                 }
             }
             BytesPerPixel::Eight => {
-                let mut lprev = [0; 8];
-                for (chunk, above) in current.chunks_exact_mut(8).zip(previous.chunks_exact(8)) {
+                const BPP: usize = 8;
+                let mut lprev = [0; BPP];
+                for (chunk, above) in current
+                    .as_chunks_mut()
+                    .0
+                    .iter_mut()
+                    .zip(previous.as_chunks::<BPP>().0.iter())
+                {
                     let new_chunk = [
                         chunk[0].wrapping_add(((above[0] as u16 + lprev[0] as u16) / 2) as u8),
                         chunk[1].wrapping_add(((above[1] as u16 + lprev[1] as u16) / 2) as u8),
@@ -349,7 +383,7 @@ pub(crate) fn unfilter(
                         chunk[6].wrapping_add(((above[6] as u16 + lprev[6] as u16) / 2) as u8),
                         chunk[7].wrapping_add(((above[7] as u16 + lprev[7] as u16) / 2) as u8),
                     ];
-                    *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                    *chunk = new_chunk;
                     lprev = new_chunk;
                 }
             }
@@ -559,8 +593,8 @@ fn entropy(buf: &[u8]) -> u64 {
     let mut total = 0;
 
     // Count the number of occurrences of each byte value.
-    let mut chunks = buf.chunks_exact(8);
-    for chunk in &mut chunks {
+    let (chunks, chunks_rem) = buf.as_chunks();
+    for &chunk in chunks {
         // Runs of zeros are common and very compressible, so treat them as free.
         if chunk == [0; 8] {
             continue;
@@ -575,7 +609,7 @@ fn entropy(buf: &[u8]) -> u64 {
         }
         total += 8;
     }
-    for &lit in chunks.remainder() {
+    for &lit in chunks_rem {
         counts[0][lit as usize] += 1;
         total += 1;
     }
@@ -608,10 +642,10 @@ fn entropy(buf: &[u8]) -> u64 {
 fn sum_buffer(buf: &[u8]) -> u64 {
     const CHUNK_SIZE: usize = 32;
 
-    let mut buf_chunks = buf.chunks_exact(CHUNK_SIZE);
+    let (chunks, chunks_rem) = buf.as_chunks::<CHUNK_SIZE>();
     let mut sum = 0_u64;
 
-    for chunk in &mut buf_chunks {
+    for chunk in chunks {
         // At most, `acc` can be `32 * (i8::MIN as u8) = 32 * 128 = 4096`.
         let mut acc = 0;
         for &b in chunk {
@@ -621,7 +655,7 @@ fn sum_buffer(buf: &[u8]) -> u64 {
     }
 
     let mut acc = 0;
-    for &b in buf_chunks.remainder() {
+    for &b in chunks_rem {
         acc += u64::from((b as i8).unsigned_abs());
     }
 

--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -93,24 +93,34 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
         BytesPerPixel::One => {
             let mut a_bpp = [0; 1];
             let mut c_bpp = [0; 1];
-            for (chunk, b_bpp) in current.chunks_exact_mut(1).zip(previous.chunks_exact(1)) {
+            for (chunk, &b_bpp) in current
+                .as_chunks_mut()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks().0)
+            {
                 let new_chunk = [chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0]))];
-                *TryInto::<&mut [u8; 1]>::try_into(chunk).unwrap() = new_chunk;
+                *chunk = new_chunk;
                 a_bpp = new_chunk;
-                c_bpp = b_bpp.try_into().unwrap();
+                c_bpp = b_bpp;
             }
         }
         BytesPerPixel::Two => {
             let mut a_bpp = [0; 2];
             let mut c_bpp = [0; 2];
-            for (chunk, b_bpp) in current.chunks_exact_mut(2).zip(previous.chunks_exact(2)) {
+            for (chunk, &b_bpp) in current
+                .as_chunks_mut()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks().0)
+            {
                 let new_chunk = [
                     chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
                     chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
                 ];
-                *TryInto::<&mut [u8; 2]>::try_into(chunk).unwrap() = new_chunk;
+                *chunk = new_chunk;
                 a_bpp = new_chunk;
-                c_bpp = b_bpp.try_into().unwrap();
+                c_bpp = b_bpp;
             }
         }
         BytesPerPixel::Three => {
@@ -177,7 +187,12 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
         BytesPerPixel::Six => {
             let mut a_bpp = [0; 6];
             let mut c_bpp = [0; 6];
-            for (chunk, b_bpp) in current.chunks_exact_mut(6).zip(previous.chunks_exact(6)) {
+            for (chunk, &b_bpp) in current
+                .as_chunks_mut()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks().0)
+            {
                 let new_chunk = [
                     chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
                     chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
@@ -186,7 +201,7 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
                     chunk[4].wrapping_add(filter_paeth(a_bpp[4], b_bpp[4], c_bpp[4])),
                     chunk[5].wrapping_add(filter_paeth(a_bpp[5], b_bpp[5], c_bpp[5])),
                 ];
-                *TryInto::<&mut [u8; 6]>::try_into(chunk).unwrap() = new_chunk;
+                *chunk = new_chunk;
                 a_bpp = new_chunk;
                 c_bpp = b_bpp.try_into().unwrap();
             }
@@ -194,7 +209,12 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
         BytesPerPixel::Eight => {
             let mut a_bpp = [0; 8];
             let mut c_bpp = [0; 8];
-            for (chunk, b_bpp) in current.chunks_exact_mut(8).zip(previous.chunks_exact(8)) {
+            for (chunk, &b_bpp) in current
+                .as_chunks_mut()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks().0)
+            {
                 let new_chunk = [
                     chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
                     chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
@@ -205,7 +225,7 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
                     chunk[6].wrapping_add(filter_paeth(a_bpp[6], b_bpp[6], c_bpp[6])),
                     chunk[7].wrapping_add(filter_paeth(a_bpp[7], b_bpp[7], c_bpp[7])),
                 ];
-                *TryInto::<&mut [u8; 8]>::try_into(chunk).unwrap() = new_chunk;
+                *chunk = new_chunk;
                 a_bpp = new_chunk;
                 c_bpp = b_bpp.try_into().unwrap();
             }
@@ -229,8 +249,10 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             let mut c_bpp = [0; BPP];
 
             for (c, p) in current
-                .chunks_exact_mut(BPP)
-                .zip(previous.chunks_exact(BPP))
+                .as_chunks_mut::<BPP>()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks::<BPP>().0.iter())
             {
                 for i in 0..BPP {
                     c[i] = c[i].wrapping_add(filter_paeth_stbi(a_bpp[i], p[i] as i16, c_bpp[i]));
@@ -246,8 +268,10 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             let mut c_bpp = [0; BPP];
 
             for (c, p) in current
-                .chunks_exact_mut(BPP)
-                .zip(previous.chunks_exact(BPP))
+                .as_chunks_mut::<BPP>()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks::<BPP>().0.iter())
             {
                 for i in 0..BPP {
                     c[i] = c[i].wrapping_add(filter_paeth_stbi(a_bpp[i], p[i] as i16, c_bpp[i]));
@@ -263,8 +287,10 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             let mut c_bpp = [0; BPP];
 
             for (c, p) in current
-                .chunks_exact_mut(BPP)
-                .zip(previous.chunks_exact(BPP))
+                .as_chunks_mut::<BPP>()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks::<BPP>().0.iter())
             {
                 for i in 0..BPP {
                     c[i] = c[i].wrapping_add(filter_paeth_stbi(a_bpp[i], p[i] as i16, c_bpp[i]));
@@ -280,8 +306,10 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             let mut c_bpp = [0; BPP];
 
             for (c, p) in current
-                .chunks_exact_mut(BPP)
-                .zip(previous.chunks_exact(BPP))
+                .as_chunks_mut::<BPP>()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks::<BPP>().0.iter())
             {
                 for i in 0..BPP {
                     c[i] = c[i].wrapping_add(filter_paeth_stbi(a_bpp[i], p[i] as i16, c_bpp[i]));
@@ -297,8 +325,10 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             let mut c_bpp = [0; BPP];
 
             for (c, p) in current
-                .chunks_exact_mut(BPP)
-                .zip(previous.chunks_exact(BPP))
+                .as_chunks_mut::<BPP>()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks::<BPP>().0.iter())
             {
                 for i in 0..BPP {
                     c[i] = c[i].wrapping_add(filter_paeth_stbi(a_bpp[i], p[i] as i16, c_bpp[i]));
@@ -328,8 +358,10 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             let mut c_bpp = [0; BPP];
 
             for (c, p) in current
-                .chunks_exact_mut(BPP)
-                .zip(previous.chunks_exact(BPP))
+                .as_chunks_mut::<BPP>()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks::<BPP>().0.iter())
             {
                 for i in 0..BPP {
                     c[i] = c[i].wrapping_add(filter_paeth_stbi(a_bpp[i], p[i] as i16, c_bpp[i]));

--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -135,21 +135,20 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
             }
             let mut a_bpp = [0; 3];
             let mut c_bpp = [0; 3];
-
-            let mut previous = &previous[..previous.len() / 3 * 3];
-            let current_len = current.len();
-            let mut current = &mut current[..current_len / 3 * 3];
-
-            while let ([c0, c1, c2, c_rest @ ..], [p0, p1, p2, p_rest @ ..]) = (current, previous) {
-                current = c_rest;
-                previous = p_rest;
-
-                *c0 = c0.wrapping_add(filter_paeth(a_bpp[0], *p0, c_bpp[0]));
-                *c1 = c1.wrapping_add(filter_paeth(a_bpp[1], *p1, c_bpp[1]));
-                *c2 = c2.wrapping_add(filter_paeth(a_bpp[2], *p2, c_bpp[2]));
-
-                a_bpp = [*c0, *c1, *c2];
-                c_bpp = [*p0, *p1, *p2];
+            for (chunk, &b_bpp) in current
+                .as_chunks_mut()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks().0)
+            {
+                let new_chunk = [
+                    chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
+                    chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
+                    chunk[2].wrapping_add(filter_paeth(a_bpp[2], b_bpp[2], c_bpp[2])),
+                ];
+                *chunk = new_chunk;
+                a_bpp = new_chunk;
+                c_bpp = b_bpp.try_into().unwrap();
             }
         }
         BytesPerPixel::Four => {
@@ -164,24 +163,21 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
 
             let mut a_bpp = [0; 4];
             let mut c_bpp = [0; 4];
-
-            let mut previous = &previous[..previous.len() & !3];
-            let current_len = current.len();
-            let mut current = &mut current[..current_len & !3];
-
-            while let ([c0, c1, c2, c3, c_rest @ ..], [p0, p1, p2, p3, p_rest @ ..]) =
-                (current, previous)
+            for (chunk, &b_bpp) in current
+                .as_chunks_mut()
+                .0
+                .iter_mut()
+                .zip(previous.as_chunks().0)
             {
-                current = c_rest;
-                previous = p_rest;
-
-                *c0 = c0.wrapping_add(filter_paeth(a_bpp[0], *p0, c_bpp[0]));
-                *c1 = c1.wrapping_add(filter_paeth(a_bpp[1], *p1, c_bpp[1]));
-                *c2 = c2.wrapping_add(filter_paeth(a_bpp[2], *p2, c_bpp[2]));
-                *c3 = c3.wrapping_add(filter_paeth(a_bpp[3], *p3, c_bpp[3]));
-
-                a_bpp = [*c0, *c1, *c2, *c3];
-                c_bpp = [*p0, *p1, *p2, *p3];
+                let new_chunk = [
+                    chunk[0].wrapping_add(filter_paeth(a_bpp[0], b_bpp[0], c_bpp[0])),
+                    chunk[1].wrapping_add(filter_paeth(a_bpp[1], b_bpp[1], c_bpp[1])),
+                    chunk[2].wrapping_add(filter_paeth(a_bpp[2], b_bpp[2], c_bpp[2])),
+                    chunk[3].wrapping_add(filter_paeth(a_bpp[3], b_bpp[3], c_bpp[3])),
+                ];
+                *chunk = new_chunk;
+                a_bpp = new_chunk;
+                c_bpp = b_bpp.try_into().unwrap();
             }
         }
         BytesPerPixel::Six => {


### PR DESCRIPTION
Based on the thumbs up in https://github.com/image-rs/image-png/issues/690, I figured it'd be worth seeing what this upgrade would look like.
- Bump MSRV to 1.88 in `Cargo.toml` and CI config
- Upgrade Rust edition from 2021 to 2024 since the edition was introduced in 1.85
- Apply clippy suggestions for functions that have been introduced since last MSRV (`is_multiple_of`, `io::Error::other`, let chains, removing unnecessary references)

Going from slices to arrays allowed us to get rid of `TryInto` casts and prevent bugs from mismatched sizes in this refactor due to type checking. I tried to split the unfilter/filter commits into similar chunks of logic.

I can split into other PRs if this is seen as too much.
- I'm mixed on the `is_multiple_of` clippy suggestion being better, this could just be unfamiliarity with using it.
- I reverted non-x86 Paeth filter 3 and 4 bpp special casing which was working around an LLVM issue. Now that we have `as_chunks`, I chose to use that since I was changing the impls around it. If this should be in its own PR, I can remove this commit.

