### PR TITLE
Remove import of miniz_oxide, unused since 0.17.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ bitflags = "2.0"
 crc32fast = "1.2.0"
 fdeflate = "0.3.3"
 flate2 = "1.0.35"
-miniz_oxide = { version = "0.8", features = ["simd"] }
 
 [dev-dependencies]
 approx = "0.5.1"


### PR DESCRIPTION
It is still a direct dependency of `flate2`.

This was originally part of #670, but can go standalone.