### PR TITLE
Remove imports already in the prelude

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use crate::text_metadata::{ITXtChunk, TEXtChunk, ZTXtChunk};
 use crate::Filter;
 use crate::{chunk, chunk::ChunkType, encoder};
 use io::Write;
-use std::{borrow::Cow, convert::TryFrom, fmt, io};
+use std::{borrow::Cow, fmt, io};
 
 /// Describes how a pixel is encoded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::error;
 use std::fmt;
 use std::io;

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -1,5 +1,3 @@
-use core::convert::TryInto;
-
 use crate::{common::BytesPerPixel, Compression};
 
 mod paeth;

--- a/src/filter/simd.rs
+++ b/src/filter/simd.rs
@@ -1,6 +1,5 @@
 ///! Optional module containing `portable_simd` versions of the most
 ///! important unfiltering algorithms. Enable using the `unstable` feature.
-use core::convert::TryInto;
 use core::simd::prelude::*;
 use core::simd::Select;
 // Import the fastest arch-specific scalar implementations from the outer crate.

--- a/src/text_metadata.rs
+++ b/src/text_metadata.rs
@@ -25,7 +25,6 @@
 //!  ```
 //!  use std::fs::File;
 //!  use std::io::BufReader;
-//!  use std::iter::FromIterator;
 //!  use std::path::PathBuf;
 //!
 //!  // Opening a png file that has a zTXt chunk
@@ -52,7 +51,6 @@
 //!  # use std::env;
 //!  # use std::fs::File;
 //!  # use std::io::BufWriter;
-//!  # use std::iter::FromIterator;
 //!  # use std::path::PathBuf;
 //!  # let file = File::create(PathBuf::from_iter(["target", "text_chunk.png"])).unwrap();
 //!  # let ref mut w = BufWriter::new(file);
@@ -102,7 +100,7 @@ use crate::{chunk, encoder, DecodingError, EncodingError};
 use fdeflate::BoundedDecompressionError;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
-use std::{convert::TryFrom, io::Write};
+use std::io::Write;
 
 /// Default decompression limit for compressed text chunks.
 pub const DECOMPRESSION_LIMIT: usize = 2097152; // 2 MiB


### PR DESCRIPTION
Since edition 2021 (bumped in af389624950f5a22d21389a8161b04874abdd43e), `std::convert::TryInto`, `std::convert::TryFrom` and `std::iter::FromIterator` are already imported in the prelude, so we don’t have to import them manually.

This was originally part of #670, but can go standalone.