### PR TITLE
Add support for the oFFs chunk

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+### Additions
+
+* Added support for reading and writing the `oFFs` chunk, which records the
+  image's offset relative to a larger page or screen. The parsed value is
+  exposed as `Info::image_offset` and can be set on the encoder via
+  `Encoder::set_image_offset`. ([#645])
+
 ### Fixes
 
 * Reject `Encoder::with_info` calls whose `info.interlaced` is `true` with
@@ -43,6 +50,7 @@
 [#632]: https://github.com/image-rs/image-png/pull/632
 [#633]: https://github.com/image-rs/image-png/pull/633
 [#635]: https://github.com/image-rs/image-png/pull/635
+[#645]: https://github.com/image-rs/image-png/issues/645
 [#646]: https://github.com/image-rs/image-png/pull/646
 [#647]: https://github.com/image-rs/image-png/pull/647
 [#650]: https://github.com/image-rs/image-png/pull/650

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -27,6 +27,8 @@ pub const bKGD: ChunkType = ChunkType(*b"bKGD");
 pub const tIME: ChunkType = ChunkType(*b"tIME");
 /// Physical pixel dimensions
 pub const pHYs: ChunkType = ChunkType(*b"pHYs");
+/// Image offset
+pub const oFFs: ChunkType = ChunkType(*b"oFFs");
 /// Source system's pixel chromaticities
 pub const cHRM: ChunkType = ChunkType(*b"cHRM");
 /// Source system's gamma value

--- a/src/common.rs
+++ b/src/common.rs
@@ -166,6 +166,36 @@ impl Unit {
     }
 }
 
+/// Image offset, as stored in the `oFFs` chunk
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ImageOffset {
+    /// Offset on the X axis, relative to the left edge of the page or screen
+    pub x: i32,
+    /// Offset on the Y axis, relative to the top edge of the page or screen
+    pub y: i32,
+    /// Either *Pixel* or *Micrometer*
+    pub unit: OffsetUnit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+/// Physical unit of the image offset
+pub enum OffsetUnit {
+    Pixel = 0,
+    Micrometer = 1,
+}
+
+impl OffsetUnit {
+    /// u8 -> Self. Temporary solution until Rust provides a canonical one.
+    pub fn from_u8(n: u8) -> Option<OffsetUnit> {
+        match n {
+            0 => Some(OffsetUnit::Pixel),
+            1 => Some(OffsetUnit::Micrometer),
+            _ => None,
+        }
+    }
+}
+
 /// How to reset buffer of an animated png (APNG) at the end of a frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -667,6 +697,8 @@ pub struct Info<'a> {
     /// The image's `tRNS` chunk, if present; contains the alpha channel of the image's palette, 1 byte per entry.
     pub trns: Option<Cow<'a, [u8]>>,
     pub pixel_dims: Option<PixelDimensions>,
+    /// The image's `oFFs` chunk, if present; the image's offset relative to a larger page or screen.
+    pub image_offset: Option<ImageOffset>,
     /// The image's `PLTE` chunk, if present; contains the RGB channels (in that order) of the image's palettes, 3 bytes per entry (1 per channel).
     pub palette: Option<Cow<'a, [u8]>>,
     /// The contents of the image's gAMA chunk, if present.
@@ -727,6 +759,7 @@ impl Default for Info<'_> {
             chrm_chunk: None,
             bkgd: None,
             pixel_dims: None,
+            image_offset: None,
             frame_control: None,
             animation_control: None,
             source_gamma: None,

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -12,8 +12,8 @@ use crate::chunk::is_critical;
 use crate::chunk::{self, ChunkType, IDAT, IEND, IHDR};
 use crate::common::{
     AnimationControl, BitDepth, BlendOp, CapturedChunk, ColorType, ContentLightLevelInfo,
-    DisposeOp, FrameControl, Info, MasteringDisplayColorVolume, ParameterError, ParameterErrorKind,
-    PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
+    DisposeOp, FrameControl, ImageOffset, Info, MasteringDisplayColorVolume, OffsetUnit,
+    ParameterError, ParameterErrorKind, PixelDimensions, ScaledFloat, SourceChromaticities, Unit,
 };
 use crate::text_metadata::{decode_iso_8859_1, ITXtChunk, TEXtChunk, TextDecodingError, ZTXtChunk};
 use crate::traits::ReadBytesExt;
@@ -240,6 +240,7 @@ pub(crate) enum FormatErrorInner {
     InvalidDisposeOp(u8),
     InvalidBlendOp(u8),
     InvalidUnit(u8),
+    InvalidOffsetUnit(u8),
     /// The rendering intent of the sRGB chunk is invalid.
     InvalidSrgbRenderingIntent(u8),
     UnknownCompressionMethod(u8),
@@ -368,6 +369,7 @@ impl fmt::Display for FormatError {
             InvalidDisposeOp(nr) => write!(fmt, "Invalid dispose op {}.", nr),
             InvalidBlendOp(nr) => write!(fmt, "Invalid blend op {}.", nr),
             InvalidUnit(nr) => write!(fmt, "Invalid physical pixel size unit {}.", nr),
+            InvalidOffsetUnit(nr) => write!(fmt, "Invalid image offset unit {}.", nr),
             InvalidSrgbRenderingIntent(nr) => write!(fmt, "Invalid sRGB rendering intent {}.", nr),
             UnknownCompressionMethod(nr) => write!(fmt, "Unknown compression method {}.", nr),
             UnknownFilterMethod(nr) => write!(fmt, "Unknown filter method {}.", nr),
@@ -1071,6 +1073,7 @@ impl StreamingDecoder {
             chunk::sBIT => 1..=4,
             chunk::tRNS => 1..=256,
             chunk::pHYs => 9..=9,
+            chunk::oFFs => 9..=9,
             chunk::gAMA => 4..=4,
             chunk::acTL => 8..=8,
             chunk::fcTL => 26..=26,
@@ -1145,6 +1148,7 @@ impl StreamingDecoder {
             chunk::sBIT => self.parse_sbit(),
             chunk::tRNS => self.parse_trns(),
             chunk::pHYs => self.parse_phys(),
+            chunk::oFFs => self.parse_offs(),
             chunk::gAMA => self.parse_gama(),
             chunk::acTL => self.parse_actl(),
             chunk::fcTL => self.parse_fctl(),
@@ -1474,6 +1478,34 @@ impl StreamingDecoder {
             };
             let pixel_dims = PixelDimensions { xppu, yppu, unit };
             info.pixel_dims = Some(pixel_dims);
+            Ok(())
+        }
+    }
+
+    fn parse_offs(&mut self) -> Result<(), DecodingError> {
+        let info = self.info.as_mut().unwrap();
+        if self.have_idat {
+            Err(DecodingError::Format(
+                FormatErrorInner::AfterIdat { kind: chunk::oFFs }.into(),
+            ))
+        } else if info.image_offset.is_some() {
+            Err(DecodingError::Format(
+                FormatErrorInner::DuplicateChunk { kind: chunk::oFFs }.into(),
+            ))
+        } else {
+            let mut buf = &self.current_chunk.raw_bytes[..];
+            let x = buf.read_be()?;
+            let y = buf.read_be()?;
+            let unit = buf.read_be()?;
+            let unit = match OffsetUnit::from_u8(unit) {
+                Some(unit) => unit,
+                None => {
+                    return Err(DecodingError::Format(
+                        FormatErrorInner::InvalidOffsetUnit(unit).into(),
+                    ))
+                }
+            };
+            info.image_offset = Some(ImageOffset { x, y, unit });
             Ok(())
         }
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -9,7 +9,8 @@ use flate2::write::ZlibEncoder;
 use crate::chunk::{self, ChunkType};
 use crate::common::{
     AnimationControl, BitDepth, BlendOp, BytesPerPixel, ColorType, Compression, DisposeOp,
-    FrameControl, Info, ParameterError, ParameterErrorKind, PixelDimensions, ScaledFloat, Unit,
+    FrameControl, ImageOffset, Info, OffsetUnit, ParameterError, ParameterErrorKind,
+    PixelDimensions, ScaledFloat, Unit,
 };
 use crate::filter::{filter, Filter};
 use crate::text_metadata::{
@@ -417,6 +418,9 @@ impl<'a, W: Write> Encoder<'a, W> {
     pub fn set_pixel_dims(&mut self, pixel_dims: Option<PixelDimensions>) {
         self.info.pixel_dims = pixel_dims
     }
+    pub fn set_image_offset(&mut self, image_offset: Option<ImageOffset>) {
+        self.info.image_offset = image_offset
+    }
     /// Convenience function to add tEXt chunks to [`Info`] struct
     pub fn add_text_chunk(&mut self, keyword: String, text: String) -> Result<()> {
         let text_chunk = TEXtChunk::new(keyword, text);
@@ -607,6 +611,18 @@ impl<W: Write> Writer<W> {
                 Unit::Unspecified => phys_data[8] = 0,
             }
             self.write_chunk(chunk::pHYs, &phys_data)?;
+        }
+
+        // Encode the oFFs chunk
+        if let Some(off) = info.image_offset {
+            let mut offs_data = [0; 9];
+            offs_data[0..4].copy_from_slice(&off.x.to_be_bytes());
+            offs_data[4..8].copy_from_slice(&off.y.to_be_bytes());
+            match off.unit {
+                OffsetUnit::Pixel => offs_data[8] = 0,
+                OffsetUnit::Micrometer => offs_data[8] = 1,
+            }
+            self.write_chunk(chunk::oFFs, &offs_data)?;
         }
 
         // If specified, the sRGB information overrides the source gamma and chromaticities.
@@ -1860,6 +1876,29 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn offs_chunk_roundtrip() {
+        let offset = ImageOffset {
+            x: -12,
+            y: 34,
+            unit: OffsetUnit::Micrometer,
+        };
+
+        let mut out = Vec::new();
+        {
+            let mut encoder = Encoder::new(&mut out, 1, 1);
+            encoder.set_color(ColorType::Grayscale);
+            encoder.set_depth(BitDepth::Eight);
+            encoder.set_image_offset(Some(offset));
+            let mut writer = encoder.write_header().unwrap();
+            writer.write_image_data(&[0]).unwrap();
+        }
+
+        let decoder = Decoder::new(Cursor::new(&*out));
+        let reader = decoder.read_info().unwrap();
+        assert_eq!(reader.info().image_offset, Some(offset));
     }
 
     #[test]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -39,5 +39,6 @@ pub trait WriteBytesExt<T>: io::Write {
 read_bytes_ext!(u8);
 read_bytes_ext!(u16);
 read_bytes_ext!(u32);
+read_bytes_ext!(i32);
 
 write_bytes_ext!(u32);


### PR DESCRIPTION
Adds reading and writing of the `oFFs` chunk, which records the image's offset relative to a larger page or screen. Requested in #645.

On decode the offset is exposed as `Info::image_offset`, and on encode it can be set with `Encoder::set_image_offset`, mirroring how the existing `pHYs` chunk is handled. Added a round-trip test.