### PR TITLE
Interlaced encode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: ["1.73.0", stable, beta, nightly]
+        rust: ["1.81.0", stable, beta, nightly]
         os: [ubuntu-latest, windows-latest, macos-latest]
         features: [""]
     runs-on: ${{ matrix.os }}
@@ -17,9 +17,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.73.0' }}
+      if: ${{ matrix.rust == '1.81.0' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.73.0' }}
+      if: ${{ matrix.rust == '1.81.0' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install or use cached cross-rs/cross
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cross
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["The image-rs Developers"]
 repository = "https://github.com/image-rs/image-png"
 
 edition = "2021"
-rust-version = "1.73"
+rust-version = "1.81"
 include = [
     "/LICENSE-MIT",
     "/LICENSE-APACHE",

--- a/src/adam7.rs
+++ b/src/adam7.rs
@@ -954,29 +954,6 @@ fn sample_pass_4bit(
     }
 }
 
-/// Given consecutive values, select every second bit.
-const fn demux_1bit_step2(bits: u8) -> u8 {
-    const _ASSERT: () = {
-        let mut i = 0u8;
-        loop {
-            let upper = (i & 0x08) << 4 | (i & 0x04) << 3 | (i & 0x02) << 2 | (i & 0x01) << 1;
-            let demuxed = demux_1bit_step2(upper);
-
-            assert!(demuxed == i);
-
-            if i == 0xf {
-                break;
-            }
-
-            i += 1;
-        }
-    };
-
-    let muxed = 0x2_0100_0804u64 * (bits as u64);
-    let muxed = muxed & 0x10_0204_0080;
-    (muxed % 31) as u8
-}
-
 /// Extract every second bit from a series of two integers.
 ///
 /// Adapted from a technique in <https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv>

--- a/src/adam7.rs
+++ b/src/adam7.rs
@@ -580,26 +580,34 @@ pub fn expand_pass_splat(
 pub fn sample_pass(
     img: &[u8],
     img_row_stride: usize,
-    interlaced_row: &mut [u8],
+    interlaced_row: &mut Vec<u8>,
     interlace_info: &Adam7Info,
     bits_per_pixel: u8,
-) {
+) -> usize {
+    let sampled_len =
+        (u64::from(interlace_info.samples) * u64::from(bits_per_pixel)).div_ceil(8) as usize;
+
+    if interlaced_row.len() < sampled_len {
+        interlaced_row.resize(sampled_len, 0u8);
+    }
+
     let cst = interlace_info.pass_constants();
-    let line = usize::from(cst.y_offset) + interlace_info.line as usize;
+    let line =
+        usize::from(cst.y_offset) + (interlace_info.line as usize) * usize::from(cst.y_sampling);
 
     match bits_per_pixel {
+        // For reasons of codegen we do subbyte passes as a separate implementation.
         1 => sample_pass_1bit(img, img_row_stride, interlaced_row, interlace_info),
-        2 => {}
-        4 => todo!(),
+        2 => sample_pass_2bit(img, img_row_stride, interlaced_row, interlace_info),
+        4 => sample_pass_4bit(img, img_row_stride, interlaced_row, interlace_info),
         8 => {
-            let line = usize::from(cst.y_offset) + interlace_info.line as usize;
             let offset = line * img_row_stride + usize::from(cst.x_offset);
 
             let samples = img[offset..]
                 .chunks(usize::from(cst.x_sampling))
                 .map(|ch| ch[0]);
 
-            for (target, sample) in interlaced_row.iter_mut().zip(samples) {
+            for (target, sample) in interlaced_row[..sampled_len].iter_mut().zip(samples) {
                 *target = sample;
             }
         }
@@ -610,11 +618,16 @@ pub fn sample_pass(
 
             let samples = img[offset * bytes_pp..].chunks(usize::from(cst.x_sampling) * bytes_pp);
 
-            for (target, sample) in interlaced_row.chunks_exact_mut(bytes_pp).zip(samples) {
+            for (target, sample) in interlaced_row[..sampled_len]
+                .chunks_exact_mut(bytes_pp)
+                .zip(samples)
+            {
                 target.copy_from_slice(&sample[..bytes_pp]);
             }
         }
     }
+
+    sampled_len
 }
 
 // Consistency between access to byte elements, if they exist.
@@ -692,6 +705,7 @@ fn sample_pass_1bit(
                 let mut byte = 0;
 
                 for i in 0..4 {
+                    // Collect bits 6 and 2
                     let v = chunk.get(i).copied().unwrap_or(0);
                     //  Offset by 1 bit for the merge below.
                     let upper = (v >> 4) & 0b10;
@@ -723,6 +737,210 @@ fn sample_pass_1bit(
                 let upper = chunk.get(0).copied().unwrap_or(0);
                 let lower = chunk.get(1).copied().unwrap_or(0);
                 demux_1bit_step2x8([upper << 1, lower << 1])
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        7 => {
+            interlaced_row[..out_bytes as usize].copy_from_slice(&row[..out_bytes as usize]);
+        }
+        _ => unreachable!("invalid Adam7 pass"),
+    }
+}
+
+// Consistency between access to byte elements, if they exist.
+#[expect(clippy::get_first)]
+fn sample_pass_2bit(
+    img: &[u8],
+    img_row_stride: usize,
+    interlaced_row: &mut [u8],
+    interlace_info: &Adam7Info,
+) {
+    let cst = interlace_info.pass_constants();
+    let line =
+        usize::from(cst.y_offset) + interlace_info.line as usize * usize::from(cst.y_sampling);
+
+    let in_bytes = interlace_info.width.div_ceil(4);
+    let out_bytes = interlace_info.samples.div_ceil(4);
+
+    let row = &img[line * img_row_stride..][..in_bytes as usize];
+    match interlace_info.pass {
+        1 => {
+            let compressed = row.chunks(8).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..4 {
+                    let bit = chunk.get(i * 2).copied().unwrap_or(0) >> 6;
+                    byte <<= 2;
+                    byte |= bit;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        2 => {
+            let compressed = row.chunks(8).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..4 {
+                    let bit = chunk.get(1 + i * 2).copied().unwrap_or(0) >> 6;
+                    byte <<= 2;
+                    byte |= bit;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        3 => {
+            let compressed = row.chunks(4).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..4 {
+                    let v = chunk.get(i).copied().unwrap_or(0);
+                    byte <<= 2;
+                    byte |= v >> 6;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        4 => {
+            let compressed = row.chunks(4).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..4 {
+                    let v = chunk.get(i).copied().unwrap_or(0);
+                    byte <<= 2;
+                    byte |= (v >> 2) & 0b11;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        5 => {
+            let compressed = row.chunks(2).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(1).copied().unwrap_or(0);
+                demux_2bit_step2x4([upper, lower])
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        6 => {
+            let compressed = row.chunks(2).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(1).copied().unwrap_or(0);
+                demux_2bit_step2x4([upper << 2, lower << 2])
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        7 => {
+            interlaced_row[..out_bytes as usize].copy_from_slice(&row[..out_bytes as usize]);
+        }
+        _ => unreachable!("invalid Adam7 pass"),
+    }
+}
+
+// Consistency between access to byte elements, if they exist.
+#[expect(clippy::get_first)]
+fn sample_pass_4bit(
+    img: &[u8],
+    img_row_stride: usize,
+    interlaced_row: &mut [u8],
+    interlace_info: &Adam7Info,
+) {
+    let cst = interlace_info.pass_constants();
+    let line =
+        usize::from(cst.y_offset) + interlace_info.line as usize * usize::from(cst.y_sampling);
+
+    let in_bytes = interlace_info.width.div_ceil(2);
+    let out_bytes = interlace_info.samples.div_ceil(2);
+
+    let row = &img[line * img_row_stride..][..in_bytes as usize];
+    match interlace_info.pass {
+        1 => {
+            let compressed = row.chunks(8).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(4).copied().unwrap_or(0);
+                upper & 0xf0 | lower >> 4
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        2 => {
+            let compressed = row.chunks(8).map(|chunk| {
+                let upper = chunk.get(2).copied().unwrap_or(0);
+                let lower = chunk.get(6).copied().unwrap_or(0);
+                upper & 0xf0 | lower >> 4
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        3 => {
+            let compressed = row.chunks(4).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(2).copied().unwrap_or(0);
+                upper & 0xf0 | lower >> 4
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        4 => {
+            let compressed = row.chunks(4).map(|chunk| {
+                let upper = chunk.get(1).copied().unwrap_or(0);
+                let lower = chunk.get(3).copied().unwrap_or(0);
+                upper & 0xf0 | lower >> 4
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        5 => {
+            let compressed = row.chunks(2).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(1).copied().unwrap_or(0);
+                upper & 0xf0 | lower >> 4
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        6 => {
+            let compressed = row.chunks(2).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(1).copied().unwrap_or(0);
+                upper << 4 | lower & 0xf
             });
 
             for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
@@ -799,6 +1017,47 @@ const fn demux_1bit_step2x8([v0, v1]: [u8; 2]) -> u8 {
     // shifted bit patterns. If we did blending the other way we'd have a maximum difference of 4.
     let muxed = 0x08_0808_0808_0808u64 * (bits as u64);
     let muxed = muxed & 0x200_8024_0900_4010;
+    (muxed % 511) as u8
+}
+
+/// Extract every second bit from a series of two integers.
+///
+/// Adapted from a technique in <https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv>
+/// on reversing bits in a byte. Note that the bits we want are at the right spot in a 9-bit base
+/// when we assemble a 16-bit number. Hence we can extract them by a modulus after isolating them.
+const fn demux_2bit_step2x4([v0, v1]: [u8; 2]) -> u8 {
+    const _ASSERT: () = {
+        assert!(demux_2bit_step2x4([0x80, 0x00]) == 0x80);
+        assert!(demux_2bit_step2x4([0x40, 0x00]) == 0x40);
+        assert!(demux_2bit_step2x4([0x20, 0x00]) == 0x00);
+        assert!(demux_2bit_step2x4([0x10, 0x00]) == 0x00);
+        assert!(demux_2bit_step2x4([0x08, 0x00]) == 0x20);
+        assert!(demux_2bit_step2x4([0x04, 0x00]) == 0x10);
+        assert!(demux_2bit_step2x4([0x02, 0x00]) == 0x00);
+        assert!(demux_2bit_step2x4([0x01, 0x00]) == 0x00);
+        assert!(demux_2bit_step2x4([0x00, 0x80]) == 0x08);
+        assert!(demux_2bit_step2x4([0x00, 0x40]) == 0x04);
+        assert!(demux_2bit_step2x4([0x00, 0x20]) == 0x00);
+        assert!(demux_2bit_step2x4([0x00, 0x10]) == 0x00);
+        assert!(demux_2bit_step2x4([0x00, 0x08]) == 0x02);
+        assert!(demux_2bit_step2x4([0x00, 0x04]) == 0x01);
+        assert!(demux_2bit_step2x4([0x00, 0x02]) == 0x00);
+        assert!(demux_2bit_step2x4([0x00, 0x01]) == 0x00);
+    };
+
+    // Blend bits into a single number.
+    let bits = (v0 & 0xcc) | (v1 & 0xcc) >> 2;
+
+    // After blending we need to match the bit pairs (by LSB index):
+    //
+    // 0145 2367 -
+    // 0123 4567 8
+    //
+    //   vv      vv    v v     vv
+    // 234567    0123456|7   0123|4567
+    // 01234567|80123456|78012345|6780
+    let muxed = (0x400801 * (bits as u32)) >> 2;
+    let muxed = muxed & 0xc1860c;
     (muxed % 511) as u8
 }
 
@@ -1234,6 +1493,86 @@ mod tests {
         let mut iter = Adam7Iterator::new(15, 8).zip(expected.into_iter());
         while let Some((pass, exp)) = iter.next() {
             sample_pass_1bit(data.as_flattened(), 2, &mut out, &pass);
+            assert_eq!(out, exp, "{pass:?}");
+        }
+    }
+
+    #[test]
+    fn test_sample_2bit() {
+        let data = [
+            [0xf0, 0xca, 0xf0, 0xca],
+            [0x00, 0x02, 0x00, 0x02],
+            [0x33, 0x02, 0x33, 0x02],
+            [0x33, 0xf2, 0x33, 0xf2],
+            [0x55, 0xf0, 0x55, 0xf0],
+            [0x33, 0x2f, 0x33, 0x2f],
+            [0x55, 0x0f, 0x55, 0x0f],
+            [0xcc, 0xf2, 0xcc, 0xf2],
+        ];
+
+        let mut out = [0u8; 4];
+
+        let expected = [
+            [0b1111_0000, 0b0, 0b0, 0b0],         // Pass 1, 0
+            [0b1111_0000, 0b0, 0b0, 0b0],         // Pass 2, 0
+            [0b0111_0111, 0b0, 0b0, 0b0],         // Pass 3, 4
+            [0b0010_0010, 0b0, 0b0, 0b0],         // Pass 4, 0
+            [0b0100_0100, 0b0, 0b0, 0b0],         // Pass 4, 4
+            [0b0000_0000, 0b0, 0b0, 0b0],         // Pass 5, 2
+            [0b0101_0011, 0b0101_0011, 0b0, 0b0], // Pass 5, 6
+            [0b1100_0010, 0b1100_0010, 0b0, 0b0], // Pass 6, 0
+            [0b1111_0010, 0b1111_0010, 0b0, 0b0], // Pass 6, 2
+            [0b0101_1100, 0b0101_1100, 0b0, 0b0], // Pass 6, 4
+            [0b0101_0011, 0b0101_0011, 0b0, 0b0], // Pass 6, 6
+            [0x00, 0x02, 0x00, 0x02],             // Pass 7, 1
+            [0x33, 0xf2, 0x33, 0xf2],             // Pass 7, 3
+            [0x33, 0x2f, 0x33, 0x2f],             // Pass 7, 5
+            [0xcc, 0xf2, 0xcc, 0xf2],             // Pass 7, 7
+        ];
+
+        let mut iter = Adam7Iterator::new(15, 8).zip(expected.into_iter());
+        while let Some((pass, exp)) = iter.next() {
+            sample_pass_2bit(data.as_flattened(), 4, &mut out, &pass);
+            assert_eq!(out, exp, "{pass:?}");
+        }
+    }
+
+    #[test]
+    fn test_sample_4bit() {
+        let data = [
+            [0xf0, 0xca, 0xf0, 0xca],
+            [0x00, 0x02, 0x00, 0x02],
+            [0x33, 0x02, 0x33, 0x02],
+            [0x33, 0xf2, 0x33, 0xf2],
+            [0x55, 0xf0, 0x55, 0xf0],
+            [0x33, 0x2f, 0x33, 0x2f],
+            [0x55, 0x0f, 0x55, 0x0f],
+            [0xcc, 0xf2, 0xcc, 0xf2],
+        ];
+
+        let mut out = [0u8; 4];
+
+        let expected = [
+            [0xf0, 0b0, 0b0, 0b0],    // Pass 1, 0
+            [0xf0, 0b0, 0b0, 0b0],    // Pass 2, 0
+            [0x55, 0b0, 0b0, 0b0],    // Pass 3, 4
+            [0xcc, 0b0, 0b0, 0b0],    // Pass 4, 0
+            [0xff, 0b0, 0b0, 0b0],    // Pass 4, 4
+            [0x30, 0x30, 0b0, 0b0],   // Pass 5, 2
+            [0x50, 0x50, 0b0, 0b0],   // Pass 5, 6
+            [0x0a, 0x0a, 0b0, 0b0],   // Pass 6, 0
+            [0x32, 0x32, 0b0, 0b0],   // Pass 6, 2
+            [0x50, 0x50, 0b0, 0b0],   // Pass 6, 4
+            [0x5f, 0x5f, 0b0, 0b0],   // Pass 6, 6
+            [0x00, 0x02, 0x00, 0x02], // Pass 7, 1
+            [0x33, 0xf2, 0x33, 0xf2], // Pass 7, 3
+            [0x33, 0x2f, 0x33, 0x2f], // Pass 7, 5
+            [0xcc, 0xf2, 0xcc, 0xf2], // Pass 7, 7
+        ];
+
+        let mut iter = Adam7Iterator::new(7, 8).zip(expected.into_iter());
+        while let Some((pass, exp)) = iter.next() {
+            sample_pass_4bit(data.as_flattened(), 4, &mut out, &pass);
             assert_eq!(out, exp, "{pass:?}");
         }
     }

--- a/src/adam7.rs
+++ b/src/adam7.rs
@@ -577,6 +577,231 @@ pub fn expand_pass_splat(
     }
 }
 
+pub fn sample_pass(
+    img: &[u8],
+    img_row_stride: usize,
+    interlaced_row: &mut [u8],
+    interlace_info: &Adam7Info,
+    bits_per_pixel: u8,
+) {
+    let cst = interlace_info.pass_constants();
+    let line = usize::from(cst.y_offset) + interlace_info.line as usize;
+
+    match bits_per_pixel {
+        1 => sample_pass_1bit(img, img_row_stride, interlaced_row, interlace_info),
+        2 => {}
+        4 => todo!(),
+        8 => {
+            let line = usize::from(cst.y_offset) + interlace_info.line as usize;
+            let offset = line * img_row_stride + usize::from(cst.x_offset);
+
+            let samples = img[offset..]
+                .chunks(usize::from(cst.x_sampling))
+                .map(|ch| ch[0]);
+
+            for (target, sample) in interlaced_row.iter_mut().zip(samples) {
+                *target = sample;
+            }
+        }
+        _ => {
+            let bytes_pp = usize::from(bits_per_pixel / 8);
+            let cst = interlace_info.pass_constants();
+            let offset = line * img_row_stride + usize::from(cst.x_offset);
+
+            let samples = img[offset * bytes_pp..].chunks(usize::from(cst.x_sampling) * bytes_pp);
+
+            for (target, sample) in interlaced_row.chunks_exact_mut(bytes_pp).zip(samples) {
+                target.copy_from_slice(&sample[..bytes_pp]);
+            }
+        }
+    }
+}
+
+// Consistency between access to byte elements, if they exist.
+#[expect(clippy::get_first)]
+fn sample_pass_1bit(
+    img: &[u8],
+    img_row_stride: usize,
+    interlaced_row: &mut [u8],
+    interlace_info: &Adam7Info,
+) {
+    let cst = interlace_info.pass_constants();
+    let line =
+        usize::from(cst.y_offset) + interlace_info.line as usize * usize::from(cst.y_sampling);
+
+    let in_bytes = interlace_info.width.div_ceil(8);
+    let out_bytes = interlace_info.samples.div_ceil(8);
+
+    let row = &img[line * img_row_stride..][..in_bytes as usize];
+    match interlace_info.pass {
+        1 => {
+            let compressed = row.chunks(8).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..8 {
+                    let bit = chunk.get(i).copied().unwrap_or(0) >> 7;
+                    byte <<= 1;
+                    byte |= bit;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        2 => {
+            let compressed = row.chunks(8).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..8 {
+                    let bit = (chunk.get(i).copied().unwrap_or(0) >> 3) & 0b1;
+                    byte <<= 1;
+                    byte |= bit;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        3 => {
+            let compressed = row.chunks(4).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..4 {
+                    let v = chunk.get(i).copied().unwrap_or(0);
+                    let upper = (v >> 6) & 0b10;
+                    let lower = (v >> 3) & 0b1;
+                    byte <<= 2;
+                    byte |= upper | lower;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        4 => {
+            let compressed = row.chunks(4).map(|chunk| {
+                let mut byte = 0;
+
+                for i in 0..4 {
+                    let v = chunk.get(i).copied().unwrap_or(0);
+                    //  Offset by 1 bit for the merge below.
+                    let upper = (v >> 4) & 0b10;
+                    let lower = (v >> 1) & 0b1;
+                    byte <<= 2;
+                    byte |= upper | lower;
+                }
+
+                byte
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        5 => {
+            let compressed = row.chunks(2).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(1).copied().unwrap_or(0);
+                demux_1bit_step2x8([upper, lower])
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        6 => {
+            let compressed = row.chunks(2).map(|chunk| {
+                let upper = chunk.get(0).copied().unwrap_or(0);
+                let lower = chunk.get(1).copied().unwrap_or(0);
+                demux_1bit_step2x8([upper << 1, lower << 1])
+            });
+
+            for (byte, target) in compressed.zip(&mut interlaced_row[..out_bytes as usize]) {
+                *target = byte;
+            }
+        }
+        7 => {
+            interlaced_row[..out_bytes as usize].copy_from_slice(&row[..out_bytes as usize]);
+        }
+        _ => unreachable!("invalid Adam7 pass"),
+    }
+}
+
+/// Given consecutive values, select every second bit.
+const fn demux_1bit_step2(bits: u8) -> u8 {
+    const _ASSERT: () = {
+        let mut i = 0u8;
+        loop {
+            let upper = (i & 0x08) << 4 | (i & 0x04) << 3 | (i & 0x02) << 2 | (i & 0x01) << 1;
+            let demuxed = demux_1bit_step2(upper);
+
+            assert!(demuxed == i);
+
+            if i == 0xf {
+                break;
+            }
+
+            i += 1;
+        }
+    };
+
+    let muxed = 0x2_0100_0804u64 * (bits as u64);
+    let muxed = muxed & 0x10_0204_0080;
+    (muxed % 31) as u8
+}
+
+/// Extract every second bit from a series of two integers.
+///
+/// Adapted from a technique in <https://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith64BitsDiv>
+/// on reversing bits in a byte. Note that the bits we want are at the right spot in a 9-bit base
+/// when we assemble a 16-bit number. Hence we can extract them by a modulus after isolating them.
+const fn demux_1bit_step2x8([v0, v1]: [u8; 2]) -> u8 {
+    const _ASSERT: () = {
+        assert!(demux_1bit_step2x8([0x80, 0x00]) == 0x80);
+        assert!(demux_1bit_step2x8([0x40, 0x00]) == 0x00);
+        assert!(demux_1bit_step2x8([0x20, 0x00]) == 0x40);
+        assert!(demux_1bit_step2x8([0x10, 0x00]) == 0x00);
+        assert!(demux_1bit_step2x8([0x08, 0x00]) == 0x20);
+        assert!(demux_1bit_step2x8([0x04, 0x00]) == 0x00);
+        assert!(demux_1bit_step2x8([0x02, 0x00]) == 0x10);
+        assert!(demux_1bit_step2x8([0x01, 0x00]) == 0x00);
+        assert!(demux_1bit_step2x8([0x00, 0x80]) == 0x08);
+        assert!(demux_1bit_step2x8([0x00, 0x40]) == 0x00);
+        assert!(demux_1bit_step2x8([0x00, 0x20]) == 0x04);
+        assert!(demux_1bit_step2x8([0x00, 0x10]) == 0x00);
+        assert!(demux_1bit_step2x8([0x00, 0x08]) == 0x02);
+        assert!(demux_1bit_step2x8([0x00, 0x04]) == 0x00);
+        assert!(demux_1bit_step2x8([0x00, 0x02]) == 0x01);
+        assert!(demux_1bit_step2x8([0x00, 0x01]) == 0x00);
+    };
+
+    // Blend bits into a single number.
+    let bits = (v0 & 0xaa) | (v1 & 0xaa) >> 1;
+
+    // After blending we need to match the bit pairs (by LSB index):
+    //
+    // 0246 1357 -
+    // 0123 4567 8
+    //     v          v           v  v       v  v          v           v
+    //    01234|56701234|56701234|56701234|56701234|56701234|56701234|56
+    // 01234567|80123456|78012345|67801234|56780123|45678012|34567801|23
+    //
+    // Look at the differences between bit indices, with matches thus generated from at least 7
+    // shifted bit patterns. If we did blending the other way we'd have a maximum difference of 4.
+    let muxed = 0x08_0808_0808_0808u64 * (bits as u64);
+    let muxed = muxed & 0x200_8024_0900_4010;
+    (muxed % 511) as u8
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -970,6 +1195,46 @@ mod tests {
         for ((data, expected), adam7_info) in passes.iter().zip(adam7) {
             expand_pass_splat(&mut img, stride, data, &adam7_info, bits_pp);
             assert_eq!(img, *expected, "{img:x?} {expected:x?} {adam7_info:?}");
+        }
+    }
+
+    #[test]
+    fn test_sample_1bit() {
+        let data = [
+            [0xf0, 0xca],
+            [0x00, 0x02],
+            [0x33, 0x02],
+            [0x33, 0xf2],
+            [0x55, 0xf0],
+            [0x33, 0x2f],
+            [0x55, 0x0f],
+            [0xcc, 0xf2],
+        ];
+
+        let mut out = [0u8; 2];
+
+        let expected = [
+            [0b1100_0000, 0b0], // Pass 1, 0
+            [0b0100_0000, 0b0], // Pass 2, 0
+            [0b0010_0000, 0b0], // Pass 3, 4
+            [0b1001_0000, 0b0], // Pass 4, 0
+            [0b0010_0000, 0b0], // Pass 4, 4
+            [0b0101_0001, 0b0], // Pass 5, 2
+            [0b0000_0011, 0b0], // Pass 5, 6
+            [0b1100_1000, 0b0], // Pass 6, 0
+            [0b0101_0000, 0b0], // Pass 6, 2
+            [0b1111_1100, 0b0], // Pass 6, 4
+            [0b1111_0011, 0b0], // Pass 6, 6
+            [0x00, 0x02],       // Pass 7, 1
+            [0x33, 0xf2],       // Pass 7, 3
+            [0x33, 0x2f],       // Pass 7, 5
+            [0xcc, 0xf2],       // Pass 7, 7
+        ];
+
+        let mut iter = Adam7Iterator::new(15, 8).zip(expected.into_iter());
+        while let Some((pass, exp)) = iter.next() {
+            sample_pass_1bit(data.as_flattened(), 2, &mut out, &pass);
+            assert_eq!(out, exp, "{pass:?}");
         }
     }
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -450,7 +450,7 @@ impl From<DecodingError> for io::Error {
     fn from(err: DecodingError) -> io::Error {
         match err {
             DecodingError::IoError(err) => err,
-            err => io::Error::new(io::ErrorKind::Other, err.to_string()),
+            err => io::Error::other(err.to_string()),
         }
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -127,7 +127,7 @@ impl From<io::Error> for EncodingError {
 
 impl From<EncodingError> for io::Error {
     fn from(err: EncodingError) -> io::Error {
-        io::Error::new(io::ErrorKind::Other, err.to_string())
+        io::Error::other(err.to_string())
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -165,6 +165,7 @@ struct Options {
     sep_def_img: bool,
     validate_sequence: bool,
     compression: DeflateCompression,
+    interlace: bool,
 }
 
 impl<'a, W: Write> Encoder<'a, W> {
@@ -457,6 +458,11 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// (It's possible to circumvent these checks by writing raw chunks instead.)
     pub fn validate_sequence(&mut self, validate: bool) {
         self.options.validate_sequence = validate;
+    }
+
+    /// Set the use of Adam7 interlacing when encoding an image.
+    pub fn set_interlacing(&mut self, interlace: bool) {
+        self.options.interlace = interlace;
     }
 }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -191,8 +191,11 @@ impl<'a, W: Write> Encoder<'a, W> {
 
         Ok(Encoder {
             w,
+            options: Options {
+                interlace: info.interlaced,
+                ..Options::default()
+            },
             info,
-            options: Options::default(),
         })
     }
 
@@ -462,7 +465,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     }
 
     /// Set the use of Adam7 interlacing when encoding an image.
-    pub fn set_interlacing(&mut self, interlace: bool) {
+    pub fn set_interlaced(&mut self, interlace: bool) {
         self.options.interlace = interlace;
         self.info.interlaced = interlace;
     }
@@ -1546,6 +1549,16 @@ pub struct StreamWriter<'a, W: Write> {
 
 impl<'a, W: Write> StreamWriter<'a, W> {
     fn new(writer: ChunkOutput<'a, W>, buf_len: usize) -> Result<StreamWriter<'a, W>> {
+        // We can not stream-write interlaced data.. That is, you would need to supply data in Adam7
+        // interlaced order yourself instead of in their original line order. This is surprising
+        // enough to warrant another type, or at least function or an explicit opt-in, and also we
+        // do not implement it below.
+        if writer.options.interlace {
+            return Err(EncodingError::Format(
+                FormatErrorKind::InterlacedEncodingUnsupported.into(),
+            ));
+        }
+
         let PartialInfo {
             width,
             height,
@@ -2168,7 +2181,7 @@ mod tests {
                 encoder.set_palette(palette.as_ref());
 
                 // the main property of this test.
-                encoder.set_interlacing(true);
+                encoder.set_interlaced(true);
 
                 let mut writer = encoder.write_header()?;
                 writer.write_image_data(&decoded_pixels)?;
@@ -2289,12 +2302,8 @@ mod tests {
 
     #[test]
     fn expect_error_when_interlacing_is_requested() {
-        // `write_image_data` does not apply Adam7 passes to the caller's raw
-        // pixel buffer, so until interlaced encoding is implemented the
-        // encoder must reject `info.interlaced = true` rather than emit an
-        // IHDR that claims interlacing over non-interlaced IDAT bytes —
-        // which decoders reject with `UnknownFilterMethod` when a pixel
-        // byte aligns with a pass's filter-type byte position.
+        // We implement interlace on explicit request by the encoder. The info must agree with the
+        // explicit request.
         let mut info = Info::with_size(4, 4);
         info.color_type = ColorType::Rgb;
         info.bit_depth = BitDepth::Eight;
@@ -2302,7 +2311,8 @@ mod tests {
 
         let mut out = Vec::new();
         let encoder = Encoder::with_info(&mut out, info).expect("with_info accepts the Info");
-        let result = encoder.write_header();
+        let mut writer = encoder.write_header().unwrap();
+        let result = writer.stream_writer();
         assert!(
             matches!(result, Err(EncodingError::Format(_))),
             "expected Format error, got {:?}",

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -6,6 +6,7 @@ use std::{borrow, error, fmt, io, mem, ops, result};
 use crc32fast::Hasher as Crc32;
 use flate2::write::ZlibEncoder;
 
+use crate::adam7::Adam7Iterator;
 use crate::chunk::{self, ChunkType};
 use crate::common::{
     AnimationControl, BitDepth, BlendOp, BytesPerPixel, ColorType, Compression, DisposeOp,
@@ -463,6 +464,7 @@ impl<'a, W: Write> Encoder<'a, W> {
     /// Set the use of Adam7 interlacing when encoding an image.
     pub fn set_interlacing(&mut self, interlace: bool) {
         self.options.interlace = interlace;
+        self.info.interlaced = interlace;
     }
 }
 
@@ -610,7 +612,7 @@ impl<W: Write> Writer<W> {
         // decoders reject (as an `UnknownFilterMethod` when a pixel byte
         // lines up with a pass's filter-byte position). Reject the request
         // rather than emit bytes that no decoder can read back.
-        if info.interlaced {
+        if info.interlaced != self.options.interlace {
             return Err(EncodingError::Format(
                 FormatErrorKind::InterlacedEncodingUnsupported.into(),
             ));
@@ -810,18 +812,18 @@ impl<W: Write> Writer<W> {
 
         self.validate_new_image()?;
 
-        let width: usize;
-        let height: usize;
+        let width: u32;
+        let height: u32;
         if let Some(ref mut fctl) = self.info.frame_control {
-            width = fctl.width as usize;
-            height = fctl.height as usize;
+            width = fctl.width;
+            height = fctl.height;
         } else {
-            width = self.info.width as usize;
-            height = self.info.height as usize;
+            width = self.info.width;
+            height = self.info.height;
         }
 
-        let in_len = self.info.raw_row_length_from_width(width as u32) - 1;
-        let data_size = in_len * height;
+        let in_len = self.info.raw_row_length_from_width(width) - 1;
+        let data_size = in_len * height as usize;
         if data_size != data.len() {
             return Err(EncodingError::Parameter(
                 ParameterErrorKind::ImageBufferSize {
@@ -832,7 +834,7 @@ impl<W: Write> Writer<W> {
             ));
         }
 
-        let zlib_encoded = self.zlib_encode_image_data(data, in_len)?;
+        let zlib_encoded = self.zlib_encode_image_data(data, (width, height))?;
 
         match self.info.frame_control {
             None => {
@@ -863,33 +865,117 @@ impl<W: Write> Writer<W> {
         Ok(())
     }
 
-    fn zlib_encode_image_data(&self, data: &[u8], in_len: usize) -> Result<Vec<u8>> {
-        let prev = vec![0; in_len];
-        let mut prev = prev.as_slice();
+    fn zlib_encode_image_data(&self, data: &[u8], (width, height): (u32, u32)) -> Result<Vec<u8>> {
+        #[derive(Clone)]
+        enum LineCursor<'lt> {
+            All {
+                lines: core::slice::ChunksExact<'lt, u8>,
+                prev: &'lt [u8],
+            },
+            Interlaced {
+                data: &'lt [u8],
+                data_pitch: usize,
+                adam7: Adam7Iterator,
+                buffer: Vec<u8>,
+                prev: Vec<u8>,
+                bpp: u8,
+            },
+        }
+
+        impl LineCursor<'_> {
+            fn next_pass_and_line(&mut self) -> Option<(u8, &'_ [u8], &'_ [u8])> {
+                match self {
+                    LineCursor::All { lines, prev } => {
+                        let line = lines.next()?;
+                        let prev = core::mem::replace(prev, line);
+                        Some((0, line, prev))
+                    }
+                    LineCursor::Interlaced {
+                        data,
+                        data_pitch,
+                        buffer,
+                        prev,
+                        adam7,
+                        bpp,
+                    } => {
+                        let info = adam7.next()?;
+                        let used =
+                            crate::adam7::sample_pass(data, *data_pitch, buffer, &info, *bpp);
+                        Some((info.pass, &buffer[..used], prev))
+                    }
+                }
+            }
+
+            fn remember_previous(&mut self) {
+                match self {
+                    LineCursor::All { .. } => { /* nothing todo */ }
+                    LineCursor::Interlaced { buffer, prev, .. } => {
+                        prev.clear();
+                        prev.extend_from_slice(buffer);
+                    }
+                }
+            }
+        }
+
+        let in_len = self.info.raw_row_length_from_width(width) - 1;
+        let zeroed_prev = vec![0; in_len];
 
         let bpp = self.info.bpp_in_prediction();
         let filter_method = self.options.filter;
+
+        // The filter loop below is used for interlaced and regular lines, as write of the lines and
+        // filtering depends on compression settings. The prediction needs to be reset between
+        // passes so this avoids type modelling.
+        //
+        // Denotes the pass associated with `prev`, requiring a reset when changed.
+        let mut filter_pass = 0;
+        // Iterator we use when not interlacing.
+        let mut interlaced_lines = if self.options.interlace {
+            LineCursor::Interlaced {
+                data,
+                data_pitch: in_len,
+                adam7: Adam7Iterator::new(width, height),
+                buffer: vec![],
+                prev: vec![],
+                bpp: self.info.color_type.bits_per_pixel(self.info.bit_depth) as u8,
+            }
+        } else {
+            let lines = data.chunks_exact(in_len);
+            LineCursor::All {
+                lines,
+                prev: zeroed_prev.as_slice(),
+            }
+        };
 
         let residual = match self.options.compression {
             DeflateCompression::NoCompression => {
                 let mut compressor =
                     fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(Vec::new()))?;
-                for line in data.chunks(in_len) {
+
+                while let Some((_pass, line, _prev)) = interlaced_lines.next_pass_and_line() {
                     compressor.write_data(&[0])?;
                     compressor.write_data(line)?;
                 }
+
                 compressor.finish()?.into_inner()
             }
             DeflateCompression::FdeflateUltraFast => {
                 let mut compressor = fdeflate::Compressor::new(std::io::Cursor::new(Vec::new()))?;
 
+                let fallback_cursor = interlaced_lines.clone();
                 let mut current = vec![0; in_len + 1];
-                for line in data.chunks(in_len) {
-                    let filter_type = filter(filter_method, bpp, prev, line, &mut current[1..]);
+                while let Some((pass, line, mut prev)) = interlaced_lines.next_pass_and_line() {
+                    if pass != filter_pass {
+                        current.resize(1 + line.len(), 0u8);
+                        prev = &zeroed_prev[..line.len()];
+                        filter_pass = pass;
+                    }
 
+                    let filter_type = filter(filter_method, bpp, prev, line, &mut current[1..]);
                     current[0] = filter_type as u8;
                     compressor.write_data(&current)?;
-                    prev = line;
+
+                    interlaced_lines.remember_previous();
                 }
 
                 let compressed = compressor.finish()?.into_inner();
@@ -898,13 +984,14 @@ impl<W: Write> Writer<W> {
                 if compressed.len()
                     > fdeflate::StoredOnlyCompressor::<()>::compressed_size((in_len + 1) * lines)
                 {
+                    let mut fallback_cursor = fallback_cursor;
                     // Write uncompressed data since the result from fast compression would take
                     // more space than that.
                     //
                     // This is essentially a fallback to NoCompression.
                     let mut compressor =
                         fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(Vec::new()))?;
-                    for line in data.chunks(in_len) {
+                    while let Some((_pass, line, _prev)) = fallback_cursor.next_pass_and_line() {
                         compressor.write_data(&[0])?;
                         compressor.write_data(line)?;
                     }
@@ -918,12 +1005,19 @@ impl<W: Write> Writer<W> {
 
                 let mut zlib =
                     ZlibEncoder::new(Vec::new(), flate2::Compression::new(u32::from(level)));
-                for line in data.chunks(in_len) {
-                    let filter_type = filter(filter_method, bpp, prev, line, &mut current);
 
+                while let Some((pass, line, mut prev)) = interlaced_lines.next_pass_and_line() {
+                    if pass != filter_pass {
+                        current.resize(line.len(), 0u8);
+                        prev = &zeroed_prev[..line.len()];
+                        filter_pass = pass;
+                    }
+
+                    let filter_type = filter(filter_method, bpp, prev, line, &mut current);
                     zlib.write_all(&[filter_type as u8])?;
                     zlib.write_all(&current)?;
-                    prev = line;
+
+                    interlaced_lines.remember_previous();
                 }
                 zlib.finish()?
             }
@@ -2049,6 +2143,51 @@ mod tests {
             reader.next_frame(&mut redecoded).unwrap();
             // check if the encoded image is ok:
             assert_eq!(indexed_data, redecoded);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn image_interlacing() -> Result<()> {
+        use DeflateCompression::*;
+        for &bit_depth in &[1u8, 2, 4, 8] {
+            for compress in &[NoCompression, FdeflateUltraFast, Level(4)] {
+                // Get ourselves some data for the depth.
+                let path = format!("tests/pngsuite/basn3p0{}.png", bit_depth);
+                let decoder = Decoder::new(BufReader::new(File::open(&path).unwrap()));
+                let mut reader = decoder.read_info().unwrap();
+                let mut decoded_pixels = vec![0; reader.output_buffer_size().unwrap()];
+                let info = reader.next_frame(&mut decoded_pixels).unwrap();
+                let palette = reader.info().palette.as_ref().unwrap();
+
+                let mut cursor = Cursor::new(vec![]);
+                let mut encoder = Encoder::new(&mut cursor, info.width, info.height);
+                encoder.set_deflate_compression(*compress);
+                encoder.set_depth(info.bit_depth);
+                encoder.set_color(ColorType::Indexed);
+                encoder.set_palette(palette.as_ref());
+
+                // the main property of this test.
+                encoder.set_interlacing(true);
+
+                let mut writer = encoder.write_header()?;
+                writer.write_image_data(&decoded_pixels)?;
+                writer.finish()?;
+
+                cursor.set_position(0);
+                let decoder = Decoder::new(&mut cursor);
+                let mut reader = decoder.read_info().unwrap();
+                let mut redecoded = vec![0; reader.output_buffer_size().unwrap()];
+                let reinfo = reader.next_frame(&mut redecoded);
+                assert_eq!(redecoded.len(), decoded_pixels.len());
+
+                assert!(
+                    reinfo.as_ref().is_ok_and(|i| *i == info),
+                    "{reinfo:?} != {info:?} for compression: {bit_depth}/{compress:?}"
+                );
+
+                assert_eq!(redecoded, decoded_pixels, "{bit_depth}/{compress:?}");
+            }
         }
         Ok(())
     }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -826,13 +826,45 @@ impl<W: Write> Writer<W> {
             ));
         }
 
+        let zlib_encoded = self.zlib_encode_image_data(data, in_len)?;
+
+        match self.info.frame_control {
+            None => {
+                self.write_zlib_encoded_idat(&zlib_encoded)?;
+            }
+            Some(_) if self.should_skip_frame_control_on_default_image() => {
+                self.write_zlib_encoded_idat(&zlib_encoded)?;
+            }
+            Some(ref mut fctl) => {
+                fctl.encode(&mut self.w)?;
+                fctl.sequence_number = fctl.sequence_number.wrapping_add(1);
+                self.animation_written += 1;
+
+                // If the default image is the first frame of an animation, it's still an IDAT.
+                if self.images_written == 0 {
+                    self.write_zlib_encoded_idat(&zlib_encoded)?;
+                } else {
+                    for chunk in zlib_encoded.chunks(Self::MAX_fdAT_CHUNK_LEN as usize) {
+                        write_fdat_chunk(&mut self.w, fctl.sequence_number, chunk)?;
+                        fctl.sequence_number = fctl.sequence_number.wrapping_add(1);
+                    }
+                }
+            }
+        }
+
+        self.increment_images_written();
+
+        Ok(())
+    }
+
+    fn zlib_encode_image_data(&self, data: &[u8], in_len: usize) -> Result<Vec<u8>> {
         let prev = vec![0; in_len];
         let mut prev = prev.as_slice();
 
         let bpp = self.info.bpp_in_prediction();
         let filter_method = self.options.filter;
 
-        let zlib_encoded = match self.options.compression {
+        let residual = match self.options.compression {
             DeflateCompression::NoCompression => {
                 let mut compressor =
                     fdeflate::StoredOnlyCompressor::new(std::io::Cursor::new(Vec::new()))?;
@@ -855,8 +887,10 @@ impl<W: Write> Writer<W> {
                 }
 
                 let compressed = compressor.finish()?.into_inner();
+                let lines = data.len().checked_div(in_len).unwrap_or(0);
+
                 if compressed.len()
-                    > fdeflate::StoredOnlyCompressor::<()>::compressed_size((in_len + 1) * height)
+                    > fdeflate::StoredOnlyCompressor::<()>::compressed_size((in_len + 1) * lines)
                 {
                     // Write uncompressed data since the result from fast compression would take
                     // more space than that.
@@ -889,33 +923,7 @@ impl<W: Write> Writer<W> {
             }
         };
 
-        match self.info.frame_control {
-            None => {
-                self.write_zlib_encoded_idat(&zlib_encoded)?;
-            }
-            Some(_) if self.should_skip_frame_control_on_default_image() => {
-                self.write_zlib_encoded_idat(&zlib_encoded)?;
-            }
-            Some(ref mut fctl) => {
-                fctl.encode(&mut self.w)?;
-                fctl.sequence_number = fctl.sequence_number.wrapping_add(1);
-                self.animation_written += 1;
-
-                // If the default image is the first frame of an animation, it's still an IDAT.
-                if self.images_written == 0 {
-                    self.write_zlib_encoded_idat(&zlib_encoded)?;
-                } else {
-                    for chunk in zlib_encoded.chunks(Self::MAX_fdAT_CHUNK_LEN as usize) {
-                        write_fdat_chunk(&mut self.w, fctl.sequence_number, chunk)?;
-                        fctl.sequence_number = fctl.sequence_number.wrapping_add(1);
-                    }
-                }
-            }
-        }
-
-        self.increment_images_written();
-
-        Ok(())
+        Ok(residual)
     }
 
     fn increment_images_written(&mut self) {


### PR DESCRIPTION
Closes: #716 

In this implementation we do not support it for `StreamWriter` but only for `write_image_data`. We assume that you never want to have an arbitrary buffer (longer than a single line) in the former case. Having the caller `Write` data in order of its adam7 passes could also be very surprising, but we may relax it like that later (or via a separate type, or a separate method parallel to `into_stream_writer` etc.).

The bulk of this is code for efficiently extracting passes into a separate line buffer. The loops should optimize in considerably different manners for many combinations of sub-byte depths and pass (1..7 mostly). Further evidence in encoding performance might evolve this at a later point.