### PR TITLE
Reuse fdeflate output buffer for stored fallback

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -811,7 +811,7 @@ impl<W: Write> Writer<W> {
                     prev = line;
                 }
 
-                let compressed = compressor.finish()?.into_inner();
+                let mut compressed = compressor.finish()?.into_inner();
                 if compressed.len()
                     > fdeflate::StoredOnlyCompressor::<()>::compressed_size((in_len + 1) * height)
                 {
@@ -819,8 +819,12 @@ impl<W: Write> Writer<W> {
                     // more space than that.
                     //
                     // This is essentially a fallback to NoCompression.
+                    // The compressed stream is larger than the stored stream, so its allocation
+                    // is guaranteed to have enough capacity for the fallback output. Reuse it to
+                    // avoid freeing and immediately reallocating an image-sized buffer.
+                    compressed.clear();
                     let mut compressor =
-                        fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(Vec::new()))?;
+                        fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(compressed))?;
                     for line in data.chunks(in_len) {
                         compressor.write_data(&[0])?;
                         compressor.write_data(line)?;


### PR DESCRIPTION
This PR reuses the fdeflate output buffer when incompressible image data falls back to stored encoding. Previously, the encoder dropped the compressed buffer and created a new one, causing an unnecessary allocation and several reallocations.

The encoded output is unchanged, and no public APIs or unsafe code are involved. Local measurements produced the following results:

| RGBA image | Allocations |        Allocated bytes | Reallocations |     Latency |
| ---------- | ----------: | ---------------------: | ------------: | ----------: |
| 64×64      |       4 → 3 |        44,545 → 27,649 |        16 → 9 |  \~3% lower |
| 256×256    |       4 → 3 |      700,417 → 436,225 |       22 → 13 |  \~4% lower |
| 1024×1024  |       4 → 3 | 11,157,505 → 6,955,009 |       28 → 17 | \~16% lower |

The benchmarks and allocation instrumentation were run locally and are not included in this PR.

Tested with `cargo test --workspace --lib --tests`, `cargo test --doc`, `cargo fmt -- --check`, and `cargo +1.73.0 check --lib`.