### PR TITLE
Clarify unstable flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 
 [dependencies]
 bitflags = "2.0"
-crc32fast = "1.2.0"
+crc32fast = "1.5.1"
 fdeflate = "0.3.3"
 flate2 = "1.0.35"
 miniz_oxide = { version = "0.8", features = ["simd"] }
@@ -38,8 +38,8 @@ rand = "0.10"
 criterion = "0.8"
 
 [features]
-# Use nightly-only features for a minor performance boost in PNG decoding
-unstable = ["crc32fast/nightly"]
+# Enable use of nightly features. Sometimes makes performance worse.
+unstable = []
 # Use zlib-rs for faster PNG encoding at the cost of some `unsafe` code.
 # WARNING: this changes the flate2 backend for your entire dependency tree!
 # While the `png` crate always uses fully memory-safe decoding,

--- a/src/filter/paeth.rs
+++ b/src/filter/paeth.rs
@@ -116,10 +116,6 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
         BytesPerPixel::Three => {
             #[cfg(all(feature = "unstable", not(target_vendor = "apple")))]
             {
-                // Results in PR: https://github.com/image-rs/image-png/pull/632
-                // Approximately 30% better on Arm Cortex A520, 7%
-                // regression on Arm Cortex X4. Switched off on Apple
-                // Silicon due to 10-12% regression.
                 super::simd::paeth_unfilter_3bpp(current, previous);
                 return;
             }
@@ -145,9 +141,6 @@ pub(super) fn unfilter(tbpp: BytesPerPixel, previous: &[u8], current: &mut [u8])
         BytesPerPixel::Four => {
             #[cfg(feature = "unstable")]
             {
-                // Results in PR: https://github.com/image-rs/image-png/pull/633
-                // No change on Apple Silicon, 42% better on Arm Cortex A520,
-                // 10% better on Arm Cortex X4.
                 super::simd::paeth_unfilter_4bpp(current, previous);
                 return;
             }


### PR DESCRIPTION
In the latest version of `crc32fast`, the `nightly` flag doesn't actually do anything so it is clearer not to enable it.

At the moment the only thing that the unstable flag does do is to enable `std::simd` unfiltering which is actually slower on every system I've been able to test on (see #704 for more details). I've adjusted the doc comment to warn about possible perf impacts, and remove code comments citing specific numbers which have almost surely gone out-of-date with newer LLVM versions