### PR TITLE
Avoid temporary buffers when writing fdAT chunks

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -535,6 +535,33 @@ pub(crate) fn write_chunk<W: Write>(mut w: W, name: chunk::ChunkType, data: &[u8
     Ok(())
 }
 
+/// Writes an `fdAT` chunk without copying its sequence number and data into one buffer.
+fn write_fdat_chunk<W: Write>(
+    mut w: W,
+    sequence_number: u32,
+    compressed_data: &[u8],
+) -> Result<()> {
+    let length = u32::try_from(compressed_data.len())
+        .ok()
+        .and_then(|length| length.checked_add(4))
+        .ok_or(EncodingError::LimitsExceeded)?;
+    let sequence_number = sequence_number.to_be_bytes();
+
+    let mut header = [0; 12];
+    header[..4].copy_from_slice(&length.to_be_bytes());
+    header[4..8].copy_from_slice(&chunk::fdAT.0);
+    header[8..].copy_from_slice(&sequence_number);
+
+    w.write_all(&header)?;
+    w.write_all(compressed_data)?;
+
+    let mut crc = Crc32::new();
+    crc.update(&header[4..]);
+    crc.update(compressed_data);
+    w.write_be(crc.finalize())?;
+    Ok(())
+}
+
 impl<W: Write> Writer<W> {
     fn new(w: W, info: PartialInfo, options: Options) -> Writer<W> {
         Writer {
@@ -862,12 +889,8 @@ impl<W: Write> Writer<W> {
                 if self.images_written == 0 {
                     self.write_zlib_encoded_idat(&zlib_encoded)?;
                 } else {
-                    let buff_size = zlib_encoded.len().min(Self::MAX_fdAT_CHUNK_LEN as usize);
-                    let mut alldata = vec![0u8; 4 + buff_size];
                     for chunk in zlib_encoded.chunks(Self::MAX_fdAT_CHUNK_LEN as usize) {
-                        alldata[..4].copy_from_slice(&fctl.sequence_number.to_be_bytes());
-                        alldata[4..][..chunk.len()].copy_from_slice(chunk);
-                        write_chunk(&mut self.w, chunk::fdAT, &alldata[..4 + chunk.len()])?;
+                        write_fdat_chunk(&mut self.w, fctl.sequence_number, chunk)?;
                         fctl.sequence_number = fctl.sequence_number.wrapping_add(1);
                     }
                 }
@@ -1802,6 +1825,27 @@ mod tests {
     use std::cmp;
     use std::fs::File;
     use std::io::Cursor;
+
+    #[test]
+    fn fdat_chunk_matches_contiguous_chunk() {
+        for data_len in [0, 1, 4, 255, 4097] {
+            let data: Vec<_> = (0..data_len).map(|i| i as u8).collect();
+
+            for sequence_number in [0, 1, u32::MAX] {
+                let mut payload = Vec::with_capacity(data.len() + 4);
+                payload.extend_from_slice(&sequence_number.to_be_bytes());
+                payload.extend_from_slice(&data);
+
+                let mut expected = Vec::new();
+                write_chunk(&mut expected, chunk::fdAT, &payload).unwrap();
+
+                let mut actual = Vec::new();
+                write_fdat_chunk(&mut actual, sequence_number, &data).unwrap();
+
+                assert_eq!(actual, expected);
+            }
+        }
+    }
 
     #[test]
     fn roundtrip1() {


### PR DESCRIPTION
This PR changes non-initial APNG frames to write the `fdAT` header and compressed frame data directly to the output. Previously, these were copied into a temporary buffer before the chunk was written, resulting in an unnecessary allocation and memory copy for each frame.

The encoded output is unchanged, and no public APIs or unsafe code are involved. Local measurements for a two-frame APNG produced the following results:

| RGBA image | Allocations |         Allocated bytes | Reallocations |     Latency |
| ---------- | ----------: | ----------------------: | ------------: | ----------: |
| 64×64      |       5 → 4 |         50,767 → 34,304 |       14 → 14 |  \~3% lower |
| 256×256    |       5 → 4 |       792,867 → 530,432 |       18 → 18 | \~11% lower |
| 1024×1024  |       5 → 4 | 12,608,847 → 8,413,184 |       22 → 22 | \~17% lower |

Throughput improved by approximately 3%, 13%, and 21% respectively. The benchmarks and allocation instrumentation were run locally and are not included in this PR.

A new test verifies that the directly written `fdAT` chunks are byte-for-byte identical to the previous contiguous representation, including the length, sequence number, payload, and CRC.

Tested with `cargo test --workspace --all-targets`, `cargo test --doc`, `cargo fmt -- --check`, and `cargo +1.73.0 check --lib`.

AI disclosure: I used Codex with GPT-5.6 Sol at xhigh reasoning effort to help identify the allocation, implement the optimization, and construct the local benchmarks. I reviewed and tested the resulting change.