### PR TITLE
Minor optimization in filter_internal Paeth

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -490,7 +490,9 @@ fn filter_internal(
             }
 
             for i in 0..bpp {
-                output[i] = current[i].wrapping_sub(paeth::filter_paeth_fpnge(0, previous[i], 0));
+                /* a = 0, b = b, c = 0
+                In this case, paeth will always return b */
+                output[i] = current[i].wrapping_sub(previous[i]);
             }
             Paeth
         }


### PR DESCRIPTION
https://github.com/image-rs/image-png/blob/4f873e4a628c0e8dbb4204fb263697298f89eb01/src/filter/mod.rs#L492-L494
This is for the first few bpp bytes where a and c are 0.
Because a and c are 0, Paeth will always return b.

p = 0 + b - 0 = b
pa = abs(p - 0) = abs(b)
pb = abs(p - b) = 0
pc = abs(p - 0) = abs(b)

So if b == 0, it doesn't matter if a or b or c is chosen - Paeth will just return 0.
If b != 0, b is guaranteed to be chosen because pb is the smallest of all pa, pb, pc.

So we could change it into:
```rust
for i in 0..bpp {
    /* a = 0, b = b, c = 0
    In this case, Paeth will always return b */
    output[i] = current[i].wrapping_sub(previous[i]);
}
```
This would be slightly more efficient compared to re-calculate Paeth for it.