### PR TITLE
Use empty slice instead of zero-filled vec for initial row in `write_image_data`

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -783,9 +783,6 @@ impl<W: Write> Writer<W> {
             ));
         }
 
-        let prev = vec![0; in_len];
-        let mut prev = prev.as_slice();
-
         let bpp = self.info.bpp_in_prediction();
         let filter_method = self.options.filter;
 
@@ -803,9 +800,10 @@ impl<W: Write> Writer<W> {
                 let mut compressor = fdeflate::Compressor::new(std::io::Cursor::new(Vec::new()))?;
 
                 let mut current = vec![0; in_len + 1];
+                let mut prev: &[u8] = &[];
+
                 for line in data.chunks(in_len) {
                     let filter_type = filter(filter_method, bpp, prev, line, &mut current[1..]);
-
                     current[0] = filter_type as u8;
                     compressor.write_data(&current)?;
                     prev = line;
@@ -831,18 +829,19 @@ impl<W: Write> Writer<W> {
                 }
             }
             DeflateCompression::Level(level) => {
-                let mut current = vec![0; in_len];
-
-                let mut zlib =
+                let mut compressor =
                     ZlibEncoder::new(Vec::new(), flate2::Compression::new(u32::from(level)));
-                for line in data.chunks(in_len) {
-                    let filter_type = filter(filter_method, bpp, prev, line, &mut current);
 
-                    zlib.write_all(&[filter_type as u8])?;
-                    zlib.write_all(&current)?;
+                let mut current = vec![0; in_len + 1];
+                let mut prev: &[u8] = &[];
+
+                for line in data.chunks(in_len) {
+                    let filter_type = filter(filter_method, bpp, prev, line, &mut current[1..]);
+                    current[0] = filter_type as u8;
+                    compressor.write_all(&current)?;
                     prev = line;
                 }
-                zlib.finish()?
+                compressor.finish()?
             }
         };
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -537,6 +537,13 @@ pub(crate) fn filter(
     let bpp = bpp.into_usize();
     let len = current.len();
 
+    // first row
+    if previous.is_empty() {
+        // Sub is the most efficient filter for the first row
+        return filter_internal(RowFilter::Sub, bpp, len, previous, current, output);
+        // NoFilter and Sub are the only filters that works when previous is empty
+    }
+
     match method {
         Filter::Adaptive => adaptive_filter(sum_buffer, bpp, len, previous, current, output),
         Filter::MinEntropy => adaptive_filter(entropy, bpp, len, previous, current, output),


### PR DESCRIPTION
In this function:
https://github.com/image-rs/image-png/blob/4f873e4a628c0e8dbb4204fb263697298f89eb01/src/encoder.rs#L757
`prev` is initialized like this:
https://github.com/image-rs/image-png/blob/4f873e4a628c0e8dbb4204fb263697298f89eb01/src/encoder.rs#L786-L787
`prev` is used as a previous scanline for the filtering logic.
But looking at how it's being used:
https://github.com/image-rs/image-png/blob/4f873e4a628c0e8dbb4204fb263697298f89eb01/src/encoder.rs#L833-L846
I noticed that the allocated buffer - `prev` - is only used on the first iteration, then dropped once `prev` is reassigned to `line`.
So we can initialize `prev` as `&[]` to avoid unnecessary allocation, like this:
```rust
DeflateCompression::Level(level) => {
    let mut compressor =
        ZlibEncoder::new(Vec::new(), flate2::Compression::new(u32::from(level)));

    let mut current = vec![0; in_len + 1];
    let mut prev: &[u8] = &[];

    for line in data.chunks(in_len) {
        let filter_type = filter(filter_method, bpp, prev, line, &mut current[1..]);
        current[0] = filter_type as u8;
        compressor.write_all(&current)?;
        prev = line;
    }
    compressor.finish()?
}
```
Note: I did some syntax cleaning so that this block looks similar to the `DeflateCompression::FdeflateUltraFas` block within the same match block.

But that means the `filter` function also has to be able to handle the empty `prev` case.
So I modified the `filter` function, so that it will simply choose the Sub filter and return early when `previous` is empty.

Note: This provides no meaningful performance improvement at all.